### PR TITLE
Add Münchner Verkehrsgesellschaft (MVG) as de feed

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -130,7 +130,7 @@
             "transitland-atlas-id": "f-vrnnextbike~rhine~neckar~gbfs"
         },
         {
-            "name": "Münchner Verkehrsgesellschaft (MVG)",
+            "name": "Münchner-Verkehrsgesellschaft(MVG)",
             "type": "mobility-database",
             "mdb-id": 2333
         }

--- a/feeds/de.json
+++ b/feeds/de.json
@@ -31,7 +31,8 @@
                 "Braunschweiger Verkehrs-GmbH",
                 "Kraftverkehrsgesellschaft mbH Braunschweig",
                 "SWO Mobil GmbH",
-                "FlixBus-de"
+                "FlixBus-de",
+                "U-Bahn München"
             ],
             "http-options": {
                 "fetch-interval-days": 2
@@ -118,7 +119,7 @@
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-sap~walldorf~gbfs"
         },
-                {
+        {
             "name": "EinfachMobil",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-einfachmobil~ortenaukreis~gbfs"
@@ -127,6 +128,11 @@
             "name": "VRNnextbike",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-vrnnextbike~rhine~neckar~gbfs"
+        },
+        {
+            "name": "Münchner Verkehrsgesellschaft (MVG)",
+            "type": "mobility-database",
+            "mdb-id": 2333
         }
     ]
 }


### PR DESCRIPTION
Hey,
this is my first time working with GTFS / Transitous. Hope I got everything right.

I noticed that the current headsigns for the Munich U-Bahn all show the wrong destination `Parkhaus Blumengroßmarkt`. For example, https://api.transitous.org/api/v1/trip?tripId=20250412_20%3A13_de-DELFI_2783325967 has `Parkhaus Blumengroßmarkt` as the headsign, even though it should be `Mangfallplatz`.
This is due to DELFI providing the wrong data: `de:mvg:1|U1|U:_1,2,Parkhaus Blumengroßmarkt,,0,,161945,2783325967`

The feed at https://mobilitydatabase.org/feeds/gtfs/mdb-2333 contains the correct headsigns. So I tried to replace it.

Hope this helps!
Thank you.