### PR TITLE
Add fix flag to capital corridor

### DIFF
--- a/feeds/us-ca.json
+++ b/feeds/us-ca.json
@@ -16,6 +16,7 @@
             "name": "Capitolcorridor",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-9qc-capitolcorridor",
+            "fix": true,
             "proxy": true
         },
         {


### PR DESCRIPTION
timepoint value in stop_times.txt is invalid (value should be 1 or 0 but is instead 10)
this should probably be emailed to the agency using the templates, making this pr to fix import