### PR TITLE
Remove v-busz for now

### DIFF
--- a/feeds/hu.json
+++ b/feeds/hu.json
@@ -27,11 +27,6 @@
             "transitland-atlas-id": "f-u2m-bkk"
         },
         {
-            "name": "v-busz",
-            "type": "http",
-            "url": "https://vbusz.hu/wp-content/uploads/2024/08/gtfs.zip"
-        },
-        {
             "name": "mkv",
             "type": "http",
             "url": "https://gtfsapi.mvkzrt.hu/gtfs/gtfs.zip"


### PR DESCRIPTION
Their GTFS feed isn't downloadable anymore.

Fixes #439.