### PR TITLE
Issue-947: Add references to conference talks to api page

### DIFF
--- a/website/content/_index.html
+++ b/website/content/_index.html
@@ -44,6 +44,6 @@ routing service that does not stop at borders.</p>
 <a class="btn btn-primary theme-button text-black" href="https://transitous.org/doc#adding-a-region"><i class="bi bi-arrow-right m-1"></i>Contributor Documentation</a>
 
 <h2>Conference talks and presentations</h2>
-<p>Sometimes an overview over Transitous is enough. There are several public talks on conferences and meetups, where we talk about Transitous.</p>
-<a class="btn btn-primary text-black" href="https://www.youtube.com/watch?v=8XVVx-212Qc">30C3 - YouTube</a>
+<p>Looking for an overview of how this project works? There are several public talks from conferences and meetups that you can watch.</p>
+<a class="btn btn-primary text-black" href="https://media.ccc.de/v/38c3-transitous-offener-routingdienst-fr-ffentliche-verkehrsmittel">38C3 (in German)</a>
 <a class="btn btn-primary text-black" href="https://fosdem.org/2025/schedule/event/fosdem-2025-4105-gnome-maps-meets-transitous-meets-motis/">FOSDEM 2025 Video</a>

--- a/website/content/_index.html
+++ b/website/content/_index.html
@@ -45,5 +45,5 @@ routing service that does not stop at borders.</p>
 
 <h2>Conference talks and presentations</h2>
 <p>Looking for an overview of how this project works? There are several public talks from conferences and meetups that you can watch.</p>
-<a class="btn btn-primary text-black" href="https://media.ccc.de/v/38c3-transitous-offener-routingdienst-fr-ffentliche-verkehrsmittel">38C3 (in German)</a>
+<a class="btn btn-primary text-black" href="https://media.ccc.de/v/38c3-transitous-offener-routingdienst-fr-ffentliche-verkehrsmittel">38C3 Video (in German)</a>
 <a class="btn btn-primary text-black" href="https://fosdem.org/2025/schedule/event/fosdem-2025-4105-gnome-maps-meets-transitous-meets-motis/">FOSDEM 2025 Video</a>

--- a/website/content/_index.html
+++ b/website/content/_index.html
@@ -42,3 +42,8 @@ routing service that does not stop at borders.</p>
 <h2>Public Transport Coverage</h2>
 <p>If you know where to find public transport data for your region, or if you are a public transport operator, you can help by adding the feed to our data set.</p>
 <a class="btn btn-primary theme-button text-black" href="https://transitous.org/doc#adding-a-region"><i class="bi bi-arrow-right m-1"></i>Contributor Documentation</a>
+
+<h2>Conference talks and presentations</h2>
+<p>Sometimes an overview over Transitous is enough. There are several public talks on conferences and meetups, where we talk about Transitous.</p>
+<a class="btn btn-primary text-black" href="https://www.youtube.com/watch?v=8XVVx-212Qc">30C3 - YouTube</a>
+<a class="btn btn-primary text-black" href="https://fosdem.org/2025/schedule/event/fosdem-2025-4105-gnome-maps-meets-transitous-meets-motis/">FOSDEM 2025 Video</a>

--- a/website/content/api.html
+++ b/website/content/api.html
@@ -31,3 +31,11 @@ You can do that by <a href="https://github.com/public-transport/transitous/blob/
 <p>The data on the legacy server is no longer kept up to date.</p>
 
 <a class="btn btn-primary text-black" href="https://routing.spline.de/doc/index.html">API Documentation</a>
+
+<h2>Conference talks and presentations</h2>
+
+<p>Sometimes an overview over Transitous is enough. There are several public talks on conferences and meetups, where we talk about Transitous.</p>
+
+<a class="btn btn-primary text-black" href="https://www.youtube.com/watch?v=8XVVx-212Qc">30C3 - YouTube</a>
+
+<a class="btn btn-primary text-black" href="https://fosdem.org/2025/schedule/event/fosdem-2025-4105-gnome-maps-meets-transitous-meets-motis/">FOSDEM 2025 Video</a>

--- a/website/content/api.html
+++ b/website/content/api.html
@@ -31,11 +31,3 @@ You can do that by <a href="https://github.com/public-transport/transitous/blob/
 <p>The data on the legacy server is no longer kept up to date.</p>
 
 <a class="btn btn-primary text-black" href="https://routing.spline.de/doc/index.html">API Documentation</a>
-
-<h2>Conference talks and presentations</h2>
-
-<p>Sometimes an overview over Transitous is enough. There are several public talks on conferences and meetups, where we talk about Transitous.</p>
-
-<a class="btn btn-primary text-black" href="https://www.youtube.com/watch?v=8XVVx-212Qc">30C3 - YouTube</a>
-
-<a class="btn btn-primary text-black" href="https://fosdem.org/2025/schedule/event/fosdem-2025-4105-gnome-maps-meets-transitous-meets-motis/">FOSDEM 2025 Video</a>


### PR DESCRIPTION
This PR [refers to a request](https://github.com/public-transport/transitous/issues/947) to add references/links to talks and presentations about Transitous.
The exact wording is still debatable, so I am open for any suggestion.

The result looks like this:

<img width="600" alt="Screenshot 2025-03-01 at 21 20 17" src="https://github.com/user-attachments/assets/2d9c1637-134f-4f02-a9ed-940742f4ba8d" />

