### PR TITLE
Fixing broken Turkey feeds

### DIFF
--- a/feeds/tr.json
+++ b/feeds/tr.json
@@ -14,12 +14,14 @@
         {
             "name": "izmir-metro",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-izmir~metro"
+            "transitland-atlas-id": "f-izmir~metro",
+            "fix": true
         },
         {
             "name": "izmir-izban",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-izmir~rail"
+            "transitland-atlas-id": "f-izmir~rail",
+            "fix": true
         },
         {
             "name": "izmir-tram",
@@ -29,12 +31,14 @@
         {
             "name": "istanbul-ibb",
             "type": "http",
-            "url": "https://s3.gtfs.pro/files/uran/improved-gtfs-ibb-istanbul.zip"
+            "url": "https://s3.gtfs.pro/files/uran/improved-gtfs-ibb-istanbul.zip",
+            "fix": true
         },
         {
             "name": "istanbul-iett",
             "type": "http",
-            "url": "https://s3.gtfs.pro/files/sourcedata/iett.zip"
+            "url": "https://s3.gtfs.pro/files/sourcedata/iett.zip",
+            "fix": true
         },
         {
             "name": "konya",

--- a/feeds/tr.json
+++ b/feeds/tr.json
@@ -26,5 +26,15 @@
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-izmir~tram"
         },
+        {
+            "name": "istanbul-ibb",
+            "type": "http",
+            "url": "https://s3.gtfs.pro/files/uran/improved-gtfs-ibb-istanbul.zip"
+        },
+        {
+            "name": "istanbul-iett",
+            "type": "http",
+            "url": "https://s3.gtfs.pro/files/sourcedata/iett.zip"
+        }
     ]
 }

--- a/feeds/tr.json
+++ b/feeds/tr.json
@@ -7,15 +7,14 @@
     ],
     "sources": [
         {
-    	   "name": "izmir-eshot",
+           "name": "izmir-eshot",
            "type": "transitland-atlas",
            "transitland-atlas-id": "f-eshot~tr"
         },
         {
             "name": "izmir-metro",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-izmir~metro",
-            "fix": true
+            "type": "http",
+            "url": "https://yasinkaraaslan.com/gtfs/izmir-metro.zip"
         },
         {
             "name": "izmir-izban",
@@ -31,14 +30,13 @@
         {
             "name": "istanbul-ibb",
             "type": "http",
-            "url": "https://s3.gtfs.pro/files/uran/improved-gtfs-ibb-istanbul.zip",
+            "url": "https://yasinkaraaslan.com/gtfs/istanbul-ibb.zip",
             "fix": true
         },
         {
             "name": "istanbul-iett",
             "type": "http",
-            "url": "https://s3.gtfs.pro/files/sourcedata/iett.zip",
-            "fix": true
+            "url": "https://yasinkaraaslan.com/gtfs/istanbul-iett.zip"
         },
         {
             "name": "konya",

--- a/feeds/tr.json
+++ b/feeds/tr.json
@@ -35,6 +35,11 @@
             "name": "istanbul-iett",
             "type": "http",
             "url": "https://s3.gtfs.pro/files/sourcedata/iett.zip"
+        },
+        {
+            "name": "konya",
+            "type": "http",
+            "url": "https://acikveri.konya.bel.tr/tr/dataset/c2e034e6-e015-49c6-8eec-6e2f7de9c105/resource/5742b7bd-3cbf-4784-bee1-f949fc0ca118/download/gtfs_07_2024.zip"
         }
     ]
 }

--- a/feeds/tr.json
+++ b/feeds/tr.json
@@ -1,0 +1,30 @@
+{
+    "maintainers": [
+        {
+            "name": "Yasin Karaaslan",
+            "github": "yasinkaraaslan"
+        }
+    ],
+    "sources": [
+        {
+    	   "name": "izmir-eshot",
+           "type": "transitland-atlas",
+           "transitland-atlas-id": "f-eshot~tr"
+        },
+        {
+            "name": "izmir-metro",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-izmir~metro"
+        },
+        {
+            "name": "izmir-izban",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-izmir~rail"
+        },
+        {
+            "name": "izmir-tram",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-izmir~tram"
+        },
+    ]
+}


### PR DESCRIPTION
It's so stupid that we have to put up with this crap, I finally got something more or less working without too many dropped infos.
It's crazy that they probably post the data without even testing.

Also, is there a chance to remove --drop-too-fast-trips from the test script? 13% of trips from istanbul-iett is dropped because of that. It's probably again someone put some numbers wrong but I am so tired and don't want to fix 17000 different numbers by hand :D 
