### PR TITLE
Proxy RailVizTrainsRequest completely

### DIFF
--- a/motis-proxy/src/main.rs
+++ b/motis-proxy/src/main.rs
@@ -210,6 +210,8 @@ struct RailVizTrainsRequest {
     corner2: Location,
     max_trains: u16,
     last_trains: u16,
+    start_time: u64,
+    end_time: u64,
 }
 
 #[derive(Deserialize, Serialize)]


### PR DESCRIPTION
The missing time range resulted in an empty response and thus missing trains on the map.