### PR TITLE
Add Hong Kong

### DIFF
--- a/feeds/hk.json
+++ b/feeds/hk.json
@@ -1,0 +1,15 @@
+{
+    "maintainers": [
+        {
+            "name": "Gordon Leung",
+            "github": "pi-cla"
+        }
+    ],
+    "sources": [
+        {
+            "name": "Hong-Kong-Transit",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-hong~kong~en"
+        }
+    ]
+}


### PR DESCRIPTION
The government has a single GTFS feed for about a dozen operators so for now the feed will just be called
"Hong-Kong-Transit"