### PR TITLE
France: Add Paris

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -40,6 +40,11 @@
             "name": "TER",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u0-sncf~ter~rt"
+        },
+        {
+            "name": "Paris",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-u09-paris~metro~bus~tram"
         }
     ]
 }


### PR DESCRIPTION
The Paris Metro is pretty important since it's the main connection between the train stations.