### PR TITLE
Add Peatus feed for Estonia

### DIFF
--- a/feeds/ee.json
+++ b/feeds/ee.json
@@ -1,0 +1,15 @@
+{
+    "maintainers": [
+        {
+            "name": "Ederson Mota Pereira",
+            "github": "edrmp"
+        }
+    ],
+    "sources": [
+        {
+            "name": "ee",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ud-atkoliinidoÜ~aktsiaseltshansabussiliinid~kihnuveeteedas~väi"
+        }
+    ]
+}


### PR DESCRIPTION
Hello.

This pull request adds a new feed for Estonia. (Peatus)

Local tests with Motis were successful after changing the map name in the generate-motis-config.py script.

https://github.com/public-transport/transitous/blob/main/src/generate-motis-config.py#L24

