### PR TITLE
Update transitland id for Estonian feed

### DIFF
--- a/feeds/ee.json
+++ b/feeds/ee.json
@@ -9,7 +9,7 @@
         {
             "name": "peatus",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-ud-atkoliinidoÜ~aktsiaseltshansabussiliinid~kihnuveeteedas~väi",
+            "transitland-atlas-id": "f-ud-atkoliinidoü~aktsiaseltshansabussiliinid~kihnuveeteedas~väi",
             "fix": true
         }
     ]


### PR DESCRIPTION
Due to https://github.com/transitland/transitland-atlas/pull/1256 the ID for the estonian feed changed.

Resolves #1002 