### PR TITLE
Add V-BUSZ and MKV to Hungary

### DIFF
--- a/feeds/hu.json
+++ b/feeds/hu.json
@@ -25,6 +25,16 @@
             "name": "bkk",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u2m-bkk"
+        },
+        {
+            "name": "v-busz",
+            "type": "http",
+            "url": "https://www.vbusz.hu/gtfs"
+        },
+        {
+            "name": "mkv",
+            "type": "http",
+            "url": "https://gtfsapi.mvkzrt.hu/gtfs/gtfs.zip"
         }
     ]
 }


### PR DESCRIPTION
Adds V-BUSZ Kft. (Veszprém) and MKV Zrt. (Miskolc) data in Hungary.
Both feeds are directly from the operators.