### PR TITLE
Fix BC-Ferries

### DIFF
--- a/feeds/ca-bc.json
+++ b/feeds/ca-bc.json
@@ -9,7 +9,8 @@
         {
             "name": "BC-Ferries",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-c0-bcferries~bc~ca"
+            "transitland-atlas-id": "f-c0-bcferries~bc~ca",
+            "fix": "true"
         },
         {
             "name": "Black-Ball-Ferry-Line",


### PR DESCRIPTION
Fix #252
This is caused by these two lines in calendar_dates.txt:
```
20240526,c_21151_b_31125_d_127t_5603137_b_31125_tn_0,,2
20240526,c_21151_b_31125_d_127t_5603137_b_31125_tn_0,,1
```
where the same service was listed as being both removed (2) and added (1) for the specific date