### PR TITLE
Fix compatibility with Python 3.9 - 3.11 in generate-france.py

### DIFF
--- a/src/generate-france.py
+++ b/src/generate-france.py
@@ -217,7 +217,7 @@ if __name__ == "__main__":
                                 )
                         else:
                             print(
-                                f"{dataset['slug']} has skipped {resource["title"]} GTFS-RT feed because not selected!",
+                                f"{dataset['slug']} has skipped {resource['title']} GTFS-RT feed because not selected!",
                                 file=sys.stderr,
                             )
                             continue


### PR DESCRIPTION
This is a minor fix to make the script also work on older Python versions.