### PR TITLE
Improve attribution

### DIFF
--- a/motis/config.yml
+++ b/motis/config.yml
@@ -6,6 +6,7 @@ server:
   host: 0.0.0.0
   port: 8080
   web_folder: "/opt/motis/ui/"  # Just for testing, not used on server
+  data_attribution_link: https://transitous.org/sources/
 
 street_routing: true
 osr_footpath: false

--- a/website/content/sources.html
+++ b/website/content/sources.html
@@ -20,4 +20,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <p>If necessary, we remove parts of the data from a source if it overlaps with a better source.
 Therefore the processed version does not necessarily cover the same area as the original. Only use it in combination with the other files for the region.</p>
 
+<p>Data from <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> is used directly and indirectly for street routing, geocoding, map tiles and stops and lines metadata.</p>
+
 {{< source-table >}}


### PR DESCRIPTION
Adds link to https://transitous.org/sources/ in the UI and as a response header of every API call (this needs not-yet-released motis 2.0.49, but shouldn't break anything rn). Adds attribution to OSM to the sources page.