### PR TITLE
pl: Add Szczecin feed

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -124,6 +124,16 @@
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u3k4-miejskieprzedsiębiorstwokomunikacyjnespzoowpoznaniu~kórni",
             "fix": true
+        },
+        {
+            "name": "Szczecin",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-u36r-zditmszczecin"
+        },
+        {
+            "name": "Szczecin",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-u36r-zditmszczecin~rt"
         }
     ]
 }


### PR DESCRIPTION
Tested with GNOME Maps 47.3 by running with the `MOTIS_BASE_URL=http://localhost:8080` environment variable.

-- 
Just as an aside, the steps at https://transitous.org/doc/#running-a-transitous-instance-locally seems somewhat outdated (mainly there's config.yml instead of config.ini, and `motis -c config.ini --server.host 0.0.0.0 --server.static_path /opt/motis/web` did not seem to work but running `motis server` did). I used .woodpecker/data-import.yml as a guide and somehow managed to get through