### PR TITLE
us-ga: Add feed for MARTA (Atlanta area)

### DIFF
--- a/feeds/us-ga.json
+++ b/feeds/us-ga.json
@@ -1,0 +1,21 @@
+{
+    "maintainers": [
+        {
+            "name": "Marcus Lundblad",
+            "github": "mlundblad"
+        }
+    ],
+    "sources": [
+        {
+            "name": "MARTA",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-dnh-marta"
+        },
+        {
+            "name": "MARTA",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-dnh-marta~rt"
+        }
+    ]
+}
+        


### PR DESCRIPTION
Add feed for MARTA (Atlanta, Georgia US).