### PR TITLE
Add Luxembourg feed

### DIFF
--- a/feeds/lu.json
+++ b/feeds/lu.json
@@ -1,0 +1,15 @@
+{
+    "maintainers": [
+        {
+            "name": "Volker Krause",
+            "github": "vkrause"
+        }
+    ],
+    "sources": [
+        {
+            "name": "openov",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-u0-openov~lu"
+        }
+    ]
+}


### PR DESCRIPTION
The GTFS-RT feed there unfortunately seems discontinued since 2017, so GTFS only for now.