### PR TITLE
Initial GBFS support

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -127,6 +127,38 @@ This example applies the updates to the `lviv` feed:
 ]
 ```
 
+### Shared Mobility feeds
+
+GBFS feeds contains relatime information like vehicle availability and characteristics for shared Mobility (e.g. Bikesharing).
+Each source can either be of `type` `gbfs-database` or `http`.
+
+Feeds from [GBFS database](https://github.com/MobilityData/gbfs) can be referenced by their System ID.
+
+GBFS Database:
+```json
+{
+    "name": "<name to be used for the output filename, should not contain spaces>",
+    "type": "gbfs-database",
+    "system-id": "<system id>"
+}
+```
+
+If the feed is not part of the existing database, a http source can be used instead.
+
+```json
+{
+    "name": "<name to be used for the output filename>",
+    "type": "http",
+    "url": "https://<url of GBFS feed>",
+    "license": {
+        "spdx-identifier": "<license identifier from https://spdx.org/licenses/ if known>",
+        "url": "< url as source for the license if available >"
+    }
+}
+```
+
+In both cases, the name needs to be unique in the file.
+
 ### Testing
 
 Once you create a pull request, fetching your feed will automatically be tested.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -130,35 +130,20 @@ This example applies the updates to the `lviv` feed:
 ### Shared Mobility feeds
 
 GBFS feeds contains relatime information like vehicle availability and characteristics for shared Mobility (e.g. Bikesharing).
-Each source can either be of `type` `gbfs-database` or `http`.
+Each source can only be of `type` `transitland-atlas`.
 
-Feeds from [GBFS database](https://github.com/MobilityData/gbfs) can be referenced by their System ID.
+Feeds from [Transitland](https://www.transit.land/feeds) can be referenced by their Onestop ID.
 
 GBFS Database:
 ```json
 {
     "name": "<name of the feed>",
-    "spec": "gbfs",
-    "type": "gbfs-database",
-    "system-id": "<system id>"
+    "type": "transitland-atlas",
+    "transitland-atlas-id": "<onestop id>"
 }
 ```
 
-If the feed is not part of the existing database, a http source can be used instead.
-
-```json
-{
-    "name": "<name to be used for the output filename>",
-    "type": "http",
-    "url": "https://<url of GBFS feed>",
-    "license": {
-        "spdx-identifier": "<license identifier from https://spdx.org/licenses/ if known>",
-        "url": "< url as source for the license if available >"
-    }
-}
-```
-
-In both cases, the name needs to be unique in the file.
+The name needs to be unique in the file.
 
 ### Testing
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -19,7 +19,7 @@ Free and open public transport routing.
 
 A community-run provider-neutral international public transport routing service.
 
-Using openly available GTFS/GTFS-RT/etc. feeds and FOSS routing engine we want to operate a
+Using openly available GTFS/GTFS-RT/GBFS/etc. feeds and FOSS routing engine we want to operate a
 routing service that:
 
 * focuses on the interest of the user rather than the public transport operators

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -137,7 +137,8 @@ Feeds from [GBFS database](https://github.com/MobilityData/gbfs) can be referenc
 GBFS Database:
 ```json
 {
-    "name": "<name to be used for the output filename, should not contain spaces>",
+    "name": "<name of the feed>",
+    "spec": "gbfs",
     "type": "gbfs-database",
     "system-id": "<system id>"
 }

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -129,7 +129,7 @@ This example applies the updates to the `lviv` feed:
 
 ### Shared Mobility feeds
 
-GBFS feeds contains relatime information like vehicle availability and characteristics for shared Mobility (e.g. Bikesharing).
+GBFS feeds contains realtime information like vehicle availability and characteristics for shared Mobility (e.g. Bikesharing).
 Each source can only be of `type` `transitland-atlas`.
 
 Feeds from [Transitland](https://www.transit.land/feeds) can be referenced by their Onestop ID.

--- a/feeds/de.json
+++ b/feeds/de.json
@@ -85,9 +85,8 @@
         },
         {
             "name": "RegioRadStuttgart",
-            "spec": "gbfs",
-            "type": "gbfs-database",
-            "system-id": "regiorad_stuttgart"
-}
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-regioradstuttgart~stuttgart~gbfs"
+        }
     ]
 }

--- a/feeds/de.json
+++ b/feeds/de.json
@@ -7,6 +7,10 @@
         {
             "name": "Robin Durner",
             "github": "traines-source"
+        },
+        {
+            "name": "Max Buchholz",
+            "github": "1Maxnet1"
         }
     ],
     "sources": [
@@ -78,6 +82,12 @@
                 "spdx-identifier": "ODbL-1.0",
                 "url": "https://opendata.avv.de/current_GTFS/lizenz_und_readme.txt"
             }
-        }
+        },
+        {
+            "name": "RegioRadStuttgart",
+            "spec": "gbfs",
+            "type": "gbfs-database",
+            "system-id": "regiorad_stuttgart"
+}
     ]
 }

--- a/motis/config.yml
+++ b/motis/config.yml
@@ -35,3 +35,6 @@ timetable:
   max_footpath_length: 20
 # The datasets are filled in by ./src/generate-motis-config.py
   datasets:
+
+gbfs:
+  feeds:

--- a/src/generate-motis-config.py
+++ b/src/generate-motis-config.py
@@ -114,5 +114,11 @@ if __name__ == "__main__":
                             config["timetable"]["datasets"][name]["rt"] \
                                 .append(rt_feed)
 
+                        case "gbfs":
+                            if "gbfs" not in config.keys():
+                                config["gbfs"] = {"feeds": {source.name: {"url": source.url}}}
+                            else:
+                                config["gbfs"]["feeds"][source.name] = {"url": source.url}
+
         with open("out/config.yml", "w") as fo:
             yaml.dump(config, fo)

--- a/src/generate-motis-config.py
+++ b/src/generate-motis-config.py
@@ -47,6 +47,7 @@ if __name__ == "__main__":
             "datasets", before="Modified by generate-motis-config.py"
         )
         config["timetable"]["datasets"] = {}
+        config["gbfs"]["feeds"] = {}
 
         if feed == "":
             glob = "*.json"
@@ -114,11 +115,9 @@ if __name__ == "__main__":
                             config["timetable"]["datasets"][name]["rt"] \
                                 .append(rt_feed)
 
-                        case "gbfs":
-                            if "gbfs" not in config.keys():
-                                config["gbfs"] = {"feeds": {source.name: {"url": source.url}}}
-                            else:
-                                config["gbfs"]["feeds"][source.name] = {"url": source.url}
+                        case "gbfs" if isinstance(source, metadata.UrlSource):
+                            name = f"{region_name}-{source.name}"
+                            config["gbfs"]["feeds"][name] = {"url": source.url}
 
         with open("out/config.yml", "w") as fo:
             yaml.dump(config, fo)

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -142,30 +142,12 @@ class UrlSource(Source):
                 self.headers = parsed["headers"]
 
 
-class GBFSDatabaseSource(Source):
-    system_id: str = ""
-    options: HttpOptions = HttpOptions()
-    url_override: Optional[str] = None
-    proxy: bool = False
-
-    def __init__(self, parsed: dict):
-        super().__init__(parsed)
-        self.system_id = parsed["system-id"]
-        self.url_override = parsed.get("url-override", None)
-        self.proxy = parsed.get("proxy", False)
-
-        if "http-options" in parsed:
-            self.options = HttpOptions(parsed["http-options"])
-
-
 def sourceFromJson(parsed: dict) -> Source:
     match parsed["type"]:
         case "transitland-atlas":
             return TransitlandSource(parsed)
         case "mobility-database":
             return MobilityDatabaseSource(parsed)
-        case "gbfs-database":
-            return GBFSDatabaseSource(parsed)
         case "http":
             return HttpSource(parsed)
         case "url":

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -142,12 +142,30 @@ class UrlSource(Source):
                 self.headers = parsed["headers"]
 
 
+class GBFSDatabaseSource(Source):
+    system_id: str = ""
+    options: HttpOptions = HttpOptions()
+    url_override: Optional[str] = None
+    proxy: bool = False
+
+    def __init__(self, parsed: dict):
+        super().__init__(parsed)
+        self.system_id = parsed["system-id"]
+        self.url_override = parsed.get("url-override", None)
+        self.proxy = parsed.get("proxy", False)
+
+        if "http-options" in parsed:
+            self.options = HttpOptions(parsed["http-options"])
+
+
 def sourceFromJson(parsed: dict) -> Source:
     match parsed["type"]:
         case "transitland-atlas":
             return TransitlandSource(parsed)
         case "mobility-database":
             return MobilityDatabaseSource(parsed)
+        case "gbfs-database":
+            return GBFSDatabaseSource(parsed)
         case "http":
             return HttpSource(parsed)
         case "url":

--- a/src/transitland.py
+++ b/src/transitland.py
@@ -54,6 +54,13 @@ class Atlas:
             result.spec = "gtfs-rt"
             result.skip = source.skip
             result.skip_reason = source.skip_reason
+        elif "gbfs_auto_discovery" in feed["urls"]:
+            result = UrlSource()
+            result.name = source.name
+            result.url = feed["urls"]["gbfs_auto_discovery"]
+            result.spec = "gbfs"
+            result.skip = source.skip
+            result.skip_reason = source.skip_reason
         else:
             print("Warning: Found Transitland source that we can't handle:", source.transitland_atlas_id)
             sys.stdout.flush()


### PR DESCRIPTION
This PR adds initial GBFS support as discussed in #74 
For now it only supports GBFS feeds from the transitland atlas and generates a working config.

However, for this specific feed I need to double check why it does not show up in search results, so do not merge for now.