### PR TITLE
Allow to specify a feed for generation

### DIFF
--- a/src/generate-motis-config.py
+++ b/src/generate-motis-config.py
@@ -20,6 +20,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     flavour = sys.argv[1]
+    feed = sys.argv[2] if len(sys.argv) > 2 else ""
 
     feed_dir = Path("feeds/")
 
@@ -45,7 +46,12 @@ if __name__ == "__main__":
         )
         config["timetable"]["datasets"] = {}
 
-        for feed in sorted(feed_dir.glob("*.json")):
+        if feed == "":
+            glob = "*.json"
+        else:
+            glob = f"{feed}.json"
+
+        for feed in sorted(feed_dir.glob(glob)):
             with open(feed, "r") as f:
                 parsed = json.load(f)
                 region = metadata.Region(parsed)


### PR DESCRIPTION
When testing locally e.g. a specific country, one first generates a config file full of feeds, just to remove them. This change allows to specify a certain feeds.json, to only fill the feeds of a specified country in the config.yml

So when I want to setup a local instance with only german feeds, I can generate the config as following
```shell
python ./src/generate-motis-config.py full de
```

Let me know what you think