### PR TITLE
Update fr.json: fix #194 and add coverage for Normandy, France

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -132,7 +132,8 @@
         {
             "name": "Nouvelle-Aquitaine-Mobilites",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-naq~pigma"
+            "transitland-atlas-id": "f-naq~pigma",
+            "fix": true
         },
         {
             "name": "TBM",
@@ -143,6 +144,21 @@
             "name": "TBM",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-ezzx-tbc~rt"
+        },
+        {
+            "name": "Atoumod",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-sp9x-normandie"
+        },
+        {
+            "name": "Cap-Cotentin",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-cap~cotentin"
+        },
+        {
+            "name": "Cap-Cotentin",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-cap~cotentin~rt"
         }
     ]
 }


### PR DESCRIPTION
Add fix option to Nouvelle-Aquitaine-Mobilites to deal with feed error, hopefully fixing #194 .

Add coverage for Normandie region in France through Atoumod. Also add "Cap Cotentin": as with Nouvelle Aquitaine Mobilités and TBM, Cap Cotentin is part of Atoumod, but its GTFS-RT feed uses IDs from Cap Cotentin feed, not Atoumod.