### PR TITLE
Amtrak shapes no longer broken, use Catenary Map's GTFS RT converter

### DIFF
--- a/feeds/us.json
+++ b/feeds/us.json
@@ -3,6 +3,10 @@
         {
             "name": "Marcus Lundblad",
             "github": "mlundblad"
+        },
+        {
+            "name": "Kyler Chin",
+            "github": "kylerchin"
         }
     ],
     "sources": [
@@ -11,7 +15,13 @@
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-9-amtrak~amtrakcalifornia~amtrakcharteredvehicle",
             "fix": true,
-            "drop-shapes": true
+            "drop-shapes": false
+        },
+        {
+            "name": "Amtrak",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://birch.catenarymaps.org/gtfs_rt?feed_id=f-amtrak~rt&feed_type=trip"
         },
         {
             "name": "Brightline",


### PR DESCRIPTION
https://catenarymaps.org Our research group supplies GTFS rt for amtrak that's converted from the website

https://birch.catenarymaps.org/gtfs_rt?feed_id=f-amtrak~rt&feed_type=vehicle
https://birch.catenarymaps.org/gtfs_rt?feed_id=f-amtrak~rt&feed_type=trip

Readable versions here:
https://birch.catenarymaps.org/gtfs_rt?feed_id=f-amtrak~rt&feed_type=vehicle&format=json
https://birch.catenarymaps.org/gtfs_rt?feed_id=f-amtrak~rt&feed_type=trip&format=json

What the dataset looks like:
![image](https://github.com/user-attachments/assets/a1623108-dcbb-4405-b40b-e4b0215e29cd)
