### PR TITLE
sg: Add feed for Singapore

### DIFF
--- a/feeds/sg.json
+++ b/feeds/sg.json
@@ -1,0 +1,15 @@
+{
+    "maintainers": [
+        {
+            "name": "Marcus Lundblad",
+            "github": "mlundblad"
+        }
+    ],
+    "sources": [
+        {
+            "name": "LTA",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-w21z-lta"
+        }
+    ]
+}


### PR DESCRIPTION
Add LTA feed for Singapore.

We have an old issue in GNOME Maps requesting transit support for Prague, so thought we might get it in: https://gitlab.gnome.org/GNOME/gnome-maps/-/issues/400