### PR TITLE
Update fr.json : Add Nouvelle Aquitaine Mobilités

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -124,6 +124,16 @@
             "name": "Navettes-Paris-Saclay",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-zenbus~paris~saclay~rt"
-        }
+        },
+        {
+            "name": "Nouvelle-Aquitaine-Mobilites",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-naq~pigma"
+        },
+        {
+            "name": "Nouvelle-Aquitaine-Mobilites",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ezzx-tbc~rt"
+        }       
     ]
 }


### PR DESCRIPTION
Add Nouvelle-Aquitaine Mobilités static feed (public transportation feed for the whole Nouvelle Aquitaine, France) and associated RT feed from TBM (one agency aggregated in the Nouvelle-Aquitaine Mobilités feed).