### PR TITLE
Update vbusz.hu GTFS feed URL

### DIFF
--- a/feeds/hu.json
+++ b/feeds/hu.json
@@ -29,7 +29,7 @@
         {
             "name": "v-busz",
             "type": "http",
-            "url": "https://www.vbusz.hu/gtfs"
+            "url": "https://vbusz.hu/wp-content/uploads/2024/08/gtfs.zip"
         },
         {
             "name": "mkv",


### PR DESCRIPTION
Not sure whether that URL is sufficiently stable, but that's the only thing there is right now it seems.

Fixes #434.