### PR TITLE
Increase nigiri time window to one year

### DIFF
--- a/ansible/roles/motis/files/config.ini
+++ b/ansible/roles/motis/files/config.ini
@@ -27,6 +27,10 @@ paths=schedule-lv-rigas-saraksti:improved-gtfs-saraksti.zip
 paths=schedule-lt:lt.zip
 paths=schedule-lt-all:lt-all.zip
 
+[nigiri]
+first_day=TODAY
+num_days=365
+
 [osrm]
 profiles=/opt/motis/osrm-profiles/car.lua
 profiles=/opt/motis/osrm-profiles/bike.lua


### PR DESCRIPTION
This does not seem to have any adverse effects on the memory consumption or query performance on my local Switzerland example at least, but it's significantly more useful.

Going beyond one year brings little benefit as the GTFS schedules don't seem to be valid that far into the future anyway.