### PR TITLE
Support LookupGeoStationRequest in motis-proxy

### DIFF
--- a/motis-proxy/src/main.rs
+++ b/motis-proxy/src/main.rs
@@ -105,6 +105,8 @@ enum Endpoint {
     PprRoute,
     #[serde(rename = "/trip_to_connection")]
     TripId,
+    #[serde(rename = "/lookup/geo_station")]
+    LookupGeoStation,
 }
 
 #[derive(Deserialize, Serialize, JsonSchema)]
@@ -409,6 +411,12 @@ struct TripId {
 }
 
 #[derive(Deserialize, Serialize, JsonSchema)]
+struct LookupGeoStationRequest {
+    max_radius: u32,
+    pos: GeoLocation,
+}
+
+#[derive(Deserialize, Serialize, JsonSchema)]
 #[serde(tag = "content_type", content = "content")]
 enum RequestContent {
     /// This request can be sent to the `/intermodal` target
@@ -431,6 +439,8 @@ enum RequestContent {
     FootRoutingRequest(FootRoutingRequest),
     /// This request can be sent to the `/trip_to_connection` target
     TripId(TripId),
+    /// This request can be sent to the `/lookup/geo_station` target
+    LookupGeoStationRequest(LookupGeoStationRequest),
 }
 
 #[derive(Deserialize, Serialize, JsonSchema)]


### PR DESCRIPTION
This is used e.g. by KPublicTransport for looking up stations by geo coordinate.