### PR TITLE
Add more feeds in Romania

### DIFF
--- a/feeds/ro.json
+++ b/feeds/ro.json
@@ -43,6 +43,55 @@
             "name": "brasov",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-ratbv~ro"
+        },
+        {
+            "name": "Cluj-Napoca",
+            "type": "mobility-database",
+            "mdb-id": 2121
+        },
+        {
+            "name": "Transbus-Buzău",
+            "type": "mobility-database",
+            "use-origin": true,
+            "mdb-id": 2106
+        },
+        {
+            "name": "Transbus-Buzău",
+            "type": "mobility-database",
+            "mdb-id": 2112
+        },
+        {
+            "name": "Consiliul-Judetean-Vrancea",
+            "type": "mobility-database",
+            "use-origin": true,
+            "mdb-id": 1984
+        },
+        {
+            "name": "Târgoviște",
+            "type": "mobility-database",
+            "use-origin": true,
+            "mdb-id": 2107
+        },
+        {
+            "name": "Sinaia",
+            "type": "mobility-database",
+            "mdb-id": 2114
+        },
+        {
+            "name": "Craiova",
+            "type": "mobility-database",
+            "mdb-id": 2115
+        },
+        {
+            "name": "Ploiești",
+            "type": "mobility-database",
+            "use-origin": true,
+            "mdb-id": 2108
+        },
+        {
+            "name": "Zalău",
+            "type": "mobility-database",
+            "mdb-id": 2102
         }
     ]
 }

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -103,11 +103,13 @@ class MobilityDatabaseSource(Source):
     mdb_id: int = -1
     options: HttpOptions = HttpOptions()
     url_override: Optional[str] = None
+    use_origin: bool = False
 
     def __init__(self, parsed: dict):
         super().__init__(parsed)
         self.mdb_id = parsed["mdb-id"]
         self.url_override = parsed.get("url-override", None)
+        self.use_origin = parsed.get("use-origin", False)
 
         if "http-options" in parsed:
             self.options = HttpOptions(parsed["http-options"])

--- a/src/mobilitydatabase.py
+++ b/src/mobilitydatabase.py
@@ -47,7 +47,10 @@ class Database:
             case "gtfs":
                 result = HttpSource()
                 result.name = source.name
-                result.url = feed["urls.latest"]
+                if source.use_origin:
+                    result.url = feed["urls.direct_download"]
+                else:
+                    result.url = feed["urls.latest"]
                 result.options = source.options
                 result.spec = "gtfs"
                 result.fix = source.fix


### PR DESCRIPTION
I added an escape hatch to not use the mirrored version from Mobility Database, because sometimes they are blocked as well.

I'm not entirely happy about the different semantics of proxy for transitland and use-origin, but neither do I want to turn proxy on unconditionally nor loose the advantage of the mobilitydatabase cache.