### PR TITLE
Add gtfs-rt feeds, fix skip reason on glendale beeline

### DIFF
--- a/feeds/us-ca.json
+++ b/feeds/us-ca.json
@@ -97,11 +97,16 @@
             "transitland-atlas-id": "f-antelope~valley~transit~authority"
         },
         {
+            "name": "Antelope-Valley-Transit-Authority",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-antelope~valley~transit~authority~rt"
+        },
+        {
             "name": "Glendale-Beeline",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-9q5f-glendalebeeline",
             "skip": true,
-            "skip-reason": "403 error code when downloading, no documentation from agency on fix"
+            "skip-reason": "403 error code when downloading, no documentation from agency on fix, supposedly requires compression on download which isnt supported yet"
         },
         {
             "name": "Burbank-Bus",
@@ -110,10 +115,22 @@
             "fix": true
         },
         {
+            "name": "Burbank-Bus",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-burbankbus~rt",
+            "fix": true
+        },
+        {
             "name": "Santa-Clarita-Transit",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-santa~clarita"
-        },        {
+        },
+        {
+            "name": "Santa-Clarita-Transit",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-santa~clarita~rt"
+        },
+        {
             "name": "Metrolink",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-9qh-metrolinktrains"


### PR DESCRIPTION
Added gtfs-rt feeds for burbank bus, avta, and santa clarita transit as they seem to have rt feeds available without api keys

Changed skip reason on Glendale beeline to add text about compression mentioned in an earlier review