### PR TITLE
Add Helsinki feed

### DIFF
--- a/feeds/fi.json
+++ b/feeds/fi.json
@@ -114,6 +114,11 @@
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-vaasa~fi",
             "fix": true
+        },
+        {
+            "name": "hsl",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ud9-helsinginseudunliikenne"
         }
     ]
 }


### PR DESCRIPTION
Realtime data is available, but not compatible with MOTIS (see #128).