### PR TITLE
Update MOTIS to v0.12.12

### DIFF
--- a/ansible/roles/motis/tasks/main.yml
+++ b/ansible/roles/motis/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Unpack MOTIS
   unarchive:
-    src: https://github.com/motis-project/motis/releases/download/v0.12.10/motis-linux-amd64.tar.bz2
+    src: https://github.com/motis-project/motis/releases/download/v0.12.12/motis-linux-amd64.tar.bz2
     dest: /opt/
     remote_src: yes
 

--- a/ci/container/Containerfile
+++ b/ci/container/Containerfile
@@ -7,7 +7,7 @@ RUN GOPROXY=direct GOBIN=/usr/local/bin/ go install github.com/public-transport/
 
 FROM docker.io/debian:bookworm-slim
 
-ARG MOTIS_VERSION=v0.12.10
+ARG MOTIS_VERSION=v0.12.12
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends git python3-requests python3-jinja2 wget bzip2 rsync openssh-client && \

--- a/ci/container/Containerfile-devcontainer
+++ b/ci/container/Containerfile-devcontainer
@@ -6,7 +6,7 @@ RUN GOPROXY=direct GOBIN=/usr/local/bin/ go install github.com/public-transport/
 
 FROM docker.io/debian:bookworm-slim
 
-ARG MOTIS_VERSION=v0.12.10
+ARG MOTIS_VERSION=v0.12.12
 ARG USERNAME=transitous
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID


### PR DESCRIPTION
Update MOTIS to v0.12.12 to get via search and transfer time settings in Transitous.