### PR TITLE
Add some Bikesharing feeds for DE-BW

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -94,9 +94,34 @@
             }
         },
         {
-            "name": "RegioRadStuttgart",
+            "name": "CallaBike",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-regioradstuttgart~stuttgart~gbfs"
+            "transitland-atlas-id": "f-call~a~bike~germany~gbfs"
+        },
+        {
+            "name": "KVV.nextbike",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-kvv~nextbike~germany~gbfs"
+        },
+        {
+            "name": "FreloFreiburg",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-frelo~freiburg~gbfs"
+        },
+        {
+            "name": "SAPWalldorf",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-sap~walldorf~gbfs"
+        },
+                {
+            "name": "EinfachMobil",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-einfachmobil~ortenaukreis~gbfs"
+        },
+        {
+            "name": "VRNnextbike",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-vrnnextbike~rhine~neckar~gbfs"
         }
     ]
 }


### PR DESCRIPTION
- Replace RegioRadStuttgart with Call-a-bike as it's included. Currently however both feeds are down :/, but I reached out to MobiData for investigation what is currently happening.
- Add Nextbike feeds from https://www.mobidata-bw.de/dataset/bikesh
Checked in a local instance, that all of them get picked up