### PR TITLE
Add feeds for RTD Denver

### DIFF
--- a/feeds/us.json
+++ b/feeds/us.json
@@ -3,6 +3,10 @@
         {
             "name": "Nathan Upchurch",
             "github": "N-Upchurch"
+        },
+        {
+            "name": "Marcus Lundblad",
+            "github": "mlundblad"
         }
     ],
     "sources": [
@@ -17,6 +21,26 @@
             "options": {
                 "fetch-interval-days": 1
             }
+        },
+        {
+            "name": "RTD",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-9xj-rtd"
+        },
+        {
+            "name": "RTD",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-rtddenver~rt"
+        },
+        {
+            "name": "RTD-bustang",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-denver~rtd~bustang"
+        },
+        {
+            "name": "RTD-bustang",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-denver~rtd~bustang-rt"
         }
     ]
 }


### PR DESCRIPTION
Add feeds for RTD (Denver)

Related to feature request to add "transit plugin" for RTD in GNOME Maps: https://gitlab.gnome.org/GNOME/gnome-maps/-/issues/639