### PR TITLE
fr: Add TBC (Bordeaux)

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -94,6 +94,17 @@
             "options": {
                 "fetch-interval-days": 2
             }
+        },
+        {
+            "name": "TBC",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ezzx-tbc",
+            "fix": true
+        },
+        {
+            "name": "TBC-bus",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ezzx-tbc~bus"
         }
     ]
 }


### PR DESCRIPTION
Add TBC (Bordeaux) feeds.

At one point we used a community-run OpenTripPlanner instance serving Bordeaux data with our plugin service definition in GNOME Maps. This has not been around for a couple of years, so thought it could be could to get it covered here now.