### PR TITLE
tr: add Ankara and Antalya

### DIFF
--- a/feeds/tr.json
+++ b/feeds/tr.json
@@ -52,6 +52,18 @@
             "type": "http",
             "url": "https://dl.dropboxusercontent.com/scl/fi/2x02vtnwmtfmloygeuc3y/kocaeli.zip?rlkey=jarn6ofb7gu5g9gdeopkcbw5k",
             "fix": true
+        },
+        {
+            "name": "ankara",
+            "type": "http",
+            "url": "https://dl.dropboxusercontent.com/scl/fi/d7u3d00gd85w2qbzedze6/ankara.zip?rlkey=4x8oz2sby5vvqgf1iuaeit70l",
+            "drop-too-fast-trips": false
+        },
+        {
+            "name": "antalya",
+            "type": "http",
+            "url": "https://dl.dropboxusercontent.com/scl/fi/3wsws4ukgdi3uio68cvu4/antalya.zip?rlkey=nafdcydx4pvbuz908luhk6i9x",
+            "drop-too-fast-trips": false
         }
     ]
 }

--- a/feeds/tr.json
+++ b/feeds/tr.json
@@ -57,7 +57,7 @@
             "name": "ankara",
             "type": "http",
             "url": "https://dl.dropboxusercontent.com/scl/fi/d7u3d00gd85w2qbzedze6/ankara.zip?rlkey=4x8oz2sby5vvqgf1iuaeit70l",
-            "drop-too-fast-trips": false
+            "drop-too-fast-trips": true
         },
         {
             "name": "antalya",


### PR DESCRIPTION
These are not official feeds, I got them from someone who scraped them. Ankara seems to have a lot of "fast trips" (still usable), I will try to fix them in the future. But Antalya doesn't seem to have any problems.

With these new feeds, 3 out of 5 biggest cities from Turkey will be supported (excluding Istanbul)