### PR TITLE
Increase rt feed download timeout

### DIFF
--- a/motis/config.yml
+++ b/motis/config.yml
@@ -30,6 +30,7 @@ timetable:
   merge_dupes_inter_src: true
   link_stop_distance: 100
   update_interval: 60
+  http_timeout: 30
   incremental_rt_update: false
   max_footpath_length: 20
 # The datasets are filled in by ./src/generate-motis-config.py


### PR DESCRIPTION
As discussed in #857, increasing the timeout for RT downloads, since this timeout does seem to encompass the entire transfer and not only until the first packet.

(Haven't actually tested it by emulating a slow connection, but quite confident that this should improve things and not make anything else worse :)