### PR TITLE
Rootless devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,48 @@
+{
+	"name": "Transitous",
+	"build": {
+		"dockerfile": "../ci/container/Containerfile",
+		"context": ".."
+	},
+
+	"runArgs": [
+		"--userns=keep-id:uid=1000,gid=1000"
+	   ],
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": { 
+				"python.defaultInterpreterPath": "/usr/local/bin/python",
+				"python.linting.enabled": true,
+				"python.linting.pylintEnabled": true,
+				"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+				"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+				"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+				"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+				"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+				"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+				"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+			},
+			
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "transitous"
+}

--- a/ci/container/Containerfile
+++ b/ci/container/Containerfile
@@ -3,8 +3,24 @@
 
 FROM docker.io/debian:bookworm-slim
 
-RUN apt-get update && apt-get install git python3-requests python3-jinja2 golang wget bzip2 -y && apt clean
+ARG MOTIS_VERSION=v0.11.20
+ARG USERNAME=transitous
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
 
-RUN wget -qO - https://github.com/motis-project/motis/releases/download/v0.11.20/motis-linux-amd64.tar.bz2 | tar -C /opt/ -jx
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends git python3-requests python3-jinja2 golang wget bzip2 && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/* 
+
+RUN wget -qO - https://github.com/motis-project/motis/releases/download/${MOTIS_VERSION}/motis-linux-amd64.tar.bz2 | tar -C /opt/ -jx
 RUN GOBIN=/usr/local/bin/ go install github.com/patrickbr/gtfstidy@latest
 ENV PATH=/opt/motis:$PATH
+
+# Create the user / set user rights
+RUN groupadd --gid $USER_GID $USERNAME && \
+    useradd --uid $USER_UID --gid $USER_GID -m $USERNAME && \
+    mkdir /workspace && chown -R $USER_UID:$USER_GID /workspace && \
+    chown -R $USER_UID:$USER_GID /opt/motis
+
+USER ${USERNAME}


### PR DESCRIPTION
This PR configures the `Containerfile` to run rootless and adds a basic `.devcontainer` configuration for VS Code.

This allows to open the cloned repository in VS Code and (with the Dev Containers extension installed) VS Code will automatically offer to open the project in a container where you can start developing.