### PR TITLE
Fix CI-pipeline warning and always save cache

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -44,12 +44,12 @@ jobs:
 
     - name: Cache feeds
       uses: actions/cache/save@v4
+      if: always()
       with:
         path: |
           downloads/
           out/*.zip
         key: feeds-${{ hashFiles('downloads/*') }}
-        save-always: true
 
     - name: Update attribution
       run: |


### PR DESCRIPTION
I messed up the import pipeline while trying to always save the cache after downloading the feeds. Currently all import runs generate a warning:

```
import
Unexpected input(s) 'save-always', valid inputs are ['path', 'key', 'upload-chunk-size', 'enableCrossOsArchive']
```

This PR should fix this warning and always save the cache...