### PR TITLE
Add script to fix csv files with incorrect quoting

### DIFF
--- a/feeds/lv.json
+++ b/feeds/lv.json
@@ -33,6 +33,7 @@
             "type": "http",
             "url": "https://www.atd.lv/sites/default/files/GTFS/gtfs-latvia-lv.zip",
             "fix": true,
+            "fix-csv-quotes": true,
             "license": {
                 "spdx-identifier": "CC0-1.0"
             }

--- a/src/fetch.py
+++ b/src/fetch.py
@@ -125,9 +125,15 @@ class Fetcher:
         print("Unknown data source", source, file=sys.stderr)
         assert False
 
-    def postprocess(self, source: Source, input_path: Path, output_path: Path):
-        command = ["gtfstidy", str(input_path.absolute()), "--check-null-coords",
-                   "--output", output_path]
+    def postprocess(self, source: Source,
+                    input_path: Path, output_path: Path):
+        shutil.copyfile(input_path, output_path)
+
+        if source.fix_csv_quotes:
+            subprocess.check_call(["./src/fix-csv-quotes.py", output_path])
+
+        command = ["gtfstidy", output_path,
+                   "--check-null-coords", "--output", output_path]
         if source.fix:
             command.append("--fix")
 

--- a/src/fix-csv-quotes.py
+++ b/src/fix-csv-quotes.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2024 Jonah Brüchert <jbb@kaidan.im>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import zipfile
+import sys
+import os
+from functools import reduce
+import csv
+import io
+
+
+def strip_quotes(field: str):
+    if field.startswith('"') and field.endswith('"'):
+        return field[1:-1]
+    else:
+        return field
+
+
+def parse_fuzzy_csv(csv: str) -> list[list[str]]:
+    rows = []
+    for line in csv.splitlines():
+        line = line.decode()
+        start = 0
+        current_field_start = 0
+        fields = []
+        while True:
+            fieldsep = line.find(",", start)
+            if fieldsep == -1:
+                field = line[current_field_start:]
+                fields.append(strip_quotes(field.strip()))
+                rows.append(fields)
+                break
+
+            field = line[current_field_start:fieldsep]
+            numquotes = reduce(
+                lambda acc, c: acc + 1 if c == '"' else acc, field, 0)
+            if numquotes % 2 == 0:
+                fields.append(strip_quotes(field.strip()))
+                current_field_start = fieldsep + 1
+                start = fieldsep + 1
+            else:
+                current_field_start = start
+                start = fieldsep + 1
+
+    return rows
+
+
+def edit_zip(source: str, destination: str):
+    with zipfile.ZipFile(source) as inzip, \
+            zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as outzip:
+        # Iterate the input files
+        for inzipinfo in inzip.infolist():
+            with inzip.open(inzipinfo) as infile:
+                if inzipinfo.filename.endswith(".txt"):
+                    print("Rewriting", inzipinfo.filename)
+                    content = infile.read()
+                    rows = parse_fuzzy_csv(content)
+
+                    with io.StringIO() as outcsv:
+                        writer = csv.writer(outcsv)
+                        for row in rows:
+                            writer.writerow(row)
+
+                        outzip.writestr(inzipinfo.filename, outcsv.getvalue())
+                else:
+                    outzip.writestr(inzipinfo.filename, infile.read())
+
+
+if __name__ == "__main__":
+    source = sys.argv[1]
+    destination = source + ".tmp"
+
+    edit_zip(source, destination)
+
+    os.rename(destination, source)

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -28,6 +28,7 @@ class Source:
     license: Optional[License] = None
     spec: str = "gtfs"
     enabled: bool = True
+    fix_csv_quotes: bool = False
 
     def __init__(self, parsed: Optional[dict] = None):
         self.license = License()
@@ -44,6 +45,8 @@ class Source:
             self.name = parsed["name"]
             if "fix" in parsed:
                 self.fix = bool(parsed["fix"])
+            if "fix-csv-quotes" in parsed:
+                self.fix_csv_quotes = bool(parsed["fix-csv-quotes"])
             if "spec" in parsed:
                 self.spec = parsed["spec"]
 


### PR DESCRIPTION
The script is currently not super flexible, but works for the one known
feed with this issue. It can be extended when needed.

This should fix this issue:
![image](https://github.com/public-transport/transitous/assets/13609393/650daef1-3530-47b6-8650-7d85cda5af8c)

