### PR TITLE
Add feed for Brittany (train, bus, metro, car, boat)

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -19,6 +19,10 @@
         {
             "name": "Tanguy Fardet",
             "github": "tfardet"
+        },
+        {
+            "name": "Gildas GH",
+            "github": "gildas-gh"
         }
     ],
     "sources": [
@@ -179,6 +183,12 @@
             "name": "Tisseo",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-spc0-tisséo"
+        },
+        {
+            "name": "Brittany",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-gbwc-mobibreizh",
+            "fix": true
         }
     ]
 }


### PR DESCRIPTION
I added a feed for Brittany public transport. It aggregates the feeds of each city in Brittany in a single one. There are some errors (12 stops and 828 stop times, most of them for train stop times, which is already included in SNCF TER feed) so I added the "fix" attribute.