### PR TITLE
feat(feeds): NZ.json - added Horizons Regional Council via URL

### DIFF
--- a/feeds/nz.json
+++ b/feeds/nz.json
@@ -65,6 +65,11 @@
             "name": "Baybus",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-boprc~nz"
+        },
+        {
+            "name": "Horizons-Regional-Council",
+            "type": "http",
+            "url": "https://www.horizons.govt.nz/HRC/media/Data/files/tranzit/HRC_GTFS_Production.zip"
         }
     ]
 }


### PR DESCRIPTION
There isn't a transitland entry for this yet, so adding it by URL for the moment.