### PR TITLE
Add PL Silesian buses (Transport GZM)

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -7,6 +7,10 @@
         {
             "name": "Wojciech Kulesza",
             "github": "wkulesza"
+        },
+        {
+            "name": "Grzegorz M",
+            "github": "grzesjam"
         }
     ],
     "sources": [
@@ -134,6 +138,26 @@
             "name": "Szczecin",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u36r-zditmszczecin~rt"
+        },
+        {
+            "name": "TransportGZM",
+            "type": "http",
+            "spec": "gtfs",
+            "url": "https://github.com/TransportGZM-GTFS-mirror/TransportGZM-GTFS-normal/releases/latest/download/TransportGZM-GTFS.zip",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0",
+                "url": "https://spdx.org/licenses/CC-BY-4.0.html"
+            }
+        },
+        {
+            "name": "TransportGZM",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://gtfsrt.transportgzm.pl:5443/gtfsrt/gzm/tripUpdates",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0",
+                "url": "https://spdx.org/licenses/CC-BY-4.0.html"
+            }
         }
     ]
 }


### PR DESCRIPTION
Hello! 👋

`ZTM TransportGZM` is a public transport organization based in the Silesian Voivodeship, Poland. They manage buses, trams, trolleybuses and bikes. 
ZTM is the organization that governs it, "[TransportGZM](https://transportgzm.pl)" is a brand under which they run busses/trams/trolleybuses, and brand "[TransportGZM MetroRower](https://metrorower.transportgzm.pl/)" is for bikes (actually NextBike runs it :wink:).



This PR adds ZTM TransportGZM GTFS and GTFS-RT.
- The GTFS-RT has a static URL. Licensed under CC-BY-4.0
- Transport GZM has two versions of GTFS ["normal"](https://otwartedane.metropoliagzm.pl/en/dataset/rozklady-jazdy-gtfs-wersja-tymczasowa) and ["extended"](https://otwartedane.metropoliagzm.pl/en/dataset/rozklady-jazdy-i-lokalizacja-przystankow-gtfs-wersja-rozszerzona). For some reason, with "extended" version app wasn't showing any buses. So i picked "normal" even tho TransportGZM says its "temporary while they develop extended", but it works.
- GTFS data doesn't have a static URL, they upload it to their CKAN instance (dataset management software) with different names, and recently broke SSL, so i created GH organization that mirrors it and republishes under static URL. Data licensed under CC-BY-4.0


If something is missing or please let me know :) 


ps. i tried to push it to [transitland-atlas](https://github.com/transitland/transitland-atlas/pull/1403), but my PR got ignored :pensive: 

