### PR TITLE
Added some autobus companies in Lombardy

### DIFF
--- a/feeds/it.json
+++ b/feeds/it.json
@@ -49,7 +49,7 @@
         {
             "name": "Lombardia-AirPullman",
             "type": "http",
-            "fix": true
+            "fix": true,
             "license": {
                 "spdx-identifier": "CC-BY-4.0"
             },

--- a/feeds/it.json
+++ b/feeds/it.json
@@ -47,10 +47,50 @@
             "fix": true
         },
         {
+            "name": "Lombardia-AirPullman",
+            "type": "http",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            },
+            "url": "https://usbshare.agenziatpl.it/index.php/s/icR3wYc53Frnbfe/download/2024-02-12_AirPullman.zip"
+        },
+        {
             "name": "Lombardia-ATM",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u0nd-comunedimilano",
             "proxy": true
+        },
+        {
+            "name": "Lombardia-Movibus",
+            "type": "http",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            },
+            "url": "https://usbshare.agenziatpl.it/index.php/s/as63KiKmeK6Kwb3/download/2024-06-11_Movibus.zip"
+        },
+        {
+            "name": "Lombardia-NET",
+            "type": "http",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            },
+            "url": "https://usbshare.agenziatpl.it/index.php/s/s3j9BZqcarzRZoN/download/2024-06-07_NET.zip"
+        },
+        {
+            "name": "Lombardia-STAR",
+            "type": "http",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            },
+            "url": "https://usbshare.agenziatpl.it/index.php/s/7PrFyAHRrqnxKFj/download/2024-02-14_PMT.zip"
+        },
+        {
+            "name": "Lombardia-STAV",
+            "type": "http",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            },
+            "url": "https://usbshare.agenziatpl.it/index.php/s/r7J4s8Q324kFtx8/download/2024-06-13_STAV.zip"
         },
         {
             "name": "Lombardia-Trenord",

--- a/feeds/it.json
+++ b/feeds/it.json
@@ -49,6 +49,7 @@
         {
             "name": "Lombardia-AirPullman",
             "type": "http",
+            "fix": true
             "license": {
                 "spdx-identifier": "CC-BY-4.0"
             },


### PR DESCRIPTION
Added Movibus, AirPullman, NET, STAR and STAV from https://www.agenziatpl.it/open-data/gtfs

I suppose those data must be checked regularly as the filename contains a date and they may change the date when updating the data.