### PR TITLE
Use proxy for GB

### DIFF
--- a/feeds/gb.json
+++ b/feeds/gb.json
@@ -10,12 +10,14 @@
             "name": "great-britain",
             "type": "http",
             "url": "https://s3.busmaps.com/files/uran/improved-gtfs-great-britain.zip",
-            "fix": true
+            "fix": true,
+            "proxy": true
         },
         {
             "name": "northern-ireland",
             "type": "http",
-            "url": "https://s3.gtfs.pro/files/uran/improved-gtfs-northern-ireland.zip"
+            "url": "https://s3.gtfs.pro/files/uran/improved-gtfs-northern-ireland.zip",
+            "proxy": true
         }
     ]
 }


### PR DESCRIPTION
Try to fix #672 by using the proxy.
Following #679, the issue with this feeds might be the DDOS protection. Using the proxy might temporarily solve the issue until we switch feeds.