### PR TITLE
Use unordered list element for references

### DIFF
--- a/website/content/_index.html
+++ b/website/content/_index.html
@@ -45,5 +45,17 @@ routing service that does not stop at borders.</p>
 
 <h2>Conference talks and presentations</h2>
 <p>Looking for an overview of how this project works? There are several public talks from conferences and meetups that you can watch.</p>
-<a class="btn btn-primary text-black" href="https://media.ccc.de/v/38c3-transitous-offener-routingdienst-fr-ffentliche-verkehrsmittel">38C3 Video (in German)</a>
-<a class="btn btn-primary text-black" href="https://fosdem.org/2025/schedule/event/fosdem-2025-4105-gnome-maps-meets-transitous-meets-motis/">FOSDEM 2025 Video</a>
+<ul>
+  <li>
+    <a target="_blank" href="https://meet.systect.de/playback/presentation/2.3/d941f8412ff350b73e9084e0fd1da86394aff088-1708540821542" >OTM Initial presentation<i class="bi bi-box-arrow-right m-2"></i></a>
+  </li>
+  <li>
+    <a target="_blank" href="https://media.ccc.de/v/38c3-transitous-offener-routingdienst-fr-ffentliche-verkehrsmittel" >38C3 Video (in German)<i class="bi bi-box-arrow-right m-2"></i></a>
+  </li>
+  <li>
+    <a target="_blank" href="https://fosdem.org/2025/schedule/event/fosdem-2025-4105-gnome-maps-meets-transitous-meets-motis/" >FOSDEM 2025 Video<i class="bi bi-box-arrow-right m-2"></i></a>
+  </li>
+  <li>
+    <a target="_blank" href="https://meet.systect.de/playback/presentation/2.3/d941f8412ff350b73e9084e0fd1da86394aff088-1739990087983" >OTM Import pipeline<i class="bi bi-box-arrow-right m-2"></i></a>
+  </li>
+</ul>

--- a/website/content/_index.html
+++ b/website/content/_index.html
@@ -49,19 +49,19 @@ routing service that does not stop at borders.</p>
 <h3>2024</h3>
 <ul>
   <li>
-     🇬🇧 <a target="_blank" href="https://meet.systect.de/playback/presentation/2.3/d941f8412ff350b73e9084e0fd1da86394aff088-1708540821542" >Open Transport Meetup Initial<i class="bi bi-box-arrow-right m-2"></i></a>
+     🇬🇧 <a target="_blank" href="https://meet.systect.de/playback/presentation/2.3/d941f8412ff350b73e9084e0fd1da86394aff088-1708540821542" >Transitous - Open Transport Meetup<i class="bi bi-box-arrow-right m-2"></i></a>
   </li>
   <li>
-     🇩🇪 <a target="_blank" href="https://media.ccc.de/v/38c3-transitous-offener-routingdienst-fr-ffentliche-verkehrsmittel" >Chaos Communication Congress<i class="bi bi-box-arrow-right m-2"></i></a>
+     🇩🇪 <a target="_blank" href="https://media.ccc.de/v/38c3-transitous-offener-routingdienst-fr-ffentliche-verkehrsmittel" >offener Routingdienst für öffentliche Verkehrsmittel - 38C3<i class="bi bi-box-arrow-right m-2"></i></a>
   </li>
 </ul>
 <h3>2025</h3>
 <ul>
   <li>
-     🇬🇧 <a target="_blank" href="https://fosdem.org/2025/schedule/event/fosdem-2025-4105-gnome-maps-meets-transitous-meets-motis/" >Free & Open source Software Developers' European Meeting<i class="bi bi-box-arrow-right m-2"></i></a>
+     🇬🇧 <a target="_blank" href="https://fosdem.org/2025/schedule/event/fosdem-2025-4105-gnome-maps-meets-transitous-meets-motis/" >GNOME Maps meets Transitous meets MOTIS - FOSDEM<i class="bi bi-box-arrow-right m-2"></i></a>
   </li>
   <li>
-     🇬🇧 <a target="_blank" href="https://meet.systect.de/playback/presentation/2.3/d941f8412ff350b73e9084e0fd1da86394aff088-1739990087983" >Open Transport Meetup Import pipeline<i class="bi bi-box-arrow-right m-2"></i></a>
+     🇬🇧 <a target="_blank" href="https://meet.systect.de/playback/presentation/2.3/d941f8412ff350b73e9084e0fd1da86394aff088-1739990087983" >Transitous Import Pipeline - Open Transport Meetup<i class="bi bi-box-arrow-right m-2"></i></a>
   </li>
   <li>
      🇩🇪 <a target="_blank" href="https://pretalx.com/fossgis2025/talk/TJVVDZ/" >Barrierefreies Routing mit MOTIS - FOSSGIS<i class="bi bi-box-arrow-right m-2"></i></a>

--- a/website/content/_index.html
+++ b/website/content/_index.html
@@ -45,17 +45,28 @@ routing service that does not stop at borders.</p>
 
 <h2>Conference talks and presentations</h2>
 <p>Looking for an overview of how this project works? There are several public talks from conferences and meetups that you can watch.</p>
+
+<h3>2024</h3>
 <ul>
   <li>
-    <a target="_blank" href="https://meet.systect.de/playback/presentation/2.3/d941f8412ff350b73e9084e0fd1da86394aff088-1708540821542" >OTM Initial presentation<i class="bi bi-box-arrow-right m-2"></i></a>
+     🇬🇧 <a target="_blank" href="https://meet.systect.de/playback/presentation/2.3/d941f8412ff350b73e9084e0fd1da86394aff088-1708540821542" >Open Transport Meetup Initial<i class="bi bi-box-arrow-right m-2"></i></a>
   </li>
   <li>
-    <a target="_blank" href="https://media.ccc.de/v/38c3-transitous-offener-routingdienst-fr-ffentliche-verkehrsmittel" >38C3 Video (in German)<i class="bi bi-box-arrow-right m-2"></i></a>
+     🇩🇪 <a target="_blank" href="https://media.ccc.de/v/38c3-transitous-offener-routingdienst-fr-ffentliche-verkehrsmittel" >Chaos Communication Congress<i class="bi bi-box-arrow-right m-2"></i></a>
+  </li>
+</ul>
+<h3>2025</h3>
+<ul>
+  <li>
+     🇬🇧 <a target="_blank" href="https://fosdem.org/2025/schedule/event/fosdem-2025-4105-gnome-maps-meets-transitous-meets-motis/" >Free & Open source Software Developers' European Meeting<i class="bi bi-box-arrow-right m-2"></i></a>
   </li>
   <li>
-    <a target="_blank" href="https://fosdem.org/2025/schedule/event/fosdem-2025-4105-gnome-maps-meets-transitous-meets-motis/" >FOSDEM 2025 Video<i class="bi bi-box-arrow-right m-2"></i></a>
+     🇬🇧 <a target="_blank" href="https://meet.systect.de/playback/presentation/2.3/d941f8412ff350b73e9084e0fd1da86394aff088-1739990087983" >Open Transport Meetup Import pipeline<i class="bi bi-box-arrow-right m-2"></i></a>
   </li>
   <li>
-    <a target="_blank" href="https://meet.systect.de/playback/presentation/2.3/d941f8412ff350b73e9084e0fd1da86394aff088-1739990087983" >OTM Import pipeline<i class="bi bi-box-arrow-right m-2"></i></a>
+     🇩🇪 <a target="_blank" href="https://pretalx.com/fossgis2025/talk/TJVVDZ/" >Barrierefreies Routing mit MOTIS - FOSSGIS<i class="bi bi-box-arrow-right m-2"></i></a>
+  </li>
+  <li>
+     🇩🇪 <a target="_blank" href="https://pretalx.com/fossgis2025/talk/HGUKFM/" >Transitous - Freies Public Transport Routing - FOSSGIS<i class="bi bi-box-arrow-right m-2"></i></a>
   </li>
 </ul>


### PR DESCRIPTION
Uses an unordered list to display several references, instead of buttons. Resolves GH-947

### Before
<img width="864" alt="Screenshot 2025-03-05 at 21 47 21" src="https://github.com/user-attachments/assets/b7c52a56-efda-46fc-8846-b0bb6a007acb" />

### After
<img width="500" alt="Screenshot 2025-03-06 at 20 57 57" src="https://github.com/user-attachments/assets/4def9413-0698-4d50-a113-60ded73a4f44" />
<img width="250" alt="Screenshot 2025-03-06 at 20 58 08" src="https://github.com/user-attachments/assets/fb0e374d-3c88-4b42-baa4-62b3d8659169" />

