### PR TITLE
feat(feeds): NZ.json - added BUSIT and Baybus

### DIFF
--- a/feeds/nz.json
+++ b/feeds/nz.json
@@ -55,6 +55,16 @@
                     "Ocp-Apim-Subscription-Key": "920de6bcafdb445699a7ba92dd5cc005"
                 }
             }
+        },
+        {
+            "name": "BUSIT",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-busit~nz"
+        },
+        {
+            "name": "Baybus",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-boprc~nz"
         }
     ]
 }


### PR DESCRIPTION
Thanks to whoever added Baybus to Transitland!

This should be the last of the larger cities, all the others don't have publicly available GTFS feeds as far as I can tell, so some emailing will be in order for the future.