### PR TITLE
us: Add Flixbus

### DIFF
--- a/feeds/us.json
+++ b/feeds/us.json
@@ -11,6 +11,12 @@
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-9-amtrak~amtrakcalifornia~amtrakcharteredvehicle",
             "fix": true
+        },
+        {
+            "name": "flixbus",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-9-flixbus",
+            "fix": true
         }
     ]
 }


### PR DESCRIPTION
Flixbus owns Greyhound which is a major operator of long distance coach services in North America.