### PR TITLE
France: improve handling of multiple feeds in one dataset

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -4848,7 +4848,7 @@
         {
             "name": "arrets-lignes-regulieres-reseau-de-transport-urbain-a-autun",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/arrets-lignes-regulieres-reseau-de-transport-urbain-a-autun/20231218-104337/gtfs-20231212-ca-roule.zip",
+            "url": "https://static.data.gouv.fr/resources/arrets-lignes-regulieres-reseau-de-transport-urbain-a-autun/20241217-163652/gtfs-20240703-111144-bfc-sud.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-lignes-regulieres-reseau-de-transport-urbain-a-autun"

--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -957,6 +957,7 @@
             "type": "http",
             "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT21",
             "fix": true,
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
             }
@@ -966,6 +967,7 @@
             "type": "http",
             "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT25",
             "fix": true,
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
             }
@@ -975,6 +977,7 @@
             "type": "http",
             "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT39",
             "fix": true,
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
             }
@@ -984,6 +987,7 @@
             "type": "http",
             "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT58",
             "fix": true,
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
             }
@@ -993,6 +997,7 @@
             "type": "http",
             "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT70",
             "fix": true,
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
             }
@@ -1002,6 +1007,7 @@
             "type": "http",
             "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT71",
             "fix": true,
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
             }
@@ -1011,6 +1017,7 @@
             "type": "http",
             "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT89",
             "fix": true,
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
             }
@@ -5239,6 +5246,7 @@
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/gtfs-transport-horaires-des-lignes-de-la-communaute-de-communes-corse-du-sud-a-berlina/20241206-130438/a-berlina-horaires.zip",
             "fix": true,
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-des-lignes-de-la-communaute-de-communes-corse-du-sud-a-berlina"
             }
@@ -5562,6 +5570,7 @@
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/gtfs-transport-horaires-des-lignes-de-la-communaute-dile-rousse-balagne-a-balanina/20241206-125922/a-balanina-horaires.zip",
             "fix": true,
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-des-lignes-de-la-communaute-dile-rousse-balagne-a-balanina"
             }

--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -1229,7 +1229,7 @@
         {
             "name": "export-quotidien-au-format-gtfs-du-reseau-de-transport-lignes-d-azur",
             "type": "http",
-            "url": "http://opendata.nicecotedazur.org/data/storage/f/gtfs1734308101/GTFSExport.zip",
+            "url": "http://opendata.nicecotedazur.org/data/storage/f/gtfs1734394501/GTFSExport.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/export-quotidien-au-format-gtfs-du-reseau-de-transport-lignes-d-azur"
@@ -1407,16 +1407,7 @@
             }
         },
         {
-            "name": "horaires-du-reseau-transvilles-au-format-gtfs--81001",
-            "type": "http",
-            "url": "https://static.data.gouv.fr/resources/horaires-du-reseau-transvilles-au-format-gtfs/20240924-134833/google-transit-23-09-24.zip",
-            "fix": true,
-            "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-du-reseau-transvilles-au-format-gtfs"
-            }
-        },
-        {
-            "name": "horaires-du-reseau-transvilles-au-format-gtfs--82442",
+            "name": "horaires-du-reseau-transvilles-au-format-gtfs",
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/horaires-du-reseau-transvilles-au-format-gtfs/20241205-131815/google-transit-27-11-24-au-31-08-25.zip",
             "fix": true,
@@ -1692,7 +1683,7 @@
         {
             "name": "gtfs-sankeo",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/gtfs-sankeo/20241209-093152/gtfs-sankeo.zip",
+            "url": "https://static.data.gouv.fr/resources/gtfs-sankeo/20241217-080311/gtfs-sankeo.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-sankeo"
@@ -1737,7 +1728,7 @@
         {
             "name": "offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt/20241125-161355/gtfs-production.zip",
+            "url": "https://static.data.gouv.fr/resources/offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt/20241217-132601/gtfs-production.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt"
@@ -1755,7 +1746,7 @@
         {
             "name": "gtfs-diviamobilites",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/gtfs-diviamobilites/20241211-095227/gtfs-diviamobilites-current.zip",
+            "url": "https://static.data.gouv.fr/resources/gtfs-diviamobilites/20241217-105757/gtfs-diviamobilites-current.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-diviamobilites"
@@ -2098,7 +2089,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-gtfs-gtfs-rt-du-reseau-palmbus-cannes-pays-de-lerins",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/horaires-theoriques-et-temps-reel-gtfs-gtfs-rt-du-reseau-palmbus-cannes-pays-de-lerins/20241215-084442/palmbus-cannes-fr.zip",
+            "url": "https://static.data.gouv.fr/resources/horaires-theoriques-et-temps-reel-gtfs-gtfs-rt-du-reseau-palmbus-cannes-pays-de-lerins/20241217-132808/palmbus-cannes-fr.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-gtfs-gtfs-rt-du-reseau-palmbus-cannes-pays-de-lerins"
@@ -2409,6 +2400,15 @@
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/agglobus-offre-theorique-mobilite-reseau-urbain-de-bourges"
             }
+        },
+        {
+            "name": "agglobus-offre-theorique-mobilite-reseau-urbain-de-bourges",
+            "type": "url",
+            "url": "https://data.centrevaldeloire.fr/api/explore/v2.1/catalog/datasets/agglobus-offre-theorique-mobilite-reseau-urbain-de-bourges/files/9b6551fc2897c3d8669770e215a836c7",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/agglobus-offre-theorique-mobilite-reseau-urbain-de-bourges"
+            },
+            "spec": "gtfs-rt"
         },
         {
             "name": "fr-200052264-t0009-0000-1",
@@ -3612,7 +3612,7 @@
         {
             "name": "arrets-horaires-et-circuit-de-la-lignes-yeu-continent-gtfs",
             "type": "http",
-            "url": "https://donnees.paysdelaloire.fr/data/pdlYeuContinent.gtfs.zip",
+            "url": "https://app.mecatran.com/utw/ws/gtfsfeed/static/pdlYeuContinent?apiKey=2c715462180f36483d5f24340c706b627f2f2361",
             "fix": true,
             "skip": true,
             "license": {
@@ -3645,6 +3645,15 @@
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-rlv-mobilites"
             }
+        },
+        {
+            "name": "horaires-rlv-mobilites",
+            "type": "url",
+            "url": "http://H23.hanoverdisplays.com:52350/api-1.0/gtfs-rt/trip-updates",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/horaires-rlv-mobilites"
+            },
+            "spec": "gtfs-rt"
         },
         {
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-roc-nva-m-1",
@@ -3794,7 +3803,7 @@
         {
             "name": "transports-urbains-tad-ville-de-soissons",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/transports-urbains-tad-ville-de-soissons/20240228-133121/gtfs-soissons-tad.zip",
+            "url": "https://static.data.gouv.fr/resources/transports-urbains-tad-ville-de-soissons/20241217-142349/gtfs-soissons-tad.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transports-urbains-tad-ville-de-soissons"
@@ -4064,7 +4073,7 @@
         {
             "name": "reseau-transport-urbain-de-bernay",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/reseau-transport-urbain-de-bernay/20231016-143505/knsbernay-18129489-gtfs-urbain-bernay.zip",
+            "url": "https://static.data.gouv.fr/resources/reseau-transport-urbain-de-bernay/20241217-142157/bernay-ibus-gtfs-18122024.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-transport-urbain-de-bernay"
@@ -5244,7 +5253,7 @@
         {
             "name": "gtfs-transport-horaires-des-lignes-de-la-communaute-de-communes-corse-du-sud-a-berlina",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/gtfs-transport-horaires-des-lignes-de-la-communaute-de-communes-corse-du-sud-a-berlina/20241206-130438/a-berlina-horaires.zip",
+            "url": "https://static.data.gouv.fr/resources/gtfs-transport-horaires-des-lignes-de-la-communaute-de-communes-corse-du-sud-a-berlina/20241216-100804/a-berlina-horaires.zip",
             "fix": true,
             "skip": true,
             "license": {
@@ -5568,7 +5577,7 @@
         {
             "name": "gtfs-transport-horaires-des-lignes-de-la-communaute-dile-rousse-balagne-a-balanina",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/gtfs-transport-horaires-des-lignes-de-la-communaute-dile-rousse-balagne-a-balanina/20241206-125922/a-balanina-horaires.zip",
+            "url": "https://static.data.gouv.fr/resources/gtfs-transport-horaires-des-lignes-de-la-communaute-dile-rousse-balagne-a-balanina/20241216-100713/a-balanina-horaires.zip",
             "fix": true,
             "skip": true,
             "license": {

--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -65,7 +65,17 @@
             }
         },
         {
-            "name": "eurostar-gtfs",
+            "name": "eurostar-gtfs--80396",
+            "type": "http",
+            "url": "https://eurostar-prod-gtfs.s3.eu-central-1.amazonaws.com/gtfs.zip",
+            "fix": true,
+            "skip": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/eurostar-gtfs"
+            }
+        },
+        {
+            "name": "eurostar-gtfs--82199",
             "type": "http",
             "url": "https://gtfs.eurostar.com/assets/gtfs.zip",
             "fix": true,
@@ -269,9 +279,8 @@
         {
             "name": "reseau-cars-region-isere-38",
             "type": "http",
-            "url": "https://www.itinisere.fr/fr/donnees-open-data/169/OpenData/Download?fileName=TRANSAL.GTFS.zip",
+            "url": "https://www.itinisere.fr/fr/donnees-open-data/169/OpenData/Download?fileName=CG38.GTFS.zip",
             "fix": true,
-            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-cars-region-isere-38"
             }
@@ -280,7 +289,6 @@
             "name": "reseau-cars-region-isere-38",
             "type": "url",
             "url": "https://www.itinisere.fr/ftp/GtfsRT/GtfsRT.CG38.pb",
-            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-cars-region-isere-38"
             },
@@ -341,7 +349,34 @@
             }
         },
         {
-            "name": "arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise-1",
+            "name": "arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise-1--81820",
+            "type": "http",
+            "url": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_60_P1.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise-1"
+            }
+        },
+        {
+            "name": "arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise-1--81821",
+            "type": "http",
+            "url": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_60_P2.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise-1"
+            }
+        },
+        {
+            "name": "arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise-1--81822",
+            "type": "http",
+            "url": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_60_P3.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise-1"
+            }
+        },
+        {
+            "name": "arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise-1--81823",
             "type": "http",
             "url": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_60_P4.zip",
             "fix": true,
@@ -350,9 +385,45 @@
             }
         },
         {
-            "name": "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord",
+            "name": "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord--81828",
+            "type": "http",
+            "url": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_59_P1.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord"
+            }
+        },
+        {
+            "name": "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord--81829",
+            "type": "http",
+            "url": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_59_P2.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord"
+            }
+        },
+        {
+            "name": "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord--81830",
+            "type": "http",
+            "url": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_59_P3A.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord"
+            }
+        },
+        {
+            "name": "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord--81831",
             "type": "http",
             "url": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_59_P3B.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord"
+            }
+        },
+        {
+            "name": "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord--81832",
+            "type": "http",
+            "url": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_59_P4.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord"
@@ -711,23 +782,121 @@
             }
         },
         {
-            "name": "breizhgo-bateaux",
+            "name": "breizhgo-bateaux--81478",
             "type": "http",
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_BATEAU_ARZ.gtfs.zip",
             "fix": true,
-            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-bateaux"
             }
         },
         {
-            "name": "breizhgo-car",
+            "name": "breizhgo-bateaux--81479",
+            "type": "http",
+            "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_BATEAU_BREHAT.gtfs.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-bateaux"
+            }
+        },
+        {
+            "name": "breizhgo-bateaux--81480",
+            "type": "http",
+            "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_BATEAU_29.gtfs.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-bateaux"
+            }
+        },
+        {
+            "name": "breizhgo-bateaux--81481",
+            "type": "http",
+            "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_BATEAU_56.gtfs.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-bateaux"
+            }
+        },
+        {
+            "name": "breizhgo-car--81461",
+            "type": "http",
+            "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_22.gtfs.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+            }
+        },
+        {
+            "name": "breizhgo-car--81462",
+            "type": "http",
+            "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_29.gtfs.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+            }
+        },
+        {
+            "name": "breizhgo-car--81463",
+            "type": "http",
+            "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_35.gtfs.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+            }
+        },
+        {
+            "name": "breizhgo-car--81464",
+            "type": "http",
+            "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_56.gtfs.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+            }
+        },
+        {
+            "name": "breizhgo-car--81465",
+            "type": "http",
+            "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_NS.gtfs.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+            }
+        },
+        {
+            "name": "breizhgo-car--81466",
             "type": "http",
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_RLP.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
             }
+        },
+        {
+            "name": "breizhgo-car--81463",
+            "type": "url",
+            "url": "https://www.korrigo.bzh/ftp/OPENDATA/gtfsrt/BREIZHGO_CAR_35.GtfsRt.pb",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+            },
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "breizhgo-car--81466",
+            "type": "url",
+            "url": "https://www.korrigo.bzh/ftp/OPENDATA/gtfsrt/BREIZHGO_CAR_RLP.GtfsRt.pb",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+            },
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "breizhgo-car--81461",
+            "type": "url",
+            "url": "https://www.korrigo.bzh/ftp/OPENDATA/gtfsrt/TIBUS.GtfsRt.pb",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+            },
+            "spec": "gtfs-rt"
         },
         {
             "name": "breizhgo-35-experimentation",
@@ -784,7 +953,61 @@
             }
         },
         {
-            "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte",
+            "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11081",
+            "type": "http",
+            "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT21",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
+            }
+        },
+        {
+            "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11082",
+            "type": "http",
+            "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT25",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
+            }
+        },
+        {
+            "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11083",
+            "type": "http",
+            "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT39",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
+            }
+        },
+        {
+            "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11084",
+            "type": "http",
+            "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT58",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
+            }
+        },
+        {
+            "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11085",
+            "type": "http",
+            "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT70",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
+            }
+        },
+        {
+            "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11086",
+            "type": "http",
+            "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT71",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
+            }
+        },
+        {
+            "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11087",
             "type": "http",
             "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT89",
             "fix": true,
@@ -813,7 +1036,7 @@
         {
             "name": "reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
             "type": "http",
-            "url": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp-ctb?apiKey=686525656f2c3228054e6a7c3e38330037076207",
+            "url": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp?apiKey=60327e505a214c77303f52206f11483069257343",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone"
@@ -842,7 +1065,7 @@
         {
             "name": "horaires-theoriques-du-reseau-libellule-sytral-de-la-communaute-dagglomeration-de-villefranche-beaujolais-saone",
             "type": "http",
-            "url": "https://gtech-transit-prod.apigee.net/v1/google/gtfs/odbl/lyon_libellule.zip?apikey=BasyG6OFZXgXnzWdQLTwJFGcGmeOs204&secret=gNo6F5PhQpsGRBCK",
+            "url": "https://download.data.grandlyon.com/files/rdata/lbl_libellule.lbltheorique/gtfs_libellule.zip",
             "fix": true,
             "skip": true,
             "license": {
@@ -862,7 +1085,7 @@
         {
             "name": "horaires-theoriques-du-reseau-transports-en-commun-lyonnais",
             "type": "http",
-            "url": "https://gtech-transit-prod.apigee.net/v1/google/gtfs/odbl/lyon_tcl.zip?apikey=BasyG6OFZXgXnzWdQLTwJFGcGmeOs204&secret=gNo6F5PhQpsGRBCK",
+            "url": "https://download.data.grandlyon.com/files/rdata/tcl_sytral.tcltheorique/GTFS_TCL.ZIP",
             "fix": true,
             "skip": true,
             "license": {
@@ -1096,7 +1319,16 @@
             "spec": "gtfs-rt"
         },
         {
-            "name": "versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs",
+            "name": "versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs--82587",
+            "type": "http",
+            "url": "https://eu.ftp.opendatasoft.com/star/gtfs/GTFS_1_20241206_20241227_20241206155024.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs"
+            }
+        },
+        {
+            "name": "versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs--82588",
             "type": "http",
             "url": "https://eu.ftp.opendatasoft.com/star/gtfs/GTFS_2_20241228_20250105_20241206155105.zip",
             "fix": true,
@@ -1105,7 +1337,7 @@
             }
         },
         {
-            "name": "versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs",
+            "name": "versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs--82587",
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/star-rennes-integration-gtfs-rt-trip-update",
             "license": {
@@ -1168,7 +1400,16 @@
             }
         },
         {
-            "name": "horaires-du-reseau-transvilles-au-format-gtfs",
+            "name": "horaires-du-reseau-transvilles-au-format-gtfs--81001",
+            "type": "http",
+            "url": "https://static.data.gouv.fr/resources/horaires-du-reseau-transvilles-au-format-gtfs/20240924-134833/google-transit-23-09-24.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/horaires-du-reseau-transvilles-au-format-gtfs"
+            }
+        },
+        {
+            "name": "horaires-du-reseau-transvilles-au-format-gtfs--82442",
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/horaires-du-reseau-transvilles-au-format-gtfs/20241205-131815/google-transit-27-11-24-au-31-08-25.zip",
             "fix": true,
@@ -1342,7 +1583,7 @@
         {
             "name": "syndicat-mixte-des-transports-en-commun-de-lagglomeration-clermontoise-smtc-ac-reseau-t2c-gtfs-gtfs-rt",
             "type": "http",
-            "url": "https://opendata.clermontmetropole.eu/api/v2/catalog/datasets/gtfs-smtc/attachments/gtfs_t2c_plus_scolaire_zip",
+            "url": "https://opendata.clermontmetropole.eu/api/v2/catalog/datasets/gtfs-smtc/alternative_exports/gtfs",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/syndicat-mixte-des-transports-en-commun-de-lagglomeration-clermontoise-smtc-ac-reseau-t2c-gtfs-gtfs-rt"
@@ -1376,9 +1617,19 @@
             "spec": "gtfs-rt"
         },
         {
-            "name": "description-de-loffre-tad-tao-gtfs-flex-orleans-metropole",
+            "name": "description-de-loffre-tad-tao-gtfs-flex-orleans-metropole--81409",
             "type": "http",
             "url": "https://data.orleans-metropole.fr/api/v2/catalog/datasets/om-mobilite-tao-tad-gtfsflex/attachments/gtfs_flex_tao_102023_zip",
+            "fix": true,
+            "skip": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/description-de-loffre-tad-tao-gtfs-flex-orleans-metropole"
+            }
+        },
+        {
+            "name": "description-de-loffre-tad-tao-gtfs-flex-orleans-metropole--81413",
+            "type": "http",
+            "url": "https://data.orleans-metropole.fr/api/v2/catalog/datasets/om-mobilite-tao-tad-gtfsflex/attachments/gtfs_flex_stopsupdated_zip",
             "fix": true,
             "skip": true,
             "license": {
@@ -1426,6 +1677,7 @@
             "type": "http",
             "url": "https://twisto.opendatasoft.com/api/v2/catalog/datasets/fichier-gtfs-du-reseau-twisto/alternative_exports/gtfs_twisto_zip",
             "fix": true,
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/caen-la-mer-reseau-twisto-gtfs-siri"
             }
@@ -1433,7 +1685,7 @@
         {
             "name": "gtfs-sankeo",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/gtfs-sankeo/20241209-122638/gtfs-sankeo-ls.zip",
+            "url": "https://static.data.gouv.fr/resources/gtfs-sankeo/20241209-093152/gtfs-sankeo.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-sankeo"
@@ -1674,7 +1926,16 @@
             }
         },
         {
-            "name": "horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin",
+            "name": "horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin--79831",
+            "type": "http",
+            "url": "https://static.data.gouv.fr/resources/horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin/20241216-083043/gtfs-capcotentin-16122024-au-29062025.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin"
+            }
+        },
+        {
+            "name": "horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin--81638",
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin/20240919-100419/lr-capcotentin-cherbourg-rennes-sept24.zip",
             "fix": true,
@@ -1683,7 +1944,7 @@
             }
         },
         {
-            "name": "horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin",
+            "name": "horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin--79831",
             "type": "url",
             "url": "https://pysae.com/api/v2/groups/transdev-cotentin/gtfs-rt",
             "license": {
@@ -1785,7 +2046,7 @@
         {
             "name": "donnees-tcat-troyes-champagne-metropole-1",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/donnees-tcat-troyes-champagne-metropole-1/20241216-090636/gtfs-navineo.zip",
+            "url": "https://static.data.gouv.fr/resources/donnees-tcat-troyes-champagne-metropole-1/20241216-150518/gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-tcat-troyes-champagne-metropole-1"
@@ -1846,9 +2107,18 @@
             "spec": "gtfs-rt"
         },
         {
-            "name": "reseau-taneo-1",
+            "name": "reseau-taneo-1--81586",
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/reseau-taneo-1/20240201-060816/gtfs-lot1-20240205-20241215.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/reseau-taneo-1"
+            }
+        },
+        {
+            "name": "reseau-taneo-1--81587",
+            "type": "http",
+            "url": "https://static.data.gouv.fr/resources/reseau-taneo-1/20240201-060853/gtfs-lot2-20240205-20241231.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-taneo-1"
@@ -1873,7 +2143,16 @@
             }
         },
         {
-            "name": "reseau-urbain-cacl-agglobus",
+            "name": "reseau-urbain-cacl-agglobus--81498",
+            "type": "http",
+            "url": "https://static.data.gouv.fr/resources/reseau-urbain-cacl-agglobus/20241008-124211/monbus-matoury-gf.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-cacl-agglobus"
+            }
+        },
+        {
+            "name": "reseau-urbain-cacl-agglobus--82387",
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-cacl-agglobus/20241008-124301/monbus-matoury-gf.zip",
             "fix": true,
@@ -2316,7 +2595,7 @@
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-corolis-interurbain-communaute-dagglomeration-du-beauvaisis",
             "type": "http",
-            "url": "https://api.oisemob.cityway.fr/dataflow/tad/download?provider=COROLIS_INT&dataFormat=gtfs",
+            "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=COROLIS_INT&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "skip": true,
             "license": {
@@ -2338,6 +2617,7 @@
             "type": "http",
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=COROLIS_URB&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-corolis-urbain-communaute-dagglomeration-du-beauvaisis"
             }
@@ -2346,6 +2626,7 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-corolis-urbain-communaute-dagglomeration-du-beauvaisis",
             "type": "url",
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=COROLIS_URB&dataFormat=gtfs-rt",
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-corolis-urbain-communaute-dagglomeration-du-beauvaisis"
             },
@@ -2424,7 +2705,16 @@
             "spec": "gtfs-rt"
         },
         {
-            "name": "lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire",
+            "name": "lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire--79821",
+            "type": "http",
+            "url": "https://static.data.gouv.fr/resources/lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire/20240823-101105/grasse-scolaire.gtfs-5-.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire"
+            }
+        },
+        {
+            "name": "lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire--79822",
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire/20240823-101208/grasse-urbain.gtfs-2-.zip",
             "fix": true,
@@ -2763,6 +3053,7 @@
             "type": "http",
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=TIC_INT&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tic-interurbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne"
             }
@@ -2771,6 +3062,7 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-tic-interurbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
             "type": "url",
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=TIC_INT&dataFormat=gtfs-rt",
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tic-interurbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne"
             },
@@ -2781,6 +3073,7 @@
             "type": "http",
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=TIC_URB&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tic-urbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne"
             }
@@ -2789,6 +3082,7 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-tic-urbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
             "type": "url",
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=TIC_URB&dataFormat=gtfs-rt",
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tic-urbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne"
             },
@@ -2840,7 +3134,16 @@
             }
         },
         {
-            "name": "gtfs-de-la-societe-de-transport-urbain-du-grand-montauban-semtm",
+            "name": "gtfs-de-la-societe-de-transport-urbain-du-grand-montauban-semtm--81195",
+            "type": "http",
+            "url": "https://static.data.gouv.fr/resources/gtfs-de-la-societe-de-transport-urbain-du-grand-montauban-semtm/20241025-105206/gtfs-241024.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-de-la-societe-de-transport-urbain-du-grand-montauban-semtm"
+            }
+        },
+        {
+            "name": "gtfs-de-la-societe-de-transport-urbain-du-grand-montauban-semtm--82434",
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/gtfs-de-la-societe-de-transport-urbain-du-grand-montauban-semtm/20241025-105649/gtfs-241024.zip",
             "fix": true,
@@ -2948,7 +3251,7 @@
             }
         },
         {
-            "name": "offre-de-transports-du-grand-albigeois-gtfs",
+            "name": "offre-de-transports-du-grand-albigeois-gtfs--79687",
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/offre-de-transports-du-grand-albigeois-gtfs/20240912-070432/reseau-libea-urbain-2024.zip",
             "fix": true,
@@ -2957,7 +3260,34 @@
             }
         },
         {
-            "name": "reseau-urbain-la-navette-commune-de-gaillac",
+            "name": "offre-de-transports-du-grand-albigeois-gtfs--79728",
+            "type": "http",
+            "url": "https://static.data.gouv.fr/resources/offre-de-transports-du-grand-albigeois-gtfs/20240808-092020/reseau-libea-navettes.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-du-grand-albigeois-gtfs"
+            }
+        },
+        {
+            "name": "offre-de-transports-du-grand-albigeois-gtfs--81522",
+            "type": "http",
+            "url": "https://static.data.gouv.fr/resources/offre-de-transports-du-grand-albigeois-gtfs/20240916-075654/reseau-libea-periurbain.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-du-grand-albigeois-gtfs"
+            }
+        },
+        {
+            "name": "reseau-urbain-la-navette-commune-de-gaillac--82293",
+            "type": "http",
+            "url": "https://static.data.gouv.fr/resources/reseau-urbain-la-navette-commune-de-gaillac/20240924-121002/gtfs-gaillac.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-la-navette-commune-de-gaillac"
+            }
+        },
+        {
+            "name": "reseau-urbain-la-navette-commune-de-gaillac--82583",
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-la-navette-commune-de-gaillac/20241205-080814/gtfs-gaillac.zip",
             "fix": true,
@@ -3157,7 +3487,7 @@
         {
             "name": "reseau-de-bus-urbain-horizon",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/reseau-de-bus-urbain-horizon/20231109-153356/gtfs-20231109-115706.zip",
+            "url": "https://data.chateauroux-metropole.fr/api/v2/catalog/datasets/reseau-de-bus-urbain_horizon/alternative_exports/gtfs_20240827_105040_zip",
             "fix": true,
             "skip": true,
             "license": {
@@ -3277,6 +3607,7 @@
             "type": "http",
             "url": "https://donnees.paysdelaloire.fr/data/pdlYeuContinent.gtfs.zip",
             "fix": true,
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-circuit-de-la-lignes-yeu-continent-gtfs"
             }
@@ -3358,6 +3689,7 @@
             "type": "http",
             "url": "https://trouver.datasud.fr/dataset/0c5ad935-272e-4d9e-b0db-cdcb1a5309b8/resource/0ca29750-b689-4580-afc0-4b127ee4b914/download/dlva.gtfs.zip",
             "fix": true,
+            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-en-commun-transagglo-de-dlva"
             }
@@ -3741,11 +4073,19 @@
             "spec": "gtfs-rt"
         },
         {
-            "name": "donnees-theoriques-et-temps-reel-du-reseau-pass-thelle-bus-communaute-de-communes-thelloise",
+            "name": "donnees-theoriques-et-temps-reel-du-reseau-pass-thelle-bus-communaute-de-communes-thelloise--81068",
             "type": "http",
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=PASSTHELLE&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
-            "skip": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-pass-thelle-bus-communaute-de-communes-thelloise"
+            }
+        },
+        {
+            "name": "donnees-theoriques-et-temps-reel-du-reseau-pass-thelle-bus-communaute-de-communes-thelloise--81648",
+            "type": "http",
+            "url": "https://api.oisemob.cityway.fr/dataflow/tad/download?provider=PASSTHELLE&dataFormat=gtfs",
+            "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-pass-thelle-bus-communaute-de-communes-thelloise"
             }
@@ -4049,9 +4389,18 @@
             "spec": "gtfs-rt"
         },
         {
-            "name": "offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs",
+            "name": "offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs--80584",
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs/20240807-113136/gtfs-urbain-20240807-100915.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs"
+            }
+        },
+        {
+            "name": "offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs--81430",
+            "type": "http",
+            "url": "https://static.data.gouv.fr/resources/offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs/20240812-075618/gtfs-coteetbus-iu.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs"
@@ -4062,7 +4411,6 @@
             "type": "http",
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=SABLONS&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
-            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-sablons-bus-communaute-de-communes-des-sablons"
             }
@@ -4071,7 +4419,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-sablons-bus-communaute-de-communes-des-sablons",
             "type": "url",
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=SABLONS&dataFormat=gtfs-rt",
-            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-sablons-bus-communaute-de-communes-des-sablons"
             },
@@ -4188,7 +4535,7 @@
         {
             "name": "offre-transport-en-commun-du-reseau-transpor-gtfs",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/offre-transport-en-commun-du-reseau-transpor-gtfs/20220701-115247/transp-or-ete-v1-gtfs-2022-06-30-17-38-32.zip",
+            "url": "https://static.data.gouv.fr/resources/offre-transport-en-commun-du-reseau-transpor-gtfs/20241106-090904/transp-or-hiver-2024-2025-gtfs-2024-11-06-10-08-25.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-transport-en-commun-du-reseau-transpor-gtfs"
@@ -4267,7 +4614,16 @@
             "spec": "gtfs-rt"
         },
         {
-            "name": "reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche",
+            "name": "reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche--79272",
+            "type": "http",
+            "url": "https://static.data.gouv.fr/resources/reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche/20240923-134747/dsp24data-gtfs-2024-09-23-15-45-06.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche"
+            }
+        },
+        {
+            "name": "reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche--81342",
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche/20241016-085959/sco24data-gtfs-2024-10-16-10-39-46.zip",
             "fix": true,
@@ -4629,7 +4985,7 @@
         {
             "name": "reseau-urbain-reso",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/reseau-urbain-reso/20241030-131559/gtfs-20241030-horsbord-reso-1-.zip",
+            "url": "https://static.data.gouv.fr/resources/reseau-urbain-reso/20241216-155605/gtfs-20241216-horsbord-reso.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-reso"
@@ -4737,9 +5093,8 @@
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-le-bus-communaute-de-communes-du-clermontois",
             "type": "http",
-            "url": "https://api.oisemob.cityway.fr/dataflow/tad/download?provider=LEBUS&dataFormat=gtfs",
+            "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=LEBUS&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
-            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-le-bus-communaute-de-communes-du-clermontois"
             }
@@ -4748,7 +5103,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-le-bus-communaute-de-communes-du-clermontois",
             "type": "url",
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=LEBUS&dataFormat=gtfs-rt",
-            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-le-bus-communaute-de-communes-du-clermontois"
             },
@@ -4791,9 +5145,18 @@
             }
         },
         {
-            "name": "tico-bus-horaires-theoriques-du-reseau-de-transport-urbain-tico",
+            "name": "tico-bus-horaires-theoriques-du-reseau-de-transport-urbain-tico--79864",
             "type": "http",
             "url": "https://exs.mlt4.cityway.fr/gtfs.aspx?operatorCode=3CM&key=OPENDATA",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/tico-bus-horaires-theoriques-du-reseau-de-transport-urbain-tico"
+            }
+        },
+        {
+            "name": "tico-bus-horaires-theoriques-du-reseau-de-transport-urbain-tico--80383",
+            "type": "http",
+            "url": "https://api.mlt4.cityway.fr/dataflow/tad/download?provider=3CM",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tico-bus-horaires-theoriques-du-reseau-de-transport-urbain-tico"
@@ -4807,6 +5170,15 @@
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/moca-communaute-de-communes-caux-austreberthe"
             }
+        },
+        {
+            "name": "moca-communaute-de-communes-caux-austreberthe",
+            "type": "url",
+            "url": "https://proxy.transport.data.gouv.fr/resource/moca-caux-austreberthe-gtfs-rt",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/moca-communaute-de-communes-caux-austreberthe"
+            },
+            "spec": "gtfs-rt"
         },
         {
             "name": "colibri-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-la-ccmp",
@@ -4928,7 +5300,7 @@
         {
             "name": "transport-urbain-du-bassin",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/transport-urbain-du-bassin/20230102-111115/transports-urbains-du-bassin-version-2-4-gtfs-2023-01-02-10-36-49.zip",
+            "url": "https://static.data.gouv.fr/resources/transport-urbain-du-bassin/20240122-151122/transports-urbains-du-bassin-2-5-1-gtfs-2023-06-06-15-33-38.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transport-urbain-du-bassin"
@@ -4998,11 +5370,19 @@
             }
         },
         {
-            "name": "donnees-theoriques-du-reseau-hopla-communaute-de-communes-de-la-plaine-destrees",
+            "name": "donnees-theoriques-du-reseau-hopla-communaute-de-communes-de-la-plaine-destrees--81519",
             "type": "http",
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=HOPLA&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
-            "skip": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-hopla-communaute-de-communes-de-la-plaine-destrees"
+            }
+        },
+        {
+            "name": "donnees-theoriques-du-reseau-hopla-communaute-de-communes-de-la-plaine-destrees--81649",
+            "type": "http",
+            "url": "https://api.oisemob.cityway.fr/dataflow/tad/download?Provider=HOPLA&dataFormat=gtfs&dataProfil=OPENDATA",
+            "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-hopla-communaute-de-communes-de-la-plaine-destrees"
             }

--- a/src/generate-france.py
+++ b/src/generate-france.py
@@ -45,6 +45,9 @@ if __name__ == "__main__":
         "donnees-theoriques-et-temps-reel-du-reseau-tic-urbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",  # agency.txt
         "arrets-horaires-et-circuit-de-la-lignes-yeu-continent-gtfs",  # agency.txt
         "caen-la-mer-reseau-twisto-gtfs-siri",  # Temporary removal, 401 error
+        "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte",  # Temporary removal, resource not available
+        "gtfs-transport-horaires-des-lignes-de-la-communaute-de-communes-corse-du-sud-a-berlina",  # Temporary removal, 404 error
+        "gtfs-transport-horaires-des-lignes-de-la-communaute-dile-rousse-balagne-a-balanina",  # Temporary removal, 404 error
     ]
 
     # List of individual resource ids (located in datasets) we want to remove

--- a/src/generate-france.py
+++ b/src/generate-france.py
@@ -17,7 +17,6 @@ if __name__ == "__main__":
         "gtfs-static-et-real-time-transporteur-thalys",  # Already in eu.json
         "eurostar-gtfs",  # Already in eu.json
         "arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise",  # broken
-        "horaires-prevus-sur-les-lignes-de-transport-en-commun-dile-de-france-gtfs-jeux-olympiques-et-paralympiques-de-paris-2024-datahub",  # try removing
         "horaires-theoriques-des-cars-du-rhone",  # requires authentication
         "horaires-theoriques-des-lignes-scolaires-du-reseau-transports-en-commun-lyonnais",  # requires authentication
         "horaires-theoriques-du-reseau-libellule-sytral-de-la-communaute-dagglomeration-de-villefranche-beaujolais-saone",  # requires authentication
@@ -32,72 +31,223 @@ if __name__ == "__main__":
         "horaires-theoriques-et-temps-reel-des-navettes-hivernales-de-lalpe-dhuez-gtfs-gtfs-rt",  # 404 not found
         "arrets-horaires-et-parcours-theoriques-des-bus-du-reseau-des-transports-publics-envibus",  # timeout
         "horaires-theoriques-du-service-rhonexpress-de-la-metropole-de-lyon-et-du-departement-du-rhone",  # 401 not authorized
-        "breizhgo-bateaux",  # Confuses MOTIS and doesn't contain any trips
-        "donnees-theoriques-et-temps-reel-du-reseau-pass-thelle-bus-communaute-de-communes-thelloise",  # Confuses MOTIS and doesn't contain any trips
         "3cm-horaires-theoriques-du-reseau-de-transport-urbain-solutions-transport-3cm",  # Confuses MOTIS and doesn't contain any trips
         "donnees-theoriques-et-temps-reel-du-reseau-corolis-interurbain-communaute-dagglomeration-du-beauvaisis",  # Confuses MOTIS
         "donnees-theoriques-et-temps-reel-du-reseau-axo-communaute-dagglomeration-creil-sud-oise",  # Confuses MOTIS
-        "donnees-theoriques-et-temps-reel-du-reseau-sablons-bus-communaute-de-communes-des-sablons",  # Confuses MOTIS
-        "donnees-theoriques-du-reseau-hopla-communaute-de-communes-de-la-plaine-destrees",  # Confuses MOTIS
-        "tedbus-horaires",  # GTFS-RT tagges as GTFS
-        "donnees-theoriques-et-temps-reel-du-reseau-le-bus-communaute-de-communes-du-clermontois",  # Confuses MOTIS
         "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-62-pas-de-calais",  # agency.txt
         "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-interurbain-62-pas-de-calais",  # agency.txt
         "naolib-arrets-horaires-et-circuits",  # Incomplete read
         "offre-transport-du-reseau-txik-txak-nord-ex-chronoplus-gtfs",  # 404
         "horaires-theoriques-et-temps-reel-lignes-scolaires-sankeo-perpignan-gtfs-gtfs-rt",  # 404
-        "reseau-cars-region-isere-38",  # empty, confuses MOTIS
+        "reseau-de-transport-en-commun-transagglo-de-dlva",  # Resource not available
+        "donnees-theoriques-et-temps-reel-du-reseau-corolis-urbain-communaute-dagglomeration-du-beauvaisis",  # agency.txt
+        "donnees-theoriques-et-temps-reel-du-reseau-tic-interurbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",  # agency.txt
+        "donnees-theoriques-et-temps-reel-du-reseau-tic-urbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",  # agency.txt
+        "arrets-horaires-et-circuit-de-la-lignes-yeu-continent-gtfs",  # agency.txt
+        "caen-la-mer-reseau-twisto-gtfs-siri",  # Temporary removal, 401 error
     ]
+
+    # List of individual resource ids (located in datasets) we want to remove
+    remove_resources = [
+        # "Lien vers le GTFS du r\u00e9seau urbain de Parthenay (PYBUS)",  # Duplicate data
+        "82619",
+        # "GTFS SANPROVENCE Ulysse (Navette Mille Sabords inclus) ",  # Duplicate data
+        "39591",
+        # "GTFS CG13 Cartreize",  # Duplicate data
+        "39602",
+        "GTFS Libébus",  # Duplicate data
+        "39592",
+        # "GTFS Les bus de la Côte Bleue",  # Duplicate data
+        "39596",
+        # "GTFS CIOTABUS",  # Duplicate data
+        "80736",
+        # "GTFS  Les bus de la Marcouline",  # Duplicate data
+        "39595",
+        # "GTFS CPA",  # Duplicate data
+        "39601",
+        # "GTFS AIXENBUS ",  # Duplicate data
+        "39603",
+        # "GTFS RTM",  # Duplicate data
+        "39589",
+        # "GTFS Agglobus - Les lignes de l'agglo",  # Duplicate data
+        "39598",
+        # "GTFS Frioul if express",  # Duplicate data
+        "39599",
+        # "GTFS Bus des collines",  # Duplicate data
+        "39593",
+        # "GTFS Les bus des Cigales",  # Duplicate data
+        "39594",
+        # "GTFS Les bus de l'étang",  # Duplicate data
+        "39597",
+        # "Transaltitude (38) - Offre théorique au format GTFS",  # Remove almost useless additional feed, + easier GTFS-RT matching
+        "82299",
+        # "gtfs-t2c_plus_scolaire.zip",  # Remove additional school feed, + easier GTFS-RT matching
+        "82302",
+        # "Réseau Sankéo - Lignes Scolaires",  # Remove additional school feed, + easier GTFS-RT matching
+        "82271",
+        # "GTFS - Horaires théoriques + TAD + Scolaire + Shapes",  # (ametis), Remove additional DRT + school feed, + easier GTFS-RT matching
+        "80223",
+        # "gtfs-navineo.zip"  # (tcat-troyes), Remove old data, + easier GTFS-RT matching
+        "79847",
+        # "Description du TAD zonal (GTFS-Flex) - réseau Corolis",  # Remove additional DRT feed, + easier GTFS-RT matching
+        "81650",
+        # "Description du TAD zonal (GTFS-Flex) - réseau AXO",  # Remove additional DRT feed, + easier GTFS-RT matching
+        "81645",
+        # "Description du TAD zonal (GTFS-Flex) - réseau Sablons Bus",  # Remove additional DRT feed, + easier GTFS-RT matching
+        "81651",
+        # "Description du TAD zonal (GTFS-Flex) - réseau Le Bus",  # Remove additional DRT feed, + easier GTFS-RT matching
+        "81652",
+    ]
+
+    # Map for each dataset slug, if needed, the selected GTFS-RT id to the corresponding GTFS id
+    gtfs_rt_select = {
+        "moca-communaute-de-communes-caux-austreberthe": {
+            "82630": "82309",
+        },
+        "breizhgo-car": {
+            "81804": "81463",
+            "81805": "81466",
+            "81806": "81461",
+        },
+        "versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs": {
+            "82161": "82587",
+        },
+        "horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin": {
+            "79830": "79831"
+        },
+    }
 
     out: list[dict] = []
     for dataset in datasets:
-        gtfs = list(filter(lambda r: "format" in r and (r["format"] == "GTFS" or r["format"] == "gtfs-rt"), dataset["resources"]))
+        gtfs = list(
+            filter(
+                lambda r: "format" in r
+                and (r["format"] == "GTFS" or r["format"] == "gtfs-rt"),
+                dataset["resources"],
+            )
+        )
         if gtfs:
-            resources = list(filter(lambda r: "format" in r and r["format"] == "GTFS", gtfs))
+            resources = list(
+                filter(lambda r: "format" in r and r["format"] == "GTFS", gtfs)
+            )
+            # Exclude resources with "community_resource_publishers" field
+            resources = [
+                r for r in resources if not r.get("community_resource_publisher")
+            ]
+
+            # Remove resources with title in remove_title
+            resources = [
+                r for r in resources if str(r.get("id")) not in remove_resources
+            ]
+
+            # Sort resources by the id field
+            resources.sort(key=lambda r: str(r.get("id", "")))
+
             if not resources:
                 print(f"{dataset['slug']} only has GTFS-RT data?", file=sys.stderr)
                 continue
 
-            source = {
-                "name": dataset["slug"],
-                "type": "http",
-                "url": resources[0]["original_url"],
-                "fix": True,
-            }
+            # Check if multiple GTFS feeds are present
+            unique_GTFS = True
+            if len(resources) > 1:
+                unique_GTFS = False
 
-            if dataset["slug"] in skip:
-                source["skip"] = True
-
-            if "page_url" in dataset:
-                source["license"] = {}
-                source["license"]["url"] = dataset["page_url"]
-
-            out.append(source)
+            # Add all GTFS resources
+            for resource in resources:
+                source_name = (
+                    dataset["slug"]
+                    if unique_GTFS
+                    else dataset["slug"]
+                    + "--"
+                    + str(resource["id"])
+                    .replace(" ", "-")
+                    .replace("_", "-")
+                    .replace("/", "-")
+                )
+                source = {
+                    "name": source_name,
+                    "type": "http",
+                    "url": resource["original_url"],
+                    "fix": True,
+                }
+                if dataset["slug"] in skip:
+                    source["skip"] = True
+                if "page_url" in dataset:
+                    source["license"] = {}
+                    source["license"]["url"] = dataset["page_url"]
+                out.append(source)
 
             def cond(r) -> bool:
-                return "format" in r \
-                    and r["format"] == "gtfs-rt" \
-                    and "features" in r \
+                return (
+                    "format" in r
+                    and r["format"] == "gtfs-rt"
+                    and "features" in r
                     and "trip_updates" in r["features"]
+                )
+
+            def contains_name(out, name_to_check):
+                return any(entry.get("name") == name_to_check for entry in out)
 
             resources = list(filter(cond, gtfs))
+            resources.sort(key=lambda r: str(r.get("id", "")))
             if not resources:
                 continue
-            if len(resources) > 1:
-                print(f"{dataset['slug']} has multiple GTFS-RT feeds?",
-                      file=sys.stderr)
-                continue
+            matches = gtfs_rt_select.get(dataset["slug"])
+            # We can only continue if their is a unique GTFS file, or a if there is a `gtfs_rt_select` entry for this dataset
+            if matches or unique_GTFS:
+                for resource in resources:
+                    if matches:
+                        if str(resource["id"]) in matches:
+                            if unique_GTFS:
+                                feed_name = dataset["slug"]
+                            else:
+                                feed_name = (
+                                    dataset["slug"]
+                                    + "--"
+                                    + matches.get(str(resource["id"]))
+                                )
+                        else:
+                            print(
+                                f"{dataset['slug']} has skipped {resource["title"]} GTFS-RT feed because not selected!",
+                                file=sys.stderr,
+                            )
+                            continue
+                    # If not matches, then it must be the unique_GTFS case
+                    else:
+                        feed_name = dataset["slug"]
 
-            source = source.copy()
-            source["spec"] = "gtfs-rt"
-            source["type"] = "url"
-            source["url"] = resources[0]["original_url"]
-            del source["fix"]
-            out.append(source)
+                    # Check if there is a corresponding GTFS feed with the same name!
+                    if contains_name(out, feed_name):
+                        source = {}
+                        source["name"] = feed_name
+                        source["type"] = "url"
+                        source["url"] = resource["original_url"]
+                        if dataset["slug"] in skip:
+                            source["skip"] = True
+                        if "page_url" in dataset:
+                            source["license"] = {"url": dataset["page_url"]}
+                        source["spec"] = "gtfs-rt"
+                        out.append(source)
+                    else:
+                        print(
+                            f"Warning: {feed_name} GTFS-RT needs to match the name of its static GTFS feed!",
+                            file=sys.stderr,
+                        )
+            else:
+                print(
+                    f"{dataset['slug']} has unmatched GTFS-RT feed(s)?",
+                    file=sys.stderr,
+                )
+                continue
 
     # This is an aggregated and improved feed that we want to keep
     out.append(
-        {"name": "Brittany", "type": "transitland-atlas", "transitland-atlas-id": "f-gbwc-mobibreizh", "fix": True}
+        {
+            "name": "Brittany",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-gbwc-mobibreizh",
+            "fix": True,
+        }
     )
 
     with open("feeds/fr.json", "r") as f:

--- a/src/generate-france.py
+++ b/src/generate-france.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
         "39591",
         # "GTFS CG13 Cartreize",  # Duplicate data
         "39602",
-        "GTFS Libébus",  # Duplicate data
+        # "GTFS Libébus",  # Duplicate data
         "39592",
         # "GTFS Les bus de la Côte Bleue",  # Duplicate data
         "39596",


### PR DESCRIPTION
Second attempt at improving handling of multiple feeds (GTFS, GTFS-RT) in one dataset.

This should be better:
- use id of resource as identifier (instead of title) : no duplicate GTFS names should happen anymore (and should be more stable too)
- added verification before adding a GTFS-RT feed : check if a corresponding GTFS feed having the same name exists, otherwise raise a warning :)