### PR TITLE
Fix download command in documentation

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -232,7 +232,7 @@ Now inside the container, you can download and post-process the feeds you want.
 ./src/fetch.py feeds/<region>.json
 ```
 
-If you want to download all of them instead, you can use `mkdir -p out && cd out && wget --mirror -l 1 --no-parent --no-directories --accept zip https://api.transitous.org/gtfs/` to download the postprocessed files from the Transitous server, or `./ci/fetch-feeds.py timer` to process them yourself. However, importing all feeds will take about half an hour even on powerful hardware.
+If you want to download all of them instead, you can use `mkdir -p out && cd out && wget --mirror -l 1 --no-parent --no-directories --accept zip  -e robots=off https://api.transitous.org/gtfs/` to download the postprocessed files from the Transitous server, or `./ci/fetch-feeds.py timer` to process them yourself. However, importing all feeds will take about half an hour even on powerful hardware.
 
 The `out/` directory should now contain a number of zip files.
 


### PR DESCRIPTION
Make sure to ignore the robots.txt, otherwise the command does not work.

resolves #932 