### PR TITLE
us-ri: Add all bus routes in Rhode Island

### DIFF
--- a/feeds/us-ri.json
+++ b/feeds/us-ri.json
@@ -1,0 +1,20 @@
+{
+    "maintainers": [
+        {
+            "name": "Steven Whitaker",
+            "github": "sjwhitak"
+        }
+    ],
+    "sources": [
+        {
+            "name": "RIPTA",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-drm-rhodeislandpublictransitauthority"
+        },
+        {
+            "name": "RIPTA",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ripta~rt"
+        }
+    ]
+}


### PR DESCRIPTION
RIPTA (Rhode Island Public Transportation Authority) is the one public bus system in the state of Rhode Island. 