### PR TITLE
Update CH

### DIFF
--- a/feeds/ch.json
+++ b/feeds/ch.json
@@ -9,7 +9,7 @@
         {
             "name": "opentransportdataswiss25",
             "type": "http",
-            "url": "https://opentransportdata.swiss/de/dataset/timetable-2025-gtfs2020/permalink",
+            "url": "https://data.opentransportdata.swiss/de/dataset/timetable-2025-gtfs2020/permalink",
             "license": {
                 "url": "https://opentransportdata.swiss/de/terms-of-use/"
             }
@@ -18,7 +18,7 @@
             "name": "opentransportdataswiss25",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://api.opentransportdata.swiss/gtfsrt2020",
+            "url": "https://api.opentransportdata.swiss/la/gtfs-rt",
             "headers": {
                 "authorization": "Bearer 57c5dbbbf1fe4d000100001833a821a9de3748e5876bfb6c1efe6973"
             }


### PR DESCRIPTION
According to https://opentransportdata.swiss/en/ckan-new-plattform-2025-01-08-en/, the GTFS static link must be updated until 5th February.
According to the opentransportdata.swiss newsletter (weirdly I haven't found any information about this on the websites), the GTFS RT link must be updated until 17th February.

<details>
  <summary>Excerpt from opentransportdata.swiss newsletter</summary>

> Due to the high data volumes on certain interfaces, we have decided to make these available via an optimised endpoint.
> From 17th February 2025, the following «LargeAPI» (LA)-data will only be accessible via the new URLs.
> Please switch to the new APIs immediately.
> 
> -GTFS Realtime (GTFS RT):
> Old: api.opentransportdata.swiss/gtfsrt2020
> New: api.opentransportdata.swiss/la/gtfs-rt
> 
> -GTFS Realtime Service Alerts (GTFS RT SA / GTFS SA):
> Old: api.opentransportdata.swiss/gtfs-sa
> New: api.opentransportdata.swiss/la/gtfs-sa
> 
> - SIRI Situation Exchange (SX) (SIRI SX):
> Old: api.opentransportdata.swiss/siri-sx
> New: api.opentransportdata.swiss/la/siri-sx
> 
> -SIRI Planned Timetable (SIRI PT):
> Alt: api.opentransportdata.swiss/siri-pt
> New: api.opentransportdata.swiss/la/siri-pt
> 
> - SIRI Estimated Timetable (ET):
> Old: api.opentransportdata.swiss/siri-et
> New: api.opentransportdata.swiss/la/siri-et
> 
> Important additional information:
> - HTTP redirects (301/302):
> Your requests will be forwarded to a new, certified endpoint. Please make sure that the option «allow redirects» or similar is enabled in your applications.
> - User-Agent in the HTTP header:
> To process your requests successfully, you must specify the user agent in the HTTP header (for more information, see Wikipedia: [«user agent»](https://in.mailing.cff.ch/d?p000oyvq0ok2wc00d0000lz0000000000mkkmqslyilynbhyojn2wbkq000d5y000000ioewmg0)). The new endpoint will not accept any other requests without this information.

</details>

(For my mirror/with wget, I struggled quite a bit, because wget continues to send Authorization headers after redirects, which the new server didn't like (switched to curl) and for some reason I needed to obtain a new API token for the GTFS-RT – but both seems not to be an issue for transitous/motis, at least everything worked locally with the existing API key.)