### PR TITLE
Add Finish local transport feeds from Waltti

### DIFF
--- a/feeds/fi.json
+++ b/feeds/fi.json
@@ -25,6 +25,95 @@
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://www.digitraffic.fi/en/railway-traffic/"
             }
+        },
+        {
+            "name": "203",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-udc-lehdonliikenneoy~hämebusoy~pekolanliikenneoy~mikkolanliike"
+        },
+        {
+            "name": "207",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ueh-savo~karjalanlinjaoy~linja~karjalaoy~ely~pohjolanturistiau"
+        },
+        {
+            "name": "209",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ue4-jyväskylänliikenneoy~koivurantaoy~tilausajotmennÄÄnbussill"
+        },
+        {
+            "name": "211",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ue7-savo~karjalanlinjaoy~oypohjolanliikenneab~liikennemheikura"
+        },
+        {
+            "name": "217",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-udg-oypohjolanliikenneab~etelä~suomenlinjaliikenneoy~jyrkiläoy"
+        },
+        {
+            "name": "219",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-kouvola~fi"
+        },
+        {
+            "name": "221",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ue5-linja~karjalaoy~oypohjolanliikenneab~kuopionliikenneoy~jää"
+        },
+        {
+            "name": "223",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-udf-r~kioski~koivistonautooy~lehtimäenliikenneoy~järvisenliike"
+        },
+        {
+            "name": "225",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ud-autolinjatoy~erantanenoy~kuljetusmikkonenky~tilausliikenneh"
+        },
+        {
+            "name": "227",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-mikkeli~fi"
+        },
+        {
+            "name": "229",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ued-oulunjoukkoliikenne"
+        },
+        {
+            "name": "231",
+            "type": "http",
+            "url": "https://tvv.fra1.digitaloceanspaces.com/231.zip",
+            "license": {
+                "spdx_identifier": "CC-BY-4.0",
+                "url": "https://opendata.waltti.fi/docs#gtfs-static-packages"
+            }
+        },
+        {
+            "name": "232",
+            "type": "http",
+            "url": "https://tvv.fra1.digitaloceanspaces.com/232.zip",
+            "license": {
+                "spdx_identifier": "CC-BY-4.0",
+                "url": "https://opendata.waltti.fi/docs#gtfs-static-packages"
+            }
+        },
+        {
+            "name": "237",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-rovaniemi~fi"
+        },
+        {
+            "name": "239",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-salo~fi"
+        },
+        {
+            "name": "249",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-vaasa~fi",
+            "fix": true
         }
     ]
 }


### PR DESCRIPTION
This still misses Helsinki, Tampere and Turku who have their own feeds, and it also doesn't include the Waltti realtime feeds yet as those need an API key.