### PR TITLE
added Poznan region and wkulesza as maintainer

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -4,6 +4,10 @@
             "name": "Jonah Brüchert",
             "github": "jbruechert"
         }
+        {
+            "name": "Wojciech Kulesza"
+            "github": "wkulesza"
+        }
     ],
     "sources": [
         {
@@ -111,6 +115,11 @@
             "name": "Elbląg",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u3tu-elblag"
+        }
+        {
+            "name": "Poznań"
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-u3k4-miejskieprzedsiębiorstwokomunikacyjnespzoowpoznaniu~kórni"
         }
     ]
 }


### PR DESCRIPTION
Added Poznan GTFS as region. ZTM Poznan (Municipal Transport Authority in Poznan) is the original maintainer of the feed. Source is here: https://ztm.poznan.pl/pl/dla-deweloperow/gtfsFiles but also here in Transitland - https://www.transit.land/feeds/f-u3k4-miejskieprzedsi%C4%99biorstwokomunikacyjnespzoowpoznaniu~k%C3%B3rni so I added transitland-atlas-id instead of original url. 