### PR TITLE
tn: Add feed for SNCTF (National Tunisian railway company)

### DIFF
--- a/feeds/tn.json
+++ b/feeds/tn.json
@@ -1,0 +1,15 @@
+{
+    "maintainers": [
+        {
+            "name": "Marcus Lundblad",
+            "github": "mlundblad"
+        }
+    ],
+    "sources": [
+        {
+            "name": "SNCTF",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-sn-tunis~banlieues"
+        }
+    ]
+}


### PR DESCRIPTION
Adds feed for Tunisian railways (SNCTF).

