### PR TITLE
feat(feeds): NZ.json - added license info to Horizons Regional Council

### DIFF
--- a/feeds/nz.json
+++ b/feeds/nz.json
@@ -69,7 +69,11 @@
         {
             "name": "Horizons-Regional-Council",
             "type": "http",
-            "url": "https://www.horizons.govt.nz/HRC/media/Data/files/tranzit/HRC_GTFS_Production.zip"
+            "url": "https://www.horizons.govt.nz/HRC/media/Data/files/tranzit/HRC_GTFS_Production.zip",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0",
+                "url": "https://creativecommons.org/licenses/by/4.0/"
+            }
         }
     ]
 }


### PR DESCRIPTION
No realtime info is available, but the standard GTFS is under CC-BY 4.0.