### PR TITLE
ci: Set up timer for import

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
   workflow_dispatch:
+  schedule:
+    - cron:  '30 2 * * *'
 
 jobs:
   import:


### PR DESCRIPTION
While the argument to the python script is called timer, so far the actual timer didn't exist.

We currently have enough activity to trigger imports often enough right now, but let's better have this.