### PR TITLE
Fix Cap Cotentin network URL

### DIFF
--- a/ansible/roles/motis/tasks/main.yml
+++ b/ansible/roles/motis/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Unpack MOTIS
   unarchive:
-    src: https://github.com/motis-project/motis/releases/download/v0.12.10/motis-linux-amd64.tar.bz2
+    src: https://github.com/motis-project/motis/releases/download/v0.12.12/motis-linux-amd64.tar.bz2
     dest: /opt/
     remote_src: yes
 

--- a/ci/container/Containerfile
+++ b/ci/container/Containerfile
@@ -7,7 +7,7 @@ RUN GOPROXY=direct GOBIN=/usr/local/bin/ go install github.com/public-transport/
 
 FROM docker.io/debian:bookworm-slim
 
-ARG MOTIS_VERSION=v0.12.10
+ARG MOTIS_VERSION=v0.12.12
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends git python3-requests python3-jinja2 wget bzip2 rsync openssh-client && \

--- a/ci/container/Containerfile-devcontainer
+++ b/ci/container/Containerfile-devcontainer
@@ -6,7 +6,7 @@ RUN GOPROXY=direct GOBIN=/usr/local/bin/ go install github.com/public-transport/
 
 FROM docker.io/debian:bookworm-slim
 
-ARG MOTIS_VERSION=v0.12.10
+ARG MOTIS_VERSION=v0.12.12
 ARG USERNAME=transitous
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID

--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -1630,9 +1630,18 @@
             }
         },
         {
+            "name": "horaires-theoriques-cap-cotentin-cherbourg-rennes",
+            "type": "http",
+            "url": "https://www.data.gouv.fr/fr/datasets/r/07f7a5b7-7ece-413d-952a-66603e426b7c",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin"
+            }
+        },
+        {
             "name": "horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin/20240604-074459/gtfs-capcotentin-31052024-au-25082024-v2.zip",
+            "url": "https://www.data.gouv.fr/fr/datasets/r/2e97c9b3-a59f-42dd-9b9e-a232fa771f21",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin"

--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -704,7 +704,7 @@
         {
             "name": "base-de-donnees-multimodale-des-reseaux-de-transport-public-normands",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/base-de-donnees-multimodale-des-reseaux-de-transport-public-normands/20240702-085115/pt-th-offer-atoumod-gtfs-20240702-608-opendata.zip",
+            "url": "https://www.data.gouv.fr/fr/datasets/r/3873ccc7-44d9-40f3-a133-920944af0c29",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/base-de-donnees-multimodale-des-reseaux-de-transport-public-normands"


### PR DESCRIPTION
URL for Cap Cotentin was an old one. Fix it.

BTW @jbruechert do you know why most (except one) data has been changed to URL format when they where updated and working in Transitland Atlas format?