### PR TITLE
Update Motis to v2.0.45

### DIFF
--- a/.woodpecker/motis-release.yml
+++ b/.woodpecker/motis-release.yml
@@ -8,7 +8,7 @@ steps:
   build-release-amd64:
     image: docker.io/alpine
     commands:
-      - export MOTIS_TAG=v2.0.34
+      - export MOTIS_TAG=v2.0.45
       - apk add musl-dev cmake ninja gcc g++ git npm linux-headers
       - git clone https://github.com/motis-project/motis -b $MOTIS_TAG motis-src
       - mkdir -p motis-src/build


### PR DESCRIPTION
@jbruechert I don't know if it the correct process for bumping Motis version (I don't know If this PR should also update CI and ansible :thinking: ), so feel free to close the PR if it's not right.