### PR TITLE
Add licenses + regenerate FR

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -29,7 +29,8 @@
             "url": "https://thello.axelor.com/public/gtfs/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-des-trains-trenitalia-france"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-des-trains-trenitalia-france",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -37,7 +38,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/trenitalia-gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-des-trains-trenitalia-france"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-des-trains-trenitalia-france",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -46,40 +48,44 @@
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/navettes-aeroport-paris-beauvais-aerobus/20250212-102506/offre-113-20250212102416z.zip",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/navettes-aeroport-paris-beauvais-aerobus"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/navettes-aeroport-paris-beauvais-aerobus",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "skip": true
         },
         {
             "name": "navettes-aeroport-paris-beauvais-aerobus--82777",
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/navettes-aeroport-paris-beauvais-aerobus/20250212-102458/offre-112-20250212102413z.zip",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/navettes-aeroport-paris-beauvais-aerobus"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/navettes-aeroport-paris-beauvais-aerobus",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "skip": true
         },
         {
             "name": "navettes-aeroport-paris-beauvais-aerobus--82778",
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/navettes-aeroport-paris-beauvais-aerobus/20250212-102446/offre-111-20250212102409z.zip",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/navettes-aeroport-paris-beauvais-aerobus"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/navettes-aeroport-paris-beauvais-aerobus",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "skip": true
         },
         {
             "name": "navettes-aeroport-paris-beauvais-aerobus--82779",
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/navettes-aeroport-paris-beauvais-aerobus/20250212-102426/offre-110-20250212102404z.zip",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/navettes-aeroport-paris-beauvais-aerobus"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/navettes-aeroport-paris-beauvais-aerobus",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "skip": true
         },
         {
             "name": "horaires-ave-espagne-france",
@@ -87,7 +93,8 @@
             "url": "https://ssl.renfe.com/gtransit/Fichero_AV_INT/Renfe_AVE_Int.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-ave-espagne-france"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-ave-espagne-france",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -95,10 +102,11 @@
             "type": "http",
             "url": "https://bus-api.blablacar.com/gtfs.zip",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/blablacar-bus-horaires-theoriques-et-temps-reel-du-reseau-europeen"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/blablacar-bus-horaires-theoriques-et-temps-reel-du-reseau-europeen",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "skip": true
         },
         {
             "name": "eurostar-gtfs",
@@ -106,7 +114,8 @@
             "url": "https://gtfs.eurostar.com/assets/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/eurostar-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/eurostar-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -114,10 +123,11 @@
             "type": "http",
             "url": "https://gtfs.gis.flix.tech/gtfs_generic_eu.zip",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/flixbus-horaires-theoriques-du-reseau-europeen-1"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/flixbus-horaires-theoriques-du-reseau-europeen-1",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "skip": true
         },
         {
             "name": "gtfs-static-et-real-time-transporteur-thalys",
@@ -125,7 +135,8 @@
             "url": "https://thapaasblobsprod.blob.core.windows.net/datagouv/gtfs_static.zip?sv=2021-08-06&st=2023-01-11T11%3A12%3A00Z&se=2050-01-13T11%3A12%3A00Z&sr=b&sp=r&sig=1CLeDy4QoLgKwRx63BMp%2BDFSnqH1IUi14k8qg1auk%2FU%3D",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-static-et-real-time-transporteur-thalys"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-static-et-real-time-transporteur-thalys",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -133,7 +144,8 @@
             "type": "url",
             "url": "https://thapaas-prd-storage.thalys.com/datagouv/gtfs-realtime.bin?sv=2021-10-04&st=2023-03-09T14%3A40%3A38Z&se=2050-03-10T14%3A40%3A00Z&sr=b&sp=r&sig=2xTfLbvsxTzlLavx%2BI1TJ2capp085ArXJYDA7i4IT04%3D",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-static-et-real-time-transporteur-thalys"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-static-et-real-time-transporteur-thalys",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -143,7 +155,8 @@
             "url": "https://eu.ftp.opendatasoft.com/sncf/plandata/export-intercites-gtfs-last.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-des-lignes-intercites-sncf"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-des-lignes-intercites-sncf",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -151,7 +164,18 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/sncf-ic-gtfs-rt-trip-updates",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-des-lignes-intercites-sncf"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-des-lignes-intercites-sncf",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "horaires-des-lignes-intercites-sncf",
+            "type": "url",
+            "url": "https://proxy.transport.data.gouv.fr/resource/sncf-all-gtfs-rt-trip-updates",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/horaires-des-lignes-intercites-sncf",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -161,7 +185,8 @@
             "url": "https://eu.ftp.opendatasoft.com/sncf/plandata/export-ter-gtfs-last.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-des-lignes-ter-sncf"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-des-lignes-ter-sncf",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -169,7 +194,18 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/sncf-ter-gtfs-rt-trip-updates",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-des-lignes-ter-sncf"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-des-lignes-ter-sncf",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "horaires-des-lignes-ter-sncf",
+            "type": "url",
+            "url": "https://proxy.transport.data.gouv.fr/resource/sncf-all-gtfs-rt-trip-updates",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/horaires-des-lignes-ter-sncf",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -179,7 +215,8 @@
             "url": "https://eu.ftp.opendatasoft.com/sncf/plandata/export_gtfs_voyages.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-des-tgv"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-des-tgv",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -187,7 +224,18 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/sncf-tgv-gtfs-rt-trip-updates",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-des-tgv"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-des-tgv",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "horaires-des-tgv",
+            "type": "url",
+            "url": "https://proxy.transport.data.gouv.fr/resource/sncf-all-gtfs-rt-trip-updates",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/horaires-des-tgv",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -197,7 +245,8 @@
             "url": "https://static.data.gouv.fr/resources/horaires-reseau-au-4-novembre-2024-fichier-gtfs/20241129-091019/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-reseau-au-4-novembre-2024-fichier-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-reseau-au-4-novembre-2024-fichier-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -215,7 +264,8 @@
             "url": "https://eu.ftp.opendatasoft.com/sncf/gtfs/transilien-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-des-lignes-transilien-1"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-des-lignes-transilien-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -224,7 +274,8 @@
             "url": "https://mobi-iti-ara.okina.fr/static/mobiiti_technique/DAT_AURA_GTFS_ExportAOM.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/agregat-oura"
+                "url": "https://transport.data.gouv.fr/datasets/agregat-oura",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -233,7 +284,8 @@
             "url": "https://www.itinisere.fr/fr/donnees-open-data/169/OpenData/Download?fileName=TRANSAL.GTFS.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/desserte-des-stations-de-ski-iseroises-transaltitude-38"
+                "url": "https://transport.data.gouv.fr/datasets/desserte-des-stations-de-ski-iseroises-transaltitude-38",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -242,7 +294,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-aravis-bus/20241205-081331/aravis-hiver-2025-hiver25-export-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-aravis-bus"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-aravis-bus",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -251,7 +304,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-interurbain-cars-region-express/20250317-080013/cars-region-express-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-express"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-express",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -260,7 +314,8 @@
             "url": "https://mobi-iti-ara.okina.fr/static/mobiiti_haute_loire/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-haute-loire-43"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-haute-loire-43",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -269,7 +324,8 @@
             "url": "https://mobi-iti-ara.okina.fr/static/mobiiti_haute_savoie/GTFS_haute_savoie.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-haute-savoie-74"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-haute-savoie-74",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -278,7 +334,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-interurbain-cars-region-ain-01/20250116-141711/cars-region-ain-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-ain-01"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-ain-01",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -287,7 +344,8 @@
             "url": "https://mobi-iti-ara.okina.fr/static/mobiiti_allier/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-allier-03"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-allier-03",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -296,7 +354,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-interurbain-cars-region-loire-42/20240905-092023/cars-region-loire-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-loire-42"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-loire-42",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -305,7 +364,8 @@
             "url": "https://mobi-iti-ara.okina.fr/static/mobiiti_ardeche/GTFS_ardeche.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-ardeche-07"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-ardeche-07",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -314,7 +374,8 @@
             "url": "https://mobi-iti-ara.okina.fr/static/mobiiti_savoie/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-savoie-73"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-savoie-73",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -323,7 +384,8 @@
             "url": "https://www.itinisere.fr/fr/donnees-open-data/169/OpenData/Download?fileName=CG38.GTFS.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-cars-region-isere-38"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-cars-region-isere-38",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -331,7 +393,8 @@
             "type": "url",
             "url": "https://www.itinisere.fr/ftp/GtfsRT/GtfsRT.CG38.pb",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-cars-region-isere-38"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-cars-region-isere-38",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -341,7 +404,8 @@
             "url": "https://mobi-iti-ara.okina.fr/static/mobiiti_car_region_cantal/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-cantal-15"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-cantal-15",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -350,7 +414,8 @@
             "url": "https://mobi-iti-ara.okina.fr/static/mobiiti_puy_de_dome/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-puy-de-dome-63"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-puy-de-dome-63",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -359,7 +424,8 @@
             "url": "https://mobi-iti-ara.okina.fr/static/mobiiti_drome/GTFS_drome.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-et-scolaire-cars-region-drome-26"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-et-scolaire-cars-region-drome-26",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -493,10 +559,10 @@
             "type": "http",
             "url": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_SCO_62.zip",
             "fix": true,
-            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-62-pas-de-calais"
-            }
+            },
+            "skip": true
         },
         {
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-nva-mobilite-agreges-1",
@@ -504,7 +570,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/naq-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-nva-mobilite-agreges-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-nva-mobilite-agreges-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -513,7 +580,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/charente-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cha-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cha-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -522,7 +590,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/charente_maritime-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cma-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cma-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -531,7 +600,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/correze-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cor-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cor-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -540,7 +610,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/creuse-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cre-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cre-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -549,7 +620,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/vienne-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-vie-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-vie-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -558,7 +630,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/deux_sevres-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-dse-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-dse-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -567,7 +640,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/dordogne-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-dor-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-dor-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -576,7 +650,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/gironde-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-gir-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-gir-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -585,7 +660,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/haute_vienne-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-hvi-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-hvi-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -594,7 +670,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/landes-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lan-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lan-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -603,7 +680,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/lot_et_garonne-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lga-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lga-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -612,7 +690,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/pyrenees_atlantiques-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-pat-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-pat-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -621,7 +700,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/bac_gironde-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-bac-nva-m"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-bac-nva-m",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -630,97 +710,108 @@
             "url": "https://app.mecatran.com/utw/ws/gtfsfeed/static/lio?apiKey=2b160d626f783808095373766f18714901325e45&type=gtfs_lio",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-lio-occitanie"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-lio-occitanie",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
-            "name": "fr-200052264-t0045-0000",
+            "name": "offre-de-transport-du-reseau-fluo-grand-est-ardennes-08",
             "type": "http",
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0045-0000/fluo-grand-est-fluo08-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0045-0000"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-ardennes-08",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
-            "name": "fr-200052264-t0046-0000-1",
+            "name": "offre-de-transport-du-reseau-fluo-grand-est-aube-10",
             "type": "http",
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0046-0000/fluo-grand-est-fluo10-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0046-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-aube-10",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
-            "name": "fr-200052264-t0049-0000-1",
+            "name": "offre-de-transport-du-reseau-fluo-grand-est-bas-rhin-67",
             "type": "http",
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0049-0000/fluo-grand-est-fluo67-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0049-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-bas-rhin-67",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
-            "name": "offre-de-transport-du-reseau-fluo-grand-est-52-region-grand-est-dga-mobilites",
+            "name": "offre-de-transport-du-reseau-fluo-grand-est-haute-marne-52",
             "type": "http",
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0055-0000/fluo-grand-est-fluo52-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-52-region-grand-est-dga-mobilites"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-haute-marne-52",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
-            "name": "fr-200052264-t0050-0000-1",
+            "name": "offre-de-transport-du-reseau-fluo-grand-est-haut-rhin-68",
             "type": "http",
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0050-0000/fluo-grand-est-fluo68-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0050-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-haut-rhin-68",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
-            "name": "fr-200052264-t0043-0000-1",
+            "name": "offre-de-transport-du-reseau-fluo-grand-est-marne-51",
             "type": "http",
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0043-0000/fluo-grand-est-fluo51-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0043-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-marne-51",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
-            "name": "fr-200052264-t0051-0000-1",
+            "name": "offre-de-transport-du-reseau-fluo-grand-est-meurthe-et-moselle-54",
             "type": "http",
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0051-0000/fluo-grand-est-fluo54-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0051-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-meurthe-et-moselle-54",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
-            "name": "fr-200052264-t0048-0000-1",
+            "name": "offre-de-transport-du-reseau-fluo-grand-est-meuse-55",
             "type": "http",
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0048-0000/fluo-grand-est-fluo55-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0048-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-meuse-55",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
-            "name": "fr-200052264-t0052-0000-1",
+            "name": "offre-de-transport-du-reseau-fluo-grand-est-moselle-57",
             "type": "http",
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0052-0000/fluo-grand-est-fluo57-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0052-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-moselle-57",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
-            "name": "fr-200052264-t0042-0000-1",
+            "name": "offre-de-transport-du-reseau-fluo-grand-est-vosges-88",
             "type": "http",
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0042-0000/fluo-grand-est-fluo88-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0042-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-vosges-88",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -729,7 +820,8 @@
             "url": "https://www.datasud.fr/fr/dataset/datasets/3745/resource/5016/download/",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/lignes-des-reseaux-transport-zou-provence-alpes-cote-d-azur-proximite-3-3"
+                "url": "https://transport.data.gouv.fr/datasets/lignes-des-reseaux-transport-zou-provence-alpes-cote-d-azur-proximite-3-3",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -737,7 +829,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/region-sud-zou-proximite-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/lignes-des-reseaux-transport-zou-provence-alpes-cote-d-azur-proximite-3-3"
+                "url": "https://transport.data.gouv.fr/datasets/lignes-des-reseaux-transport-zou-provence-alpes-cote-d-azur-proximite-3-3",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -747,7 +840,8 @@
             "url": "https://www.datasud.fr/fr/dataset/datasets/3743/resource/5153/download/",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/lignes-des-reseaux-transport-zou-provence-alpes-cote-d-azur-express-3-3"
+                "url": "https://transport.data.gouv.fr/datasets/lignes-des-reseaux-transport-zou-provence-alpes-cote-d-azur-express-3-3",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -755,7 +849,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/region-sud-zou-express-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/lignes-des-reseaux-transport-zou-provence-alpes-cote-d-azur-express-3-3"
+                "url": "https://transport.data.gouv.fr/datasets/lignes-des-reseaux-transport-zou-provence-alpes-cote-d-azur-express-3-3",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -765,7 +860,8 @@
             "url": "https://www.datasud.fr/fr/dataset/datasets/3746/resource/5015/download/",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/lignes-des-reseaux-transport-zou-provence-alpes-cote-d-azur-scolaire-1-3"
+                "url": "https://transport.data.gouv.fr/datasets/lignes-des-reseaux-transport-zou-provence-alpes-cote-d-azur-scolaire-1-3",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -774,7 +870,8 @@
             "url": "https://mobi-iti-pdl.okina.fr/static/mobiiti_technique/gtfs_global.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-circuits-des-lignes-de-transports-en-commun-en-pays-de-la-loire-gtfs-destineo-reseaux-aom-aleop-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-circuits-des-lignes-de-transports-en-commun-en-pays-de-la-loire-gtfs-destineo-reseaux-aom-aleop-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -783,7 +880,8 @@
             "url": "https://data.loire-atlantique.fr/api/explore/v2.1/catalog/datasets/224400028_horaires-bacs-loire-en-loire-atlantique-gtfs/files/31402ade013bcb1279c8729853eb362d",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-des-bacs-de-loire-en-loire-atlantique-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-des-bacs-de-loire-en-loire-atlantique-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -792,7 +890,8 @@
             "url": "https://donnees.paysdelaloire.fr/data/pdl.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-circuits-des-lignes-de-transports-aleop-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-circuits-des-lignes-de-transports-aleop-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -800,7 +899,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/aleop-pdl-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-circuits-des-lignes-de-transports-aleop-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-circuits-des-lignes-de-transports-aleop-1",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -810,7 +910,8 @@
             "url": "https://app.mecatran.com/utw/ws/gtfsfeed/static/pdlFlex?apiKey=19496e1c0c0e42607d54444b2a191b61533b3634",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/transports-a-la-demande-en-pays-de-la-loire-gtfs-flex-aleop"
+                "url": "https://transport.data.gouv.fr/datasets/transports-a-la-demande-en-pays-de-la-loire-gtfs-flex-aleop",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -819,7 +920,8 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/KORRIGOBRET.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/base-de-donnees-multimodale-transports-publics-en-bretagne-korrigo-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/base-de-donnees-multimodale-transports-publics-en-bretagne-korrigo-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -828,7 +930,8 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_BATEAU_ARZ.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/breizhgo-bateaux"
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-bateaux",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -837,7 +940,8 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_BATEAU_BREHAT.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/breizhgo-bateaux"
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-bateaux",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -846,7 +950,8 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_BATEAU_29.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/breizhgo-bateaux"
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-bateaux",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -855,7 +960,8 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_BATEAU_56.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/breizhgo-bateaux"
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-bateaux",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -864,7 +970,8 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_22.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -873,7 +980,8 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_29.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -882,7 +990,8 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_35.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -891,7 +1000,8 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_56.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -900,7 +1010,8 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_NS.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -909,7 +1020,8 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_RLP.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -917,7 +1029,8 @@
             "type": "url",
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/gtfsrt/BREIZHGO_CAR_35.GtfsRt.pb",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -926,7 +1039,8 @@
             "type": "url",
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/gtfsrt/BREIZHGO_CAR_RLP.GtfsRt.pb",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -935,7 +1049,8 @@
             "type": "url",
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/gtfsrt/TIBUS.GtfsRt.pb",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car"
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -945,7 +1060,8 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_35.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/breizhgo-35-experimentation"
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-35-experimentation",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -954,16 +1070,18 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_TER.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/breizhgo-ter"
+                "url": "https://transport.data.gouv.fr/datasets/breizhgo-ter",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
             "name": "base-de-donnees-multimodale-des-reseaux-de-transport-public-normands",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/base-de-donnees-multimodale-des-reseaux-de-transport-public-normands/20250312-135644/pt-th-offer-atoumod-gtfs-20250312-661-opendata.zip",
+            "url": "https://static.data.gouv.fr/resources/base-de-donnees-multimodale-des-reseaux-de-transport-public-normands/20250409-141214/pt-th-offer-atoumod-gtfs-20250409-683-opendata.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/base-de-donnees-multimodale-des-reseaux-de-transport-public-normands"
+                "url": "https://transport.data.gouv.fr/datasets/base-de-donnees-multimodale-des-reseaux-de-transport-public-normands",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -971,7 +1089,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/atoumod-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/base-de-donnees-multimodale-des-reseaux-de-transport-public-normands"
+                "url": "https://transport.data.gouv.fr/datasets/base-de-donnees-multimodale-des-reseaux-de-transport-public-normands",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -981,7 +1100,8 @@
             "url": "https://static.data.gouv.fr/resources/nomad-car-region-normandie/20250116-090711/pt-th-offer-nomad-gtfs-20250116-584-opendata.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/nomad-car-region-normandie"
+                "url": "https://transport.data.gouv.fr/datasets/nomad-car-region-normandie",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -990,7 +1110,8 @@
             "url": "https://static.data.gouv.fr/resources/bacs-de-seine-departement-seine-maritime/20241220-103514/pt-th-offer-seinemaritime76-gtfs-20241219-367-opendata.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/bacs-de-seine-departement-seine-maritime"
+                "url": "https://transport.data.gouv.fr/datasets/bacs-de-seine-departement-seine-maritime",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -998,70 +1119,77 @@
             "type": "http",
             "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT21",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11082",
             "type": "http",
             "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT25",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11083",
             "type": "http",
             "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT39",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11084",
             "type": "http",
             "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT58",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11085",
             "type": "http",
             "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT70",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11086",
             "type": "http",
             "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT71",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11087",
             "type": "http",
             "url": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT89",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "arrets-itineraires-et-horaires-theoriques-des-reseaux-de-transport-des-membres-de-jvmalin",
@@ -1069,7 +1197,8 @@
             "url": "https://data.centrevaldeloire.fr/api/explore/v2.1/catalog/datasets/jvmalin-point-dacces-national/files/e4c49416b6a28d91287b6c81b8ba0569",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-itineraires-et-horaires-theoriques-des-reseaux-de-transport-des-membres-de-jvmalin"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-itineraires-et-horaires-theoriques-des-reseaux-de-transport-des-membres-de-jvmalin",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1078,7 +1207,8 @@
             "url": "https://data.centrevaldeloire.fr/api/explore/v2.1/catalog/datasets/offre-theorique-mobilite-remi/files/eeb5dcb26f8ef4bc4aedcae5193a9e8d",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/remi-offre-theorique-mobilite-reseau-interurbain-regional"
+                "url": "https://transport.data.gouv.fr/datasets/remi-offre-theorique-mobilite-reseau-interurbain-regional",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1087,7 +1217,8 @@
             "url": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp?apiKey=60327e505a214c77303f52206f11483069257343",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone"
+                "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1095,50 +1226,50 @@
             "type": "http",
             "url": "https://download.data.grandlyon.com/files/rdata/cdr_carsdurhone.cdrtheorique/gtfs.zip",
             "fix": true,
-            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-des-cars-du-rhone"
-            }
+            },
+            "skip": true
         },
         {
             "name": "horaires-theoriques-des-lignes-scolaires-du-reseau-transports-en-commun-lyonnais",
             "type": "http",
             "url": "https://download.data.grandlyon.com/files/rdata/jd_juniordirect.jdtheorique/GTFS_SCOLAIRE.ZIP",
             "fix": true,
-            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-des-lignes-scolaires-du-reseau-transports-en-commun-lyonnais"
-            }
+            },
+            "skip": true
         },
         {
             "name": "horaires-theoriques-du-reseau-libellule-sytral-de-la-communaute-dagglomeration-de-villefranche-beaujolais-saone",
             "type": "http",
             "url": "https://download.data.grandlyon.com/files/rdata/lbl_libellule.lbltheorique/gtfs_libellule.zip",
             "fix": true,
-            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-libellule-sytral-de-la-communaute-dagglomeration-de-villefranche-beaujolais-saone"
-            }
+            },
+            "skip": true
         },
         {
             "name": "horaires-theoriques-du-service-rhonexpress-de-la-metropole-de-lyon-et-du-departement-du-rhone",
             "type": "http",
             "url": "https://download.data.grandlyon.com/files/rdata/rx_rhonexpress.rxtheorique/GTFS_RX.ZIP",
             "fix": true,
-            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-service-rhonexpress-de-la-metropole-de-lyon-et-du-departement-du-rhone"
-            }
+            },
+            "skip": true
         },
         {
             "name": "horaires-theoriques-du-reseau-transports-en-commun-lyonnais",
             "type": "http",
             "url": "https://download.data.grandlyon.com/files/rdata/tcl_sytral.tcltheorique/GTFS_TCL.ZIP",
             "fix": true,
-            "skip": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-transports-en-commun-lyonnais"
-            }
+            },
+            "skip": true
         },
         {
             "name": "localisation-des-arrets-ilevia-bus-metro-et-tram-gtfs-pictogrammes-du-reseau-ilevia-2",
@@ -1146,7 +1277,8 @@
             "url": "https://media.ilevia.fr/opendata/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/localisation-des-arrets-ilevia-bus-metro-et-tram-gtfs-pictogrammes-du-reseau-ilevia-2"
+                "url": "https://transport.data.gouv.fr/datasets/localisation-des-arrets-ilevia-bus-metro-et-tram-gtfs-pictogrammes-du-reseau-ilevia-2",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1154,7 +1286,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/ilevia-lille-gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/localisation-des-arrets-ilevia-bus-metro-et-tram-gtfs-pictogrammes-du-reseau-ilevia-2"
+                "url": "https://transport.data.gouv.fr/datasets/localisation-des-arrets-ilevia-bus-metro-et-tram-gtfs-pictogrammes-du-reseau-ilevia-2",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1164,7 +1297,8 @@
             "url": "https://data.toulouse-metropole.fr/explore/dataset/tisseo-gtfs/files/fc1dda89077cf37e4f7521760e0ef4e9/download/",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/tisseo-offre-de-transport-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/tisseo-offre-de-transport-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1173,7 +1307,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=bordeaux-navettes-aeroport",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-bordeaux-navettes-aeroport-30-direct-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-bordeaux-navettes-aeroport-30-direct-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1181,7 +1316,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=bordeaux-navettes-aeroport",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-bordeaux-navettes-aeroport-30-direct-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-bordeaux-navettes-aeroport-30-direct-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1191,7 +1327,8 @@
             "url": "https://bdx.mecatran.com/utw/ws/gtfsfeed/static/bordeaux?apiKey=opendata-bordeaux-metropole-flux-gtfs-rt",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offres-de-services-bus-tram-et-scolaire-au-format-gtfs-gtfs-rt-siri-lite"
+                "url": "https://transport.data.gouv.fr/datasets/offres-de-services-bus-tram-et-scolaire-au-format-gtfs-gtfs-rt-siri-lite",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1199,7 +1336,8 @@
             "type": "url",
             "url": "https://bdx.mecatran.com/utw/ws/gtfsfeed/realtime/bordeaux?apiKey=opendata-bordeaux-metropole-flux-gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offres-de-services-bus-tram-et-scolaire-au-format-gtfs-gtfs-rt-siri-lite"
+                "url": "https://transport.data.gouv.fr/datasets/offres-de-services-bus-tram-et-scolaire-au-format-gtfs-gtfs-rt-siri-lite",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1208,10 +1346,11 @@
             "type": "http",
             "url": "https://data.nantesmetropole.fr/explore/dataset/244400404_tan-arrets-horaires-circuits/files/16a1a0af5946619af621baa4ad9ee662/download/",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/naolib-arrets-horaires-et-circuits"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/naolib-arrets-horaires-et-circuits",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "skip": true
         },
         {
             "name": "gtfs-tadao--82654",
@@ -1219,7 +1358,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-tadao/20241219-093924/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-tadao"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-tadao",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1228,7 +1368,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-tadao/20250310-095329/gtfs-janvier2025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-tadao"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-tadao",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1237,7 +1378,8 @@
             "url": "https://data.mobilites-m.fr/api/gtfs/MCO",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-des-lignes-m-covoit-ligne-plus"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-des-lignes-m-covoit-ligne-plus",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1246,7 +1388,8 @@
             "url": "https://data.mobilites-m.fr/api/gtfs/SEM",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-tag"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-tag",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1255,7 +1398,8 @@
             "url": "https://data.mobilites-m.fr/api/gtfs/GSV",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-tougo"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-tougo",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1264,7 +1408,8 @@
             "url": "https://data.mobilites-m.fr/api/gtfs/TPV",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-transport-du-pays-voironnais"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-transport-du-pays-voironnais",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1273,16 +1418,18 @@
             "url": "https://data.mobilites-m.fr/api/gtfs/BUL",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-telepherique-de-la-bastille"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-telepherique-de-la-bastille",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
             "name": "export-quotidien-au-format-gtfs-du-reseau-de-transport-lignes-d-azur",
             "type": "http",
-            "url": "http://opendata.nicecotedazur.org/data/storage/f/gtfs1742516101/GTFSExport.zip",
+            "url": "http://opendata.nicecotedazur.org/data/storage/f/gtfs1743808501/GTFSExport.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/export-quotidien-au-format-gtfs-du-reseau-de-transport-lignes-d-azur"
+                "url": "https://transport.data.gouv.fr/datasets/export-quotidien-au-format-gtfs-du-reseau-de-transport-lignes-d-azur",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1291,7 +1438,8 @@
             "url": "https://opendata.cts-strasbourg.eu/google_transit.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-gtfs-et-temps-reel-siri-lite-du-reseau-cts"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-gtfs-et-temps-reel-siri-lite-du-reseau-cts",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1300,7 +1448,8 @@
             "url": "https://exs.tcar.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=ASTUCE",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1308,7 +1457,8 @@
             "type": "url",
             "url": "https://www.reseau-astuce.fr/ftp/gtfsrt/Astuce.TripUpdate.pb",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1317,17 +1467,19 @@
             "type": "url",
             "url": "https://gtfs.bus-tracker.fr/gtfs-rt/tcar/trip-updates",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
         {
             "name": "donnees-statiques-et-temps-reel-des-lignes-26-et-530-du-reseau-astuce-metropole-rouen-normandie",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/donnees-statiques-et-temps-reel-des-lignes-26-et-530-du-reseau-astuce-metropole-rouen-normandie/20250224-091257/gtfs-astuce-v115-du-24-02-25-au-06-04-25.zip",
+            "url": "https://static.data.gouv.fr/resources/donnees-statiques-et-temps-reel-des-lignes-26-et-530-du-reseau-astuce-metropole-rouen-normandie/20250407-064026/gtfs-astuce-v116-pvs-avril-du-07-04-25-au-21-04-.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-des-lignes-26-et-530-du-reseau-astuce-metropole-rouen-normandie"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-des-lignes-26-et-530-du-reseau-astuce-metropole-rouen-normandie",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1335,7 +1487,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/astuce-26-30-rouen-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-des-lignes-26-et-530-du-reseau-astuce-metropole-rouen-normandie"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-des-lignes-26-et-530-du-reseau-astuce-metropole-rouen-normandie",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1345,7 +1498,8 @@
             "url": "https://gtfs.tae76.fr/gtfs/feed.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-des-lignes-sur-le-secteur-delbeuf-du-reseau-astuce-metropole-rouen-normandie"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-des-lignes-sur-le-secteur-delbeuf-du-reseau-astuce-metropole-rouen-normandie",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1353,7 +1507,8 @@
             "type": "url",
             "url": "https://gtfs.tae76.fr/gtfs-rt.bin",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-des-lignes-sur-le-secteur-delbeuf-du-reseau-astuce-metropole-rouen-normandie"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-des-lignes-sur-le-secteur-delbeuf-du-reseau-astuce-metropole-rouen-normandie",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1363,7 +1518,8 @@
             "url": "https://data.montpellier3m.fr/sites/default/files/ressources/TAM_MMM_GTFS.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-de-montpellier-mediterranee-metropole-tam-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-de-montpellier-mediterranee-metropole-tam-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1372,7 +1528,8 @@
             "url": "https://data.montpellier3m.fr/TAM_MMM_GTFSRT/GTFS.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-tam-en-temps-reel-gtfs-rt-urbain"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-tam-en-temps-reel-gtfs-rt-urbain",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1380,34 +1537,38 @@
             "type": "url",
             "url": "https://data.montpellier3m.fr/TAM_MMM_GTFSRT/TripUpdate.pb",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-tam-en-temps-reel-gtfs-rt-urbain"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-tam-en-temps-reel-gtfs-rt-urbain",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
         {
-            "name": "versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs--82877",
+            "name": "versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs--82951",
             "type": "http",
-            "url": "https://eu.ftp.opendatasoft.com/star/gtfs/GTFS_1_20250318_20250418_20250318140629.zip",
+            "url": "https://eu.ftp.opendatasoft.com/star/gtfs/GTFS_1_20250408_20250418_20250408073448.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
-            "name": "versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs--82878",
+            "name": "versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs--82952",
             "type": "http",
-            "url": "https://eu.ftp.opendatasoft.com/star/gtfs/GTFS_2_20250419_20250428_20250318150643.zip",
+            "url": "https://eu.ftp.opendatasoft.com/star/gtfs/GTFS_2_20250419_20250519_20250408073537.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
-            "name": "versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs--82877",
+            "name": "versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs--82951",
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/star-rennes-integration-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1417,7 +1578,8 @@
             "url": "https://pysae.com/api/v2/groups/car-jaune/gtfs/pub",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-au-format-gtfs-et-horaires-temps-reel-au-format-gtfs-rt-du-reseau-car-jaune-a-la-reunion"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-au-format-gtfs-et-horaires-temps-reel-au-format-gtfs-rt-du-reseau-car-jaune-a-la-reunion",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1425,7 +1587,8 @@
             "type": "url",
             "url": "https://pysae.com/api/v2/groups/car-jaune/gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-au-format-gtfs-et-horaires-temps-reel-au-format-gtfs-rt-du-reseau-car-jaune-a-la-reunion"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-au-format-gtfs-et-horaires-temps-reel-au-format-gtfs-rt-du-reseau-car-jaune-a-la-reunion",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1435,7 +1598,8 @@
             "url": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/rd-toulon/exports/gtfs-complet.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-urbain-de-la-metropole-toulon-provence-mediterranee"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-urbain-de-la-metropole-toulon-provence-mediterranee",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1443,7 +1607,8 @@
             "type": "url",
             "url": "https://feed-rdtpm-toulon.ratpdev.com/TripUpdate/GTFS-RT",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-urbain-de-la-metropole-toulon-provence-mediterranee"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-urbain-de-la-metropole-toulon-provence-mediterranee",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1453,7 +1618,8 @@
             "url": "https://static.data.gouv.fr/resources/telepherique-du-mont-faron/20250206-162325/gtfs-tel-summer.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/telepherique-du-mont-faron"
+                "url": "https://transport.data.gouv.fr/datasets/telepherique-du-mont-faron",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1462,7 +1628,8 @@
             "url": "https://api.saint-etienne-metropole.fr/stas/api/horraires_tc/GTFS.aspx",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-stas"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-stas",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1471,16 +1638,18 @@
             "url": "https://static.data.gouv.fr/resources/horaires-du-reseau-transvilles-au-format-gtfs/20250210-151800/google-transit-10-02-au-31-08-25.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-du-reseau-transvilles-au-format-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-du-reseau-transvilles-au-format-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
             "name": "gtfs-transport-horaires-chemins-de-fer-corse-1",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/gtfs-transport-horaires-chemins-de-fer-corse-1/20250114-180701/chemins-de-fer-de-la-corse-horaires.zip",
+            "url": "https://static.data.gouv.fr/resources/gtfs-transport-horaires-chemins-de-fer-corse-1/20250325-095147/chemins-de-fer-de-la-corse-horaires.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-chemins-de-fer-corse-1"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-chemins-de-fer-corse-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1489,7 +1658,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-transport-horaires-cars-de-corse-du-sud-1/20250107-153104/autocars-de-corse-du-sud-horaires.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-cars-de-corse-du-sud-1"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-cars-de-corse-du-sud-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1497,7 +1667,8 @@
             "type": "url",
             "url": "https://ctc.plateforme-2cloud.com/api/gtfsrt/2.0/tripupdates/CTC-2298-2048-0876/bin",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-cars-de-corse-du-sud-1"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-cars-de-corse-du-sud-1",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1507,7 +1678,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-transport-horaires-cars-de-haute-corse/20241031-104121/autocars-de-haute-corse-horaires.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-cars-de-haute-corse"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-cars-de-haute-corse",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1516,7 +1688,8 @@
             "url": "https://static.data.gouv.fr/resources/programme-des-rotations-corsica-ferries/20241231-140652/gtfs-generated.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/programme-des-rotations-corsica-ferries"
+                "url": "https://transport.data.gouv.fr/datasets/programme-des-rotations-corsica-ferries",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1525,7 +1698,8 @@
             "url": "https://app.mecatran.com/utw/ws/gtfsfeed/static/txiktxak?apiKey=0f64273f070b7d4621002040646e180d374e5373",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-transport-du-reseau-txik-txak"
+                "url": "https://transport.data.gouv.fr/datasets/offre-transport-du-reseau-txik-txak",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1533,7 +1707,8 @@
             "type": "url",
             "url": "https://app.mecatran.com/utw/ws/gtfsfeed/realtime/txiktxak?apiKey=0f64273f070b7d4621002040646e180d374e5373",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-transport-du-reseau-txik-txak"
+                "url": "https://transport.data.gouv.fr/datasets/offre-transport-du-reseau-txik-txak",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1543,7 +1718,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0031-0000/fluo-grand-est-rei-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-grand-reims-mobilites-communaute-urbaine-du-grand-reims"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-grand-reims-mobilites-communaute-urbaine-du-grand-reims",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1551,7 +1727,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/fluo-citura-reims-gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-grand-reims-mobilites-communaute-urbaine-du-grand-reims"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-grand-reims-mobilites-communaute-urbaine-du-grand-reims",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1561,7 +1738,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=gpso-rt",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-gpso-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-gpso-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1569,7 +1747,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=gpso-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-gpso-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-gpso-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1579,7 +1758,8 @@
             "url": "https://data.tours-metropole.fr/api/v2/catalog/datasets/horaires-temps-reel-gtfsrt-reseau-filbleu-tmvl/alternative_exports/filbleu_gtfszip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fil-bleu-syndicat-des-mobilites-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/fil-bleu-syndicat-des-mobilites-gtfs-gtfs-rt",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1587,7 +1767,8 @@
             "type": "url",
             "url": "https://data.filbleu.fr/ws-tr/gtfs-rt/opendata/trip-updates",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fil-bleu-syndicat-des-mobilites-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/fil-bleu-syndicat-des-mobilites-gtfs-gtfs-rt",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1597,7 +1778,8 @@
             "url": "https://chouette.enroute.mobi/api/v1/datas/Irigo/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/angers-loire-metropole-reseau-irigo-gtfs-gtfs-rt-siri"
+                "url": "https://transport.data.gouv.fr/datasets/angers-loire-metropole-reseau-irigo-gtfs-gtfs-rt-siri",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1605,7 +1787,8 @@
             "type": "url",
             "url": "https://ara-api.enroute.mobi/irigo/gtfs/trip-updates",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/angers-loire-metropole-reseau-irigo-gtfs-gtfs-rt-siri"
+                "url": "https://transport.data.gouv.fr/datasets/angers-loire-metropole-reseau-irigo-gtfs-gtfs-rt-siri",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1615,7 +1798,8 @@
             "url": "https://opendata.clermontmetropole.eu/api/v2/catalog/datasets/gtfs-smtc/alternative_exports/gtfs",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/syndicat-mixte-des-transports-en-commun-de-lagglomeration-clermontoise-smtc-ac-reseau-t2c-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/syndicat-mixte-des-transports-en-commun-de-lagglomeration-clermontoise-smtc-ac-reseau-t2c-gtfs-gtfs-rt",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1623,7 +1807,8 @@
             "type": "url",
             "url": "https://opendata.clermontmetropole.eu/explore/dataset/gtfsrt_tripupdates/files/2c6b5c63d7be78905779d28500e6ab7e/download/",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/syndicat-mixte-des-transports-en-commun-de-lagglomeration-clermontoise-smtc-ac-reseau-t2c-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/syndicat-mixte-des-transports-en-commun-de-lagglomeration-clermontoise-smtc-ac-reseau-t2c-gtfs-gtfs-rt",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1633,7 +1818,8 @@
             "url": "https://chouette.enroute.mobi/api/v1/datas/keolis_orleans.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-et-gtfs-rt-reseau-tao-orleans-metropole-1"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-et-gtfs-rt-reseau-tao-orleans-metropole-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1641,7 +1827,8 @@
             "type": "url",
             "url": "https://ara-api.enroute.mobi/tao/gtfs/trip-updates",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-et-gtfs-rt-reseau-tao-orleans-metropole-1"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-et-gtfs-rt-reseau-tao-orleans-metropole-1",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1650,10 +1837,11 @@
             "type": "http",
             "url": "https://data.orleans-metropole.fr/api/v2/catalog/datasets/om-mobilite-tao-tad-gtfsflex/attachments/gtfs_flex_stopsupdated_zip",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/description-de-loffre-tad-tao-gtfs-flex-orleans-metropole"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/description-de-loffre-tad-tao-gtfs-flex-orleans-metropole",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "fr-200052264-t0014-0000-1",
@@ -1661,7 +1849,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0014-0000/fluo-grand-est-sitram-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0014-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0014-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1670,7 +1859,8 @@
             "url": "https://eu.ftp.opendatasoft.com/mulhouse/TRANSPORT_GTFS/SOLEA.GTFS_current.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-solea-et-tram-train-en-format-gtfs-1"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-solea-et-tram-train-en-format-gtfs-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1679,34 +1869,89 @@
             "url": "https://static.data.gouv.fr/resources/reseau-de-transport-en-commun-lia-gtfs-siri/20250310-103446/lia-2025-03-10-06-29.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-en-commun-lia-gtfs-siri"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-en-commun-lia-gtfs-siri",
+                "spdx-identifier": "ODbL-1.0"
             }
+        },
+        {
+            "name": "reseau-de-transport-en-commun-lia-gtfs-siri",
+            "type": "url",
+            "url": "https://gtfs.bus-tracker.fr/gtfs-rt/lia/trip-updates",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-en-commun-lia-gtfs-siri",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "spec": "gtfs-rt"
         },
         {
             "name": "caen-la-mer-reseau-twisto-gtfs-siri",
             "type": "http",
             "url": "https://twisto.opendatasoft.com/api/v2/catalog/datasets/fichier-gtfs-du-reseau-twisto/alternative_exports/gtfs_twisto_zip",
             "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/caen-la-mer-reseau-twisto-gtfs-siri",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "skip": true
+        },
+        {
+            "name": "caen-la-mer-reseau-twisto-gtfs-siri",
+            "type": "url",
+            "url": "https://gtfs.bus-tracker.fr/gtfs-rt/twisto",
             "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/caen-la-mer-reseau-twisto-gtfs-siri"
+                "url": "https://transport.data.gouv.fr/datasets/caen-la-mer-reseau-twisto-gtfs-siri",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "gtfs-sankeo--82900",
+            "type": "http",
+            "url": "https://eur.mecatran.com/utw/ws/gtfsfeed/static/perpignan?apiKey=612f606b5e3b0a3e6e1f441a2c4a050f6a345b55",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-sankeo",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
-            "name": "gtfs-sankeo",
+            "name": "gtfs-sankeo--82902",
+            "type": "http",
+            "url": "https://static.data.gouv.fr/resources/gtfs-sankeo/20241209-122638/gtfs-sankeo-ls.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-sankeo",
+                "spdx-identifier": "etalab-2.0"
+            }
+        },
+        {
+            "name": "gtfs-sankeo--82903",
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/gtfs-sankeo/20250318-094439/gtfs-sankeo.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-sankeo"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-sankeo",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
-            "name": "gtfs-sankeo",
+            "name": "gtfs-sankeo--82902",
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?src=true&dataset=sankeo-scolaire",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-sankeo"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-sankeo",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "gtfs-sankeo--82900",
+            "type": "url",
+            "url": "https://eur.mecatran.com/utw/ws/gtfsfeed/realtime/perpignan?apiKey=612f606b5e3b0a3e6e1f441a2c4a050f6a345b55",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-sankeo",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1716,7 +1961,8 @@
             "url": "https://hstan.g-ny.eu/gtfs/gtfs_stan.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-du-reseau-stan-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-du-reseau-stan-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1725,16 +1971,18 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0039-0000/fluo-grand-est-lesub-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0039-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0039-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
             "name": "offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt/20250224-070605/gtfs-production.zip",
+            "url": "https://static.data.gouv.fr/resources/offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt/20250331-080920/gtfs-production.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1742,17 +1990,19 @@
             "type": "url",
             "url": "http://185.220.72.38:8085/ProfilGtfsRt2_0RSProducer-TANGO/TripUpdate.pb",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
         {
             "name": "gtfs-diviamobilites",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/gtfs-diviamobilites/20250320-155534/gtfs-diviamobilites-current.zip",
+            "url": "https://static.data.gouv.fr/resources/gtfs-diviamobilites/20250404-125756/gtfs-diviamobilites-current.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-diviamobilites"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-diviamobilites",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1760,7 +2010,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/divia-dijon-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-diviamobilites"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-diviamobilites",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1770,7 +2021,8 @@
             "url": "https://data.lemet.fr/documents/LEMET-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fichiers-gtfs-eurometropole-de-metz"
+                "url": "https://transport.data.gouv.fr/datasets/fichiers-gtfs-eurometropole-de-metz",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1778,17 +2030,19 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/lemet-metz-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fichiers-gtfs-eurometropole-de-metz"
+                "url": "https://transport.data.gouv.fr/datasets/fichiers-gtfs-eurometropole-de-metz",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
         {
             "name": "eveole-douai-reseau-bus-du-syndicat-mixte-des-transports-du-douaisis-smtd",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/eveole-douai-reseau-bus-du-syndicat-mixte-des-transports-du-douaisis-smtd/20241118-092450/gtfs.zip",
+            "url": "https://static.data.gouv.fr/resources/eveole-douai-reseau-bus-du-syndicat-mixte-des-transports-du-douaisis-smtd/20250410-135307/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/eveole-douai-reseau-bus-du-syndicat-mixte-des-transports-du-douaisis-smtd"
+                "url": "https://transport.data.gouv.fr/datasets/eveole-douai-reseau-bus-du-syndicat-mixte-des-transports-du-douaisis-smtd",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1797,7 +2051,8 @@
             "url": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/bibus/exports/medias.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-bus-et-tramways-circulant-sur-le-territoire-de-brest-metropole"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-bus-et-tramways-circulant-sur-le-territoire-de-brest-metropole",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1805,7 +2060,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/bibus-brest-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-bus-et-tramways-circulant-sur-le-territoire-de-brest-metropole"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-bus-et-tramways-circulant-sur-le-territoire-de-brest-metropole",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1815,7 +2071,8 @@
             "url": "https://static.data.gouv.fr/resources/horaire-du-reseau-citalis/20250318-122311/gtfs-citalis-bus.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaire-du-reseau-citalis"
+                "url": "https://transport.data.gouv.fr/datasets/horaire-du-reseau-citalis",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1824,16 +2081,18 @@
             "url": "https://static.data.gouv.fr/resources/citalis-telepherique-papang/20250319-112904/pap1-gtfs-2024-12-01-2026-01-01.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/citalis-telepherique-papang"
+                "url": "https://transport.data.gouv.fr/datasets/citalis-telepherique-papang",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
             "name": "offre-de-transports-sibra-a-annecy-gtfs",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/offre-de-transports-sibra-a-annecy-gtfs/20250207-143508/gtfs-sibra.zip",
+            "url": "https://static.data.gouv.fr/resources/offre-de-transports-sibra-a-annecy-gtfs/20250402-125246/gtfs-sibra.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-sibra-a-annecy-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-sibra-a-annecy-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1842,7 +2101,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_limoges_metropole-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lim-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lim-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1851,7 +2111,8 @@
             "url": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/rdla-lorient/exports/medias.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-izilo-format-gtfs-de-lorient-agglomeration"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-izilo-format-gtfs-de-lorient-agglomeration",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1859,7 +2120,8 @@
             "type": "url",
             "url": "https://feed-rdla-lorient.ratpdev.com/GTFS-RT",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-izilo-format-gtfs-de-lorient-agglomeration"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-izilo-format-gtfs-de-lorient-agglomeration",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1869,7 +2131,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=caee",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-paris-saclay-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-paris-saclay-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -1877,7 +2140,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=caee",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-paris-saclay-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-paris-saclay-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1887,7 +2151,8 @@
             "url": "https://api.ginko.voyage/gtfs-ginko.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-et-siri-du-reseau-ginko-besancon-lignes-urbaines-et-periurbaines"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-et-siri-du-reseau-ginko-besancon-lignes-urbaines-et-periurbaines",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1896,7 +2161,8 @@
             "url": "https://static.data.gouv.fr/resources/ce-jeu-de-donnees-contient-la-liste-des-arrets-des-horaires-et-des-parcours-theoriques-du-reseau-de-transport-urbain-et-interurbain-de-vrm/20250304-144859/inter-mars2025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/ce-jeu-de-donnees-contient-la-liste-des-arrets-des-horaires-et-des-parcours-theoriques-du-reseau-de-transport-urbain-et-interurbain-de-vrm"
+                "url": "https://transport.data.gouv.fr/datasets/ce-jeu-de-donnees-contient-la-liste-des-arrets-des-horaires-et-des-parcours-theoriques-du-reseau-de-transport-urbain-et-interurbain-de-vrm",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1905,16 +2171,18 @@
             "url": "https://static.data.gouv.fr/resources/offre-de-transports-reseau-dk-bus-de-la-communaute-urbaine-de-dunkerque-gtfs/20250314-070752/gtfs-20250313-142150-dkbus.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-reseau-dk-bus-de-la-communaute-urbaine-de-dunkerque-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-reseau-dk-bus-de-la-communaute-urbaine-de-dunkerque-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
             "name": "gtfs-du-reseau-des-transports-bus-et-tramway-setram-circulant-sur-le-territoire-le-mans-metropole",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/gtfs-du-reseau-des-transports-bus-et-tramway-setram-circulant-sur-le-territoire-le-mans-metropole/20250319-224025/gtfs-setram-lmm.zip",
+            "url": "https://static.data.gouv.fr/resources/gtfs-du-reseau-des-transports-bus-et-tramway-setram-circulant-sur-le-territoire-le-mans-metropole/20250404-110637/gtfs-setram-lmm.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-des-transports-bus-et-tramway-setram-circulant-sur-le-territoire-le-mans-metropole"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-des-transports-bus-et-tramway-setram-circulant-sur-le-territoire-le-mans-metropole",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1922,7 +2190,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/setram-lemans-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-des-transports-bus-et-tramway-setram-circulant-sur-le-territoire-le-mans-metropole"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-des-transports-bus-et-tramway-setram-circulant-sur-le-territoire-le-mans-metropole",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -1932,7 +2201,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0040-0000/fluo-grand-est-citeline-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0040-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0040-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1941,7 +2211,8 @@
             "url": "https://static.data.gouv.fr/resources/horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin/20250204-085856/gtfs-capcotentin-03022025-au-29062025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1950,7 +2221,8 @@
             "url": "https://static.data.gouv.fr/resources/horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin/20240919-100419/lr-capcotentin-cherbourg-rennes-sept24.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1959,7 +2231,8 @@
             "url": "https://data.idelis.fr/api/explore/v2.1/catalog/datasets/fichier-des-donnees-theoriques-du-reseau-scolaris-au-format-gtfs/files/b2d11deac94e5271d88cef3ece50b3ac",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fichier-des-donnees-theoriques-du-reseau-scolaris-au-format-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/fichier-des-donnees-theoriques-du-reseau-scolaris-au-format-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1968,7 +2241,8 @@
             "url": "https://data.idelis.fr/api/explore/v2.1/catalog/datasets/fichier-des-donnees-theoriques-du-reseau-idelis-au-format-gtfs/files/400d7da94eaacb5e52c612f8ac28e420",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fichier-des-donnees-theoriques-du-reseau-idelis-au-format-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/fichier-des-donnees-theoriques-du-reseau-idelis-au-format-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1976,18 +2250,20 @@
             "type": "http",
             "url": "https://open-share.agglo-casa.fr/s/34FS2SWg36NEZk4/download",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-bus-du-reseau-des-transports-publics-envibus"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-bus-du-reseau-des-transports-publics-envibus",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "skip": true
         },
         {
             "name": "ametis",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/ametis/20250120-103255/sae-du-01-01-2025-au-04-07-2025.zip",
+            "url": "https://static.data.gouv.fr/resources/ametis/20250407-090100/sae-du-01-01-2025-au-04-07-2025-2-.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/ametis"
+                "url": "https://transport.data.gouv.fr/datasets/ametis",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -1995,7 +2271,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/ametis-amiens-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/ametis"
+                "url": "https://transport.data.gouv.fr/datasets/ametis",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2005,7 +2282,8 @@
             "url": "https://data.grandpoitiers.fr/data-fair/api/v1/datasets/2gwvlq16siyb7d9m3rqt1pb1/metadata-attachments/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/mobilite-offre-de-transport-du-reseau-bus-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/mobilite-offre-de-transport-du-reseau-bus-gtfs-gtfs-rt",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2013,7 +2291,8 @@
             "type": "url",
             "url": "https://data.grandpoitiers.fr/data-fair/api/v1/datasets/2gwvlq16siyb7d9m3rqt1pb1/metadata-attachments/poitiers.pbf",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/mobilite-offre-de-transport-du-reseau-bus-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/mobilite-offre-de-transport-du-reseau-bus-gtfs-gtfs-rt",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2023,16 +2302,18 @@
             "url": "https://static.data.gouv.fr/resources/navettes-estivales-arzibus-2/20240604-104721/arzon-gtfs-20240604.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/navettes-estivales-arzibus-2"
+                "url": "https://transport.data.gouv.fr/datasets/navettes-estivales-arzibus-2",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
             "name": "reseau-urbain-kiceo",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/reseau-urbain-kiceo/20250321-095749/gtfs-20250321-102536-kiceo.zip",
+            "url": "https://static.data.gouv.fr/resources/reseau-urbain-kiceo/20250402-155359/gtfs-20250402-170303-kiceo.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-kiceo"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-kiceo",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2040,7 +2321,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/kiceo-vannes-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-kiceo"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-kiceo",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2050,7 +2332,8 @@
             "url": "https://static.data.gouv.fr/resources/donnees-tcat-troyes-champagne-metropole-1/20250220-092552/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-tcat-troyes-champagne-metropole-1"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-tcat-troyes-champagne-metropole-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2058,17 +2341,19 @@
             "type": "url",
             "url": "http://94.143.218.42:13485/ProfilGtfsRt2_0RSProducer-TCAT/TripUpdate.pb",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-tcat-troyes-champagne-metropole-1"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-tcat-troyes-champagne-metropole-1",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
         {
             "name": "arrets-circuits-et-horaires-du-reseau-optymo-de-belfort",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/arrets-circuits-et-horaires-du-reseau-optymo-de-belfort/20250311-133655/gtfs.zip",
+            "url": "https://static.data.gouv.fr/resources/arrets-circuits-et-horaires-du-reseau-optymo-de-belfort/20250409-122209/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-circuits-et-horaires-du-reseau-optymo-de-belfort"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-circuits-et-horaires-du-reseau-optymo-de-belfort",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2077,7 +2362,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_la_rochelle-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lro-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lro-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2086,16 +2372,18 @@
             "url": "https://exs.tcra2.cityway.fr/gtfs.aspx?key=UID&operatorCode=TCRA",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-et-gtfs-rt-reseau-orizo-grand-avignon"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-et-gtfs-rt-reseau-orizo-grand-avignon",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
             "name": "horaires-theoriques-et-temps-reel-gtfs-gtfs-rt-du-reseau-palmbus-cannes-pays-de-lerins",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/horaires-theoriques-et-temps-reel-gtfs-gtfs-rt-du-reseau-palmbus-cannes-pays-de-lerins/20250319-094107/palmbus-cannes-fr.zip",
+            "url": "https://static.data.gouv.fr/resources/horaires-theoriques-et-temps-reel-gtfs-gtfs-rt-du-reseau-palmbus-cannes-pays-de-lerins/20250411-063300/palmbus-cannes-fr.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-gtfs-gtfs-rt-du-reseau-palmbus-cannes-pays-de-lerins"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-gtfs-gtfs-rt-du-reseau-palmbus-cannes-pays-de-lerins",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2103,7 +2391,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/palmbus-cannes-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-gtfs-gtfs-rt-du-reseau-palmbus-cannes-pays-de-lerins"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-gtfs-gtfs-rt-du-reseau-palmbus-cannes-pays-de-lerins",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2113,7 +2402,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-taneo-1/20250214-064628/gtfs-lot1-20250217-20251231.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-taneo-1"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-taneo-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2122,7 +2412,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-du-reseau-de-transports-publics-de-saint-brieuc-armor-agglomeration/20250206-135925/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-de-transports-publics-de-saint-brieuc-armor-agglomeration"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-de-transports-publics-de-saint-brieuc-armor-agglomeration",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2131,7 +2422,8 @@
             "url": "https://static.data.gouv.fr/resources/agence-agglobus/20240409-130220/agglobus-peri-urbain-2024-gtfs-2023-12-18-11-51-29.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/agence-agglobus"
+                "url": "https://transport.data.gouv.fr/datasets/agence-agglobus",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2140,7 +2432,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-cacl-agglobus/20241008-124211/monbus-matoury-gf.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-cacl-agglobus"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-cacl-agglobus",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2149,7 +2442,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-cacl-agglobus/20241008-124301/monbus-matoury-gf.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-cacl-agglobus"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-cacl-agglobus",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2158,7 +2452,8 @@
             "url": "https://mwe.mecatran.com/utw/ws/gtfsfeed/static/chambery?apiKey=223f2f102c1242570d3f0231326a271940774f72&type=gtfs_urbain",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-et-horaires-theoriques-bus-temps-reel"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-et-horaires-theoriques-bus-temps-reel",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2166,7 +2461,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/synchrobus-chambery-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-et-horaires-theoriques-bus-temps-reel"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-et-horaires-theoriques-bus-temps-reel",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2176,7 +2472,8 @@
             "url": "https://static.data.gouv.fr/resources/horaires-theoriques-et-temps-reel-reseau-mobius/20240912-073113/gtfs-mobius-hiver24-25-20240826-tad.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-reseau-mobius"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-reseau-mobius",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2184,17 +2481,19 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/mobius-angouleme",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-reseau-mobius"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-reseau-mobius",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
         {
             "name": "evolity-horaires-theoriques-de-transport-public",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/evolity-horaires-theoriques-de-transport-public/20250310-071258/evolity-10-03-2025-au-14-07-2025.zip",
+            "url": "https://static.data.gouv.fr/resources/evolity-horaires-theoriques-de-transport-public/20250324-130121/evolity-21-03-2025-au-14-07-2025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/evolity-horaires-theoriques-de-transport-public"
+                "url": "https://transport.data.gouv.fr/datasets/evolity-horaires-theoriques-de-transport-public",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2203,7 +2502,8 @@
             "url": "https://static.data.gouv.fr/resources/syndicat-mixte-des-transports-du-petit-cul-de-sac-marin/20250121-172441/gtfs-smtpcsm-2025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/syndicat-mixte-des-transports-du-petit-cul-de-sac-marin"
+                "url": "https://transport.data.gouv.fr/datasets/syndicat-mixte-des-transports-du-petit-cul-de-sac-marin",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2212,7 +2512,8 @@
             "url": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/rd-laval/exports/gtfs-complet-orchestra-issu-d-hastus.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-de-laval-agglomeration-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-de-laval-agglomeration-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2221,7 +2522,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-illygo/20250319-175852/gtfs-hordbord-174313-illygo.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-illygo"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-illygo",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2229,17 +2531,19 @@
             "type": "url",
             "url": "https://pysae.com/api/v2/groups/illygo/gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-illygo"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-illygo",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
         {
             "name": "filibus-urbain",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/filibus-urbain/20240729-125753/chartres.zip",
+            "url": "https://static.data.gouv.fr/resources/filibus-urbain/20250401-151135/chartres-ete25.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/filibus-urbain"
+                "url": "https://transport.data.gouv.fr/datasets/filibus-urbain",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2248,16 +2552,18 @@
             "url": "https://exs.mlt4.cityway.fr/gtfs.aspx?operatorCode=BOURG&key=OPENDATA",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/rubis-horaires-theoriques-du-reseau-de-transport-urbain-de-grand-bourg-agglomeration"
+                "url": "https://transport.data.gouv.fr/datasets/rubis-horaires-theoriques-du-reseau-de-transport-urbain-de-grand-bourg-agglomeration",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
             "name": "horaires-theoriques-des-lignes-urbaines-et-interurbaines-sur-le-reseau-alesy-gtfs",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/horaires-theoriques-des-lignes-urbaines-et-interurbaines-sur-le-reseau-alesy-gtfs/20250224-102506/gtfs-is-20250224.zip",
+            "url": "https://static.data.gouv.fr/resources/horaires-theoriques-des-lignes-urbaines-et-interurbaines-sur-le-reseau-alesy-gtfs/20250407-080507/gtfs-is-20250407.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-des-lignes-urbaines-et-interurbaines-sur-le-reseau-alesy-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-des-lignes-urbaines-et-interurbaines-sur-le-reseau-alesy-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2265,7 +2571,8 @@
             "type": "url",
             "url": "https://alesy.plateforme-2cloud.com/api/gtfsrt/tripupdates/ALESY-6574-4401-7572/bin",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-des-lignes-urbaines-et-interurbaines-sur-le-reseau-alesy-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-des-lignes-urbaines-et-interurbaines-sur-le-reseau-alesy-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2275,16 +2582,18 @@
             "url": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/narbonne/exports/scolaires-sans-tad.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-communaute-dagglomeration-le-grand-narbonne"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-communaute-dagglomeration-le-grand-narbonne",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
             "name": "arrets-horaires-et-parcours-theoriques-du-reseau-de-transports-beemob-beziers-mediterranee",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/arrets-horaires-et-parcours-theoriques-du-reseau-de-transports-beemob-beziers-mediterranee/20250224-170524/beziers-2025-pvssco-export-gtfs.zip",
+            "url": "https://static.data.gouv.fr/resources/arrets-horaires-et-parcours-theoriques-du-reseau-de-transports-beemob-beziers-mediterranee/20250407-075843/gtfs-31-03-2025-05-02.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-du-reseau-de-transports-beemob-beziers-mediterranee"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-du-reseau-de-transports-beemob-beziers-mediterranee",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2293,7 +2602,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0002-0000/fluo-grand-est-chm-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0002-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0002-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2301,17 +2611,19 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/fluo-tac-ardenne-gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0002-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0002-0000-1",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
         {
             "name": "transurbain-evreux-portes-de-normandie",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/transurbain-evreux-portes-de-normandie/20241107-121332/pt-th-offer-transurbain-gtfs-20241107-647-opendata.zip",
+            "url": "https://static.data.gouv.fr/resources/transurbain-evreux-portes-de-normandie/20250331-132033/pt-th-offer-transurbain-gtfs-20250331-619-opendata.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/transurbain-evreux-portes-de-normandie"
+                "url": "https://transport.data.gouv.fr/datasets/transurbain-evreux-portes-de-normandie",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2319,7 +2631,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/transurbain-evreux-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/transurbain-evreux-portes-de-normandie"
+                "url": "https://transport.data.gouv.fr/datasets/transurbain-evreux-portes-de-normandie",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2329,7 +2642,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_du_niortais-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-nio-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-nio-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2338,7 +2652,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-3/20241125-093438/gtfs-20241024-172839.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-3"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-3",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2346,7 +2661,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=tlp-mobilites",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-3"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-3",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2356,7 +2672,8 @@
             "url": "https://drive.google.com/uc?export=download&id=1JPmGimO4tfQpzL8A0ixYnYrPDehYILWn",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-bus-sete-agglopole-mobilite"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-bus-sete-agglopole-mobilite",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2364,7 +2681,8 @@
             "type": "url",
             "url": "https://sete.ceccli.com/gtfs/TripUpdates.pb",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-bus-sete-agglopole-mobilite"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-bus-sete-agglopole-mobilite",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2374,7 +2692,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-rtca/20250130-162650/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-rtca"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-rtca",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2383,7 +2702,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0004-0000/fluo-grand-est-cac-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0004-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0004-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2392,7 +2712,8 @@
             "url": "https://data.centrevaldeloire.fr/api/explore/v2.1/catalog/datasets/dreux-offre-theorique-mobilite-reseau-urbain/files/5c88b6c9cc1968f8d2e8a6b48ab13117",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/dreux-offre-theorique-mobilite-reseau-urbain"
+                "url": "https://transport.data.gouv.fr/datasets/dreux-offre-theorique-mobilite-reseau-urbain",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2401,7 +2722,8 @@
             "url": "https://data.centrevaldeloire.fr/api/explore/v2.1/catalog/datasets/agglobus-offre-theorique-mobilite-reseau-urbain-de-bourges/files/03b395ff43085db427c8f51d83e88643",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/agglobus-offre-theorique-mobilite-reseau-urbain-de-bourges"
+                "url": "https://transport.data.gouv.fr/datasets/agglobus-offre-theorique-mobilite-reseau-urbain-de-bourges",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2410,7 +2732,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0009-0000/fluo-grand-est-imagine-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0009-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0009-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2419,7 +2742,8 @@
             "url": "https://static.data.gouv.fr/resources/horaires-theoriques-du-reseau-zoom-le-grand-chalon/20241224-111818/gtfs-20241223-163822-stac.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-zoom-le-grand-chalon"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-zoom-le-grand-chalon",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2428,7 +2752,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_bassin_de_brive-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-bri-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-bri-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2437,7 +2762,8 @@
             "url": "https://static.data.gouv.fr/resources/horaires-theoriques-et-temps-reel-au-format-gtfs-et-gtfs-rt-du-reseau-sitac/20241205-144727/gtfs-20241121-113331-1.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-aux-formats-gtfs-et-gtfs-rt-du-reseau-sitac"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-aux-formats-gtfs-et-gtfs-rt-du-reseau-sitac",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2445,7 +2771,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=sitac-calais-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-aux-formats-gtfs-et-gtfs-rt-du-reseau-sitac"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-aux-formats-gtfs-et-gtfs-rt-du-reseau-sitac",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2455,7 +2782,8 @@
             "url": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/boulogne/exports/medias.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-de-transport-marineo"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-de-transport-marineo",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2463,7 +2791,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/marineo-boulonnais-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-de-transport-marineo"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-de-transport-marineo",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2473,7 +2802,8 @@
             "url": "https://static.data.gouv.fr/resources/donnees-transport-du-reseau-artis/20240826-144255/gtfs-20240826-155116.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-transport-du-reseau-artis"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-transport-du-reseau-artis",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2482,7 +2812,8 @@
             "url": "https://www.datasud.fr/fr/dataset/datasets/1760/resource/2210/download/",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/tedbus-horaires-des-lignes-reseau"
+                "url": "https://transport.data.gouv.fr/datasets/tedbus-horaires-des-lignes-reseau",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2490,7 +2821,8 @@
             "type": "url",
             "url": "https://pysae.com/api/v2/groups/draguignan/gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/tedbus-horaires-des-lignes-reseau"
+                "url": "https://transport.data.gouv.fr/datasets/tedbus-horaires-des-lignes-reseau",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2500,7 +2832,8 @@
             "url": "https://www.itinisere.fr/fr/donnees-open-data/169/OpenData/Download?fileName=CAPI.GTFS.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-ruban"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-ruban",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2509,7 +2842,8 @@
             "url": "https://static.data.gouv.fr/resources/navettes-de-loire-forez-agglomeration/20240917-095003/navettes-urbaines-lfa.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/navettes-de-loire-forez-agglomeration"
+                "url": "https://transport.data.gouv.fr/datasets/navettes-de-loire-forez-agglomeration",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2518,7 +2852,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-du-reseau-maritime-de-martinique/20250210-130113/gtfs-maritime-bluelines.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-maritime-de-martinique"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-maritime-de-martinique",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2527,7 +2862,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-du-transport-scolaire-en-martinique/20250228-161358/gtfs-scolaire-mt.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-du-transport-scolaire-en-martinique"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-du-transport-scolaire-en-martinique",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2536,7 +2872,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-urbain-de-la-zone-centre/20250227-133546/gtfs-centre-rtm.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-urbain-de-la-zone-centre"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-urbain-de-la-zone-centre",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2545,7 +2882,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-urbain-de-la-zone-nord-cap-nord/20241230-194554/gtfs-nord-rtm.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-urbain-de-la-zone-nord-cap-nord"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-urbain-de-la-zone-nord-cap-nord",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2554,7 +2892,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-urbain-de-la-zone-sud/20241106-151027/gtfs-sud-sudlib.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-urbain-de-la-zone-sud"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-urbain-de-la-zone-sud",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2563,7 +2902,8 @@
             "url": "https://static.data.gouv.fr/resources/horaires-theoriques-reseau-choletbus/20250312-093200/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-reseau-choletbus"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-reseau-choletbus",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2571,7 +2911,8 @@
             "type": "url",
             "url": "https://app.mecatran.com/utw/ws/gtfsfeed/realtime/choletbus?apiKey=0b0f0b6035007b7f1243311973401c294e6a0143",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-reseau-choletbus"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-reseau-choletbus",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2580,10 +2921,11 @@
             "type": "http",
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=COROLIS_INT&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-corolis-interurbain-communaute-dagglomeration-du-beauvaisis"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-corolis-interurbain-communaute-dagglomeration-du-beauvaisis",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-corolis-interurbain-communaute-dagglomeration-du-beauvaisis",
@@ -2591,7 +2933,8 @@
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=COROLIS_INT&dataFormat=gtfs-rt",
             "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-corolis-interurbain-communaute-dagglomeration-du-beauvaisis"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-corolis-interurbain-communaute-dagglomeration-du-beauvaisis",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2600,10 +2943,11 @@
             "type": "http",
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=COROLIS_URB&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-corolis-urbain-communaute-dagglomeration-du-beauvaisis"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-corolis-urbain-communaute-dagglomeration-du-beauvaisis",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-corolis-urbain-communaute-dagglomeration-du-beauvaisis",
@@ -2611,7 +2955,8 @@
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=COROLIS_URB&dataFormat=gtfs-rt",
             "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-corolis-urbain-communaute-dagglomeration-du-beauvaisis"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-corolis-urbain-communaute-dagglomeration-du-beauvaisis",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2621,7 +2966,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=quimper",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-quimper-bretagne-occidentale-qub-city-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-quimper-bretagne-occidentale-qub-city-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2629,7 +2975,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=quimper",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-quimper-bretagne-occidentale-qub-city-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-quimper-bretagne-occidentale-qub-city-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2639,7 +2986,8 @@
             "url": "https://static.data.gouv.fr/resources/horaires-et-lignes-de-bus-du-reseau-qub-transports-urbains-de-quimper-bretagne-occidentale/20250113-080126/gtfs-qub-du-06-01-au-31-08-25.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-et-lignes-de-bus-du-reseau-qub-transports-urbains-de-quimper-bretagne-occidentale"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-et-lignes-de-bus-du-reseau-qub-transports-urbains-de-quimper-bretagne-occidentale",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2648,7 +2996,8 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/TILT.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/tilt-lannion-tregor-communaute"
+                "url": "https://transport.data.gouv.fr/datasets/tilt-lannion-tregor-communaute",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2656,7 +3005,8 @@
             "type": "url",
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/gtfsrt/TILT.GtfsRt.pb",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/tilt-lannion-tregor-communaute"
+                "url": "https://transport.data.gouv.fr/datasets/tilt-lannion-tregor-communaute",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2666,7 +3016,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_grand_perigueux-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-per-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-per-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2675,7 +3026,8 @@
             "url": "https://exs.mlt4.cityway.fr/gtfs.aspx?operatorCode=ROANNE&key=OPENDATA",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/star-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-roannais-agglomeration"
+                "url": "https://transport.data.gouv.fr/datasets/star-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-roannais-agglomeration",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2683,7 +3035,8 @@
             "type": "url",
             "url": "https://api.mlt4.cityway.fr/dataflow/horaire-tr/download?provider=ROANNE&dataFormat=GTFS-RT&dataProfil=OPENDATA",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/star-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-roannais-agglomeration"
+                "url": "https://transport.data.gouv.fr/datasets/star-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-roannais-agglomeration",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2693,7 +3046,8 @@
             "url": "https://static.data.gouv.fr/resources/lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire/20240823-101105/grasse-scolaire.gtfs-5-.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire"
+                "url": "https://transport.data.gouv.fr/datasets/lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2702,7 +3056,8 @@
             "url": "https://static.data.gouv.fr/resources/lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire/20240823-101208/grasse-urbain.gtfs-2-.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire"
+                "url": "https://transport.data.gouv.fr/datasets/lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2711,7 +3066,8 @@
             "url": "https://static.data.gouv.fr/resources/semo-val-de-reuil-louviers-seine-eure-agglo/20240919-070710/pt-th-offer-semo-gtfs-20240918-649-opendata.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/semo-val-de-reuil-louviers-seine-eure-agglo"
+                "url": "https://transport.data.gouv.fr/datasets/semo-val-de-reuil-louviers-seine-eure-agglo",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2720,7 +3076,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-dinamo/20241220-161156/gtfs-20241220-170740-dinamo.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-dinamo"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-dinamo",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2729,7 +3086,8 @@
             "url": "https://static.data.gouv.fr/resources/transports-publics-urbains-sur-le-territoire-de-la-ca-du-pays-de-gex-1/20250115-151914/gtfs-2025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/transports-publics-urbains-sur-le-territoire-de-la-ca-du-pays-de-gex-1"
+                "url": "https://transport.data.gouv.fr/datasets/transports-publics-urbains-sur-le-territoire-de-la-ca-du-pays-de-gex-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2738,7 +3096,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=haguenau",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-ritmo-haguenau-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-ritmo-haguenau-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2746,7 +3105,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=haguenau",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-ritmo-haguenau-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-ritmo-haguenau-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2756,7 +3116,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0008-0000/fluo-grand-est-haguenau-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0008-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0008-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2765,7 +3126,8 @@
             "url": "https://data.centrevaldeloire.fr/api/explore/v2.1/catalog/datasets/agglopolys-offre-theorique-mobilite-reseau-urbain-blois/files/af673e7cbb43033c60c117ddf5f4ecaa",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/agglopolys-offre-theorique-mobilite-reseau-urbain-azalys-de-blois"
+                "url": "https://transport.data.gouv.fr/datasets/agglopolys-offre-theorique-mobilite-reseau-urbain-azalys-de-blois",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2774,7 +3136,8 @@
             "url": "https://mobi-iti-pdl.okina.fr/static/mobiiti_saumur_val_de_loire/gtfs_imported-id_saumur.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/lignes-arrets-et-horaires-theorique-du-reseau-de-transport-gtfs-netex-saumur-val-de-loire-agglomeration"
+                "url": "https://transport.data.gouv.fr/datasets/lignes-arrets-et-horaires-theorique-du-reseau-de-transport-gtfs-netex-saumur-val-de-loire-agglomeration",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2783,7 +3146,8 @@
             "url": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/impulsyon/exports/medias.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-impulsyon-a-la-roche-sur-yon"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-impulsyon-a-la-roche-sur-yon",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2792,7 +3156,8 @@
             "url": "https://www.datasud.fr/fr/dataset/datasets/1311/resource/5230/download/",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-transport-mouv-enbus-agglomeration-provence-verte"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-transport-mouv-enbus-agglomeration-provence-verte",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2801,7 +3166,8 @@
             "url": "https://static.data.gouv.fr/resources/referentiel-topologique-reseau-carsud/20250131-070837/gtfs-carsud-31012025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/referentiel-topologique-reseau-carsud"
+                "url": "https://transport.data.gouv.fr/datasets/referentiel-topologique-reseau-carsud",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2809,7 +3175,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?src=true&dataset=carsud-reunion",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/referentiel-topologique-reseau-carsud"
+                "url": "https://transport.data.gouv.fr/datasets/referentiel-topologique-reseau-carsud",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2819,7 +3186,8 @@
             "url": "https://static.data.gouv.fr/resources/agen-gtfs-scolaire/20250120-084344/agen-ggtfs-scolaire-rentree-janvier-2025-v3.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/agen-gtfs-scolaire"
+                "url": "https://transport.data.gouv.fr/datasets/agen-gtfs-scolaire",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2827,7 +3195,8 @@
             "type": "url",
             "url": "https://urldefense.com/v3/__https://zenbus.net/gtfs/rt/poll.proto?src=true&dataset=agen-scolaire__;!!GXVuaUlRqA!aP1rnhWBNoKP6uStLU2TfthgAipcY9qdn_A_68IeuGnuVnTxm-jRYTvXwJGm5Dbawfr9VBhW7Gx6bfpuE8Bd4PP5VhDwhtE$",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/agen-gtfs-scolaire"
+                "url": "https://transport.data.gouv.fr/datasets/agen-gtfs-scolaire",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2837,7 +3206,8 @@
             "url": "https://static.data.gouv.fr/resources/agen-gtfs-urbain/20250120-084401/agen-gtfs-urbain-travaux-janvier-2025-v4.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/agen-gtfs-urbain"
+                "url": "https://transport.data.gouv.fr/datasets/agen-gtfs-urbain",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2845,7 +3215,8 @@
             "type": "url",
             "url": "https://urldefense.com/v3/__https://zenbus.net/gtfs/rt/poll.proto?src=true&dataset=agen-urbain__;!!GXVuaUlRqA!aP1rnhWBNoKP6uStLU2TfthgAipcY9qdn_A_68IeuGnuVnTxm-jRYTvXwJGm5Dbawfr9VBhW7Gx6bfpuE8Bd4PP5glcwziM$",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/agen-gtfs-urbain"
+                "url": "https://transport.data.gouv.fr/datasets/agen-gtfs-urbain",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2855,7 +3226,8 @@
             "url": "https://static.data.gouv.fr/resources/agen-gtfs-tad/20250106-095241/agen-gtfs-tad-travaux-janvier-2025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/agen-gtfs-tad"
+                "url": "https://transport.data.gouv.fr/datasets/agen-gtfs-tad",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2864,7 +3236,8 @@
             "url": "https://static.data.gouv.fr/resources/thonon-agglomeration-donnees-gtfs/20241010-063850/2024.10.07.16-gtfs-start-2024-09-01-2025-04-30.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/thonon-agglomeration-donnees-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/thonon-agglomeration-donnees-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2873,7 +3246,8 @@
             "url": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/tp2a/exports/medias.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-reseau-tac-annemasse-agglo"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-reseau-tac-annemasse-agglo",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2881,7 +3255,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/tac-annemasse-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-reseau-tac-annemasse-agglo"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-reseau-tac-annemasse-agglo",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2891,7 +3266,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_du_libournais-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lib-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lib-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2900,7 +3276,8 @@
             "url": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/vienne-mobi/exports/medias.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-lva"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-lva",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -2908,7 +3285,8 @@
             "type": "url",
             "url": "https://feed-vienne-mobi.ratpdev.com/GTFS-RT/gtfs-rt.bin",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-lva"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-lva",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2918,7 +3296,8 @@
             "url": "https://static.data.gouv.fr/resources/information-sur-les-transports-en-commun/20250117-074102/gtfs-capa.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/information-sur-les-transports-en-commun"
+                "url": "https://transport.data.gouv.fr/datasets/information-sur-les-transports-en-commun",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2927,7 +3306,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-tac-2024-2025/20241231-135247/gtfs-tac-06012025-06072025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-tac-2024-2025"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-tac-2024-2025",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2935,7 +3315,8 @@
             "type": "url",
             "url": "https://grand-chatellerault.plateforme-2cloud.com/api/gtfsrt/2.0/tripupdates/GCH-0910-7677-1418/bin",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-tac-2024-2025"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-tac-2024-2025",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2945,7 +3326,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-mat/20250320-095822/gtfs-200325-du-20325-au-040725.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-mat"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-mat",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -2953,7 +3335,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/mat-saint-malo-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-mat"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-mat",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -2962,10 +3345,11 @@
             "type": "http",
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=AXO&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-axo-communaute-dagglomeration-creil-sud-oise"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-axo-communaute-dagglomeration-creil-sud-oise",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-axo-communaute-dagglomeration-creil-sud-oise",
@@ -2973,9 +3357,20 @@
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=AXO&dataFormat=gtfs-rt",
             "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-axo-communaute-dagglomeration-creil-sud-oise"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-axo-communaute-dagglomeration-creil-sud-oise",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
+        },
+        {
+            "name": "donnees-gtfs-du-reseau-de-transport-public-cara-bus",
+            "type": "http",
+            "url": "https://data.agglo-royan.fr/dataset/9b761974-a195-4e33-91b7-ecee3b368016/resource/d4915904-ebd0-43cf-9b35-fbfc04ce91fd/download/gtfs_20250320_171245_tdra.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/donnees-gtfs-du-reseau-de-transport-public-cara-bus",
+                "spdx-identifier": "etalab-2.0"
+            }
         },
         {
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-car-nva-m-1",
@@ -2983,25 +3378,18 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_royan_atlantique-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-car-nva-m-1"
-            }
-        },
-        {
-            "name": "donnees-gtfs-du-reseau-de-transport-public-cara-bus",
-            "type": "http",
-            "url": "https://data.agglo-royan.fr/dataset/9b761974-a195-4e33-91b7-ecee3b368016/resource/d4915904-ebd0-43cf-9b35-fbfc04ce91fd/download/gtfs_20240820_170804_tdra.zip",
-            "fix": true,
-            "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-gtfs-du-reseau-de-transport-public-cara-bus"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-car-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
             "name": "donnees-statiques-et-temps-reels-reseau-envia",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/donnees-statiques-et-temps-reels-reseau-envia/20250220-142835/gtfs-20250220-152157-1.zip",
+            "url": "https://static.data.gouv.fr/resources/donnees-statiques-et-temps-reels-reseau-envia/20250407-093835/gtfs-envia-20250407.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reels-reseau-envia"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reels-reseau-envia",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3009,7 +3397,8 @@
             "type": "url",
             "url": "https://accm.2cloud.app/api/gtfsrt/2.0/tripupdates/LUMIPLAN-2021-4815-1108/bin",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reels-reseau-envia"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reels-reseau-envia",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3019,7 +3408,8 @@
             "url": "https://static.data.gouv.fr/resources/mobivie-reseau-urbain-vichy-communaute/20240826-081451/gtfs-vichy-v20240801.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/mobivie-reseau-urbain-vichy-communaute"
+                "url": "https://transport.data.gouv.fr/datasets/mobivie-reseau-urbain-vichy-communaute",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3028,7 +3418,8 @@
             "url": "https://static.data.gouv.fr/resources/transports-en-commun-audomarois-1/20250305-161731/01-01-2025bis.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/transports-en-commun-audomarois-1"
+                "url": "https://transport.data.gouv.fr/datasets/transports-en-commun-audomarois-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3036,10 +3427,11 @@
             "type": "http",
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=TIC_INT&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tic-interurbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tic-interurbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-tic-interurbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
@@ -3047,7 +3439,8 @@
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=TIC_INT&dataFormat=gtfs-rt",
             "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tic-interurbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tic-interurbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3056,10 +3449,11 @@
             "type": "http",
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=TIC_URB&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tic-urbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tic-urbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-tic-urbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
@@ -3067,7 +3461,8 @@
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=TIC_URB&dataFormat=gtfs-rt",
             "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tic-urbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tic-urbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3077,7 +3472,8 @@
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=ALLOTIC&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-de-transport-a-la-demande-allotic-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-de-transport-a-la-demande-allotic-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3086,7 +3482,8 @@
             "url": "https://static.data.gouv.fr/resources/bus-pastel-saint-quentin-nouveaux-horaires-2025/20250109-113938/gtfs-20250103-154107-sqm.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/bus-pastel-saint-quentin"
+                "url": "https://transport.data.gouv.fr/datasets/bus-pastel-saint-quentin",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3095,7 +3492,8 @@
             "url": "https://exs.mlt4.cityway.fr/gtfs.aspx?operatorCode=TAM&key=OPENDATA",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/tam-horaires-theoriques-du-reseau-de-transport-urbain-sur-la-ville-damberieu-en-bugey"
+                "url": "https://transport.data.gouv.fr/datasets/tam-horaires-theoriques-du-reseau-de-transport-urbain-sur-la-ville-damberieu-en-bugey",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3104,7 +3502,8 @@
             "url": "https://www.datasud.fr/fr/dataset/datasets/1224/resource/4791/download/",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-transport-urbain-le-bus"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-transport-urbain-le-bus",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3113,7 +3512,8 @@
             "url": "https://static.data.gouv.fr/resources/donnees-gtfs-reseau-tuc-communaute-dagglomeration-de-cambrai/20241011-083124/rhdf-gtfs-cac-tuc-2024.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-gtfs-reseau-tuc-communaute-dagglomeration-de-cambrai"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-gtfs-reseau-tuc-communaute-dagglomeration-de-cambrai",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3122,7 +3522,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-de-la-societe-de-transport-urbain-du-grand-montauban-semtm/20241025-105206/gtfs-241024.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-de-la-societe-de-transport-urbain-du-grand-montauban-semtm"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-de-la-societe-de-transport-urbain-du-grand-montauban-semtm",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3131,7 +3532,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-de-la-societe-de-transport-urbain-du-grand-montauban-semtm/20241025-105649/gtfs-241024.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-de-la-societe-de-transport-urbain-du-grand-montauban-semtm"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-de-la-societe-de-transport-urbain-du-grand-montauban-semtm",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3140,7 +3542,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0005-0000/fluo-grand-est-cec-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0005-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0005-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3148,7 +3551,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/fluo-sitac-chalons-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0005-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0005-0000-1",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3158,7 +3562,8 @@
             "url": "https://static.data.gouv.fr/resources/arrets-horaires-et-parcours-theoriques-du-reseau-monrezo-cucm-gtfs-1/20250129-150355/gtfs-20250128-150227-cmt.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-du-reseau-monrezo-cucm-gtfs-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-du-reseau-monrezo-cucm-gtfs-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3167,7 +3572,8 @@
             "url": "https://static.data.gouv.fr/resources/offre-de-transport-du-reseau-trema-gtfs/20241108-160404/trema-gtfs-2024-11-08-17-03-22.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-trema-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-trema-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3176,7 +3582,8 @@
             "url": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/ctlb-aix-les-bains/exports/medias.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/ctlb-donnees-theoriques-et-rt-aix-les-bains-lac-du-bourget"
+                "url": "https://transport.data.gouv.fr/datasets/ctlb-donnees-theoriques-et-rt-aix-les-bains-lac-du-bourget",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3184,7 +3591,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/ondea-aix-les-bains-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/ctlb-donnees-theoriques-et-rt-aix-les-bains-lac-du-bourget"
+                "url": "https://transport.data.gouv.fr/datasets/ctlb-donnees-theoriques-et-rt-aix-les-bains-lac-du-bourget",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3194,7 +3602,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-caux-seine-mobilite-rezobus/20250305-092613/v42-du-01-07-2023-au-31-12-2039-modif-course-ligne-2-du-samedi-dep-16h31.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-caux-seine-mobilite-rezobus"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-caux-seine-mobilite-rezobus",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3202,7 +3611,8 @@
             "type": "url",
             "url": "https://app.pysae.com/api/v2/groups/caux-seine-agglo/gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-caux-seine-mobilite-rezobus"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-caux-seine-mobilite-rezobus",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3212,7 +3622,8 @@
             "url": "https://static.data.gouv.fr/resources/horaires-theoriques-et-temps-reel-du-reseau-luneo-gtfs-gtfs-rt/20241105-095154/gtfs-luneo.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-luneo-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-luneo-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3220,7 +3631,8 @@
             "type": "url",
             "url": "https://pysae.com/api/v2/groups/luneo/gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-luneo-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-luneo-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3230,7 +3642,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0007-0000/fluo-grand-est-forbus-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0007-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0007-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3238,7 +3651,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/fluo-forbus-forbach-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0007-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0007-0000-1",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3248,7 +3662,8 @@
             "url": "https://static.data.gouv.fr/resources/offre-de-transports-du-grand-albigeois-gtfs/20240912-070432/reseau-libea-urbain-2024.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-du-grand-albigeois-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-du-grand-albigeois-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3257,7 +3672,8 @@
             "url": "https://static.data.gouv.fr/resources/offre-de-transports-du-grand-albigeois-gtfs/20241219-134911/reseau-libea-navettes.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-du-grand-albigeois-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-du-grand-albigeois-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3266,7 +3682,8 @@
             "url": "https://static.data.gouv.fr/resources/offre-de-transports-du-grand-albigeois-gtfs/20250207-103724/reseau-libea-periurbain-v2.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-du-grand-albigeois-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-du-grand-albigeois-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3275,7 +3692,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-la-navette-commune-de-gaillac/20240924-121002/gtfs-gaillac.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-la-navette-commune-de-gaillac"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-la-navette-commune-de-gaillac",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3284,7 +3702,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-la-navette-commune-de-gaillac/20241205-080814/gtfs-gaillac.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-la-navette-commune-de-gaillac"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-la-navette-commune-de-gaillac",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3293,7 +3712,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-la-navette-commune-de-graulhet/20241205-080952/gtfs-graulhet-corr-0312.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-la-navette-commune-de-graulhet"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-la-navette-commune-de-graulhet",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3302,7 +3722,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-le-passe-pont-communes-de-couffouleux-et-de-rabastens/20240909-134416/gtfs-passe-pont.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-le-passe-pont-communes-de-couffouleux-et-de-rabastens"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-le-passe-pont-communes-de-couffouleux-et-de-rabastens",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3311,7 +3732,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-lislenbus-commune-de-lisle-sur-tarn/20240909-135032/gtfs-lisle.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-lislenbus-commune-de-lisle-sur-tarn"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-lislenbus-commune-de-lisle-sur-tarn",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3320,7 +3742,8 @@
             "url": "https://static.data.gouv.fr/resources/horaires-theoriques-du-reseau-tgl/20241004-080313/tgl-04102024-julien-carayon-x1-gtfs-2024-10-04-10-02-27.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-tgl"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-tgl",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3328,7 +3751,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/tgl-longwy-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-tgl"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-tgl",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3338,7 +3762,8 @@
             "url": "https://app.mecatran.com/utw/ws/gtfsfeed/static/lilapresquile?apiKey=3b5f1b483e47272d497403293c565f2c6a440b5c",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/lignes-arrets-et-horaires-de-transport-pour-cap-atlantique-lila-presquile-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/lignes-arrets-et-horaires-de-transport-pour-cap-atlantique-lila-presquile-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3347,7 +3772,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=agdecapbus68429531",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-capbus-en-lien-avec-le-temps-reel-zenbus"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-capbus-en-lien-avec-le-temps-reel-zenbus",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3355,7 +3781,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=agdecapbus68429531",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-capbus-en-lien-avec-le-temps-reel-zenbus"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-capbus-en-lien-avec-le-temps-reel-zenbus",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3365,7 +3792,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_bocage_bressuirais-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-ca-du-bocage-bressuirais-1"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-ca-du-bocage-bressuirais-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3374,7 +3802,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-scolaire-guingamp-paimpol-mobilite/20250127-161835/gtfs-20250123-152325-gpmobi.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-scolaire-guingamp-paimpol-mobilite"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-scolaire-guingamp-paimpol-mobilite",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3382,17 +3811,19 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/axeo-guingamp-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-scolaire-guingamp-paimpol-mobilite"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-scolaire-guingamp-paimpol-mobilite",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
         {
             "name": "astrobus-lisieux-normandie",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/astrobus-lisieux-normandie/20250103-083009/pt-th-offer-astrobus-gtfs-20241224-562-opendata-1-.zip",
+            "url": "https://static.data.gouv.fr/resources/astrobus-lisieux-normandie/20250324-105552/pt-th-offer-astrobus-gtfs-20250319-540-opendata.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/astrobus-lisieux-normandie"
+                "url": "https://transport.data.gouv.fr/datasets/astrobus-lisieux-normandie",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3400,7 +3831,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/astrobus-lisieux-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/astrobus-lisieux-normandie"
+                "url": "https://transport.data.gouv.fr/datasets/astrobus-lisieux-normandie",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3410,7 +3842,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0038-0000/fluo-grand-est-lefil-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0038-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0038-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3419,7 +3852,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-karouest/20240912-100208/gtfs-ko.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-karouest"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-karouest",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3428,7 +3862,8 @@
             "url": "https://static.data.gouv.fr/resources/horaires-reseau-zest/20250123-132453/gtfs-23-01-2025-08-03.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-reseau-zest"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-reseau-zest",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3436,7 +3871,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/zest-menton-riviera-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-reseau-zest"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-reseau-zest",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3446,7 +3882,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-ville-de-vitre/20240905-093612/16-gtfs-urbain-vitre-sept24-v02.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-ville-de-vitre"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-ville-de-vitre",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3455,7 +3892,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0016-0000/fluo-grand-est-deobus-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0016-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0016-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3463,7 +3901,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/fluo-sylvia-stdie-des-vosges-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0016-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0016-0000-1",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3473,7 +3912,8 @@
             "url": "https://static.data.gouv.fr/resources/transport-scolaire-redon-agglomeration-format-gtfs/20240206-144951/export-gtfs-883.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/transport-scolaire-redon-agglomeration-format-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/transport-scolaire-redon-agglomeration-format-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3482,7 +3922,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-de-bus-urbain-horizon/20241230-084719/gtfs-20241216-135829.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-bus-urbain-horizon"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-bus-urbain-horizon",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3491,7 +3932,8 @@
             "url": "https://data.chateauroux-metropole.fr/api/v2/catalog/datasets/reseau-de-bus-urbain_horizon/alternative_exports/gtfs_20241216_135829_zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-bus-urbain-horizon"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-bus-urbain-horizon",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3500,7 +3942,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_grand_cognac-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cog-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cog-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3509,7 +3952,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/coban-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-coban"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-coban",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3518,7 +3962,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-distribus/20250113-181753/gtfs-20241206-170917-distribus.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-distribus"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-distribus",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3526,7 +3971,8 @@
             "type": "url",
             "url": "http://h21.hanoverdisplays.com:52320/api-1.0/gtfs-rt/trip-updates",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-distribus"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-distribus",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3536,7 +3982,8 @@
             "url": "https://www.datasud.fr/fr/dataset/datasets/2268/resource/5566/download/",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-transcove-de-la-communaute-dagglomeration-ventoux-comtat-venaissin"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-transcove-de-la-communaute-dagglomeration-ventoux-comtat-venaissin",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3545,7 +3992,8 @@
             "url": "https://static.data.gouv.fr/resources/horaires-a-compter-du-18-novembre-2024/20241114-090441/gtfs-montelibus-mybus.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-a-compter-du-18-novembre-2024"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-a-compter-du-18-novembre-2024",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3554,7 +4002,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/cobas-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-cobas"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-cobas",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3563,7 +4012,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-yego-macs/20250319-081033/gtfs-yego-2025-03-18.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-yego-macs"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-yego-macs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3572,16 +4022,18 @@
             "url": "https://static.data.gouv.fr/resources/versions-des-horaires-theoriques-des-lignes-du-reseau-de-bus-au-format-gtfs/20241125-063911/gtfs-20241001-20240706.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/versions-des-horaires-theoriques-des-lignes-du-reseau-de-bus-au-format-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/versions-des-horaires-theoriques-des-lignes-du-reseau-de-bus-au-format-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
             "name": "reseau-de-transports-en-commun-de-la-communaute-dagglomeration-de-lauxerrois",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/reseau-de-transports-en-commun-de-la-communaute-dagglomeration-de-lauxerrois/20250303-180827/gtfs-mdma.zip",
+            "url": "https://static.data.gouv.fr/resources/reseau-de-transports-en-commun-de-la-communaute-dagglomeration-de-lauxerrois/20250404-100859/2025.03.03-gtfs-ubi-mdma.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transports-en-commun-de-la-communaute-dagglomeration-de-lauxerrois"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transports-en-commun-de-la-communaute-dagglomeration-de-lauxerrois",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3589,7 +4041,8 @@
             "type": "url",
             "url": "https://leo.plateforme-2cloud.com/api/gtfsrt/2.0/tripUpdates/LEO-6547-2543-6895?&format=bin&network=AURMLEBUS",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transports-en-commun-de-la-communaute-dagglomeration-de-lauxerrois"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transports-en-commun-de-la-communaute-dagglomeration-de-lauxerrois",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3599,7 +4052,8 @@
             "url": "https://static.data.gouv.fr/resources/transports-en-commun-ca2bm/20240628-123901/ca2bm-lignes-regulieres-ca2bm-reg-v48-reseau-01062024-gtfs-2024-06-28-14-38-48.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/transports-en-commun-ca2bm"
+                "url": "https://transport.data.gouv.fr/datasets/transports-en-commun-ca2bm",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3607,10 +4061,11 @@
             "type": "http",
             "url": "https://app.mecatran.com/utw/ws/gtfsfeed/static/pdlYeuContinent?apiKey=2c715462180f36483d5f24340c706b627f2f2361",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-circuit-de-la-lignes-yeu-continent-gtfs"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-circuit-de-la-lignes-yeu-continent-gtfs",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "fr-200052264-t0001-0000-1",
@@ -3618,7 +4073,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0001-0000/fluo-grand-est-cabus-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0001-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0001-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3627,13 +4083,14 @@
             "url": "https://static.data.gouv.fr/resources/regie-des-transports-baag-gtfs/20241203-092034/gtfs-baag-03122024.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/regie-des-transports-baag-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/regie-des-transports-baag-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
             "name": "horaires-rlv-mobilites",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/donnees-gtfs-1/20241119-134820/gtfs-24-10-14-au-25-08-31.zip",
+            "url": "https://static.data.gouv.fr/resources/horaires-rlv-mobilites/20250407-133809/gtfs-07-04-2025-08-01.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-rlv-mobilites"
@@ -3654,7 +4111,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_rochefort_ocean-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-roc-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-roc-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3663,7 +4121,8 @@
             "url": "https://static.data.gouv.fr/resources/via-bastia-1/20241015-092049/viabastia-viabastia-v6-3-gtfs-2024-10-15-09-30-39.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/via-bastia-1"
+                "url": "https://transport.data.gouv.fr/datasets/via-bastia-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3672,7 +4131,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_val_de_garonne-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-vdg-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-vdg-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3681,7 +4141,8 @@
             "url": "https://static.data.gouv.fr/resources/horaires-theoriques-du-reseau-maelis-montlucon-communaute-gtfs/20241107-082241/gtfs-2024-10-24-au-2025-08-31-sans-sault.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-maelis-montlucon-communaute-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-maelis-montlucon-communaute-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3690,18 +4151,20 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/LINEOTIM_Complet.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/lineotim-morlaix-communaute"
+                "url": "https://transport.data.gouv.fr/datasets/lineotim-morlaix-communaute",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
             "name": "reseau-de-transport-en-commun-transagglo-de-dlva",
             "type": "http",
-            "url": "https://trouver.datasud.fr/dataset/0c5ad935-272e-4d9e-b0db-cdcb1a5309b8/resource/0ca29750-b689-4580-afc0-4b127ee4b914/download/dlva.gtfs.zip",
+            "url": "https://www.datasud.fr/fr/indexer/service/ckan/",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-en-commun-transagglo-de-dlva"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-en-commun-transagglo-de-dlva",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "fr-200052264-t0017-0000-1",
@@ -3709,7 +4172,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0017-0000/fluo-grand-est-cc3f-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0017-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0017-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3717,7 +4181,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/fluo-distribus-stlouis-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0017-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0017-0000-1",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3727,7 +4192,8 @@
             "url": "https://static.data.gouv.fr/resources/horaires-du-reseau-de-bus-intercom-3/20240829-161146/gtfs-open-data.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-du-reseau-de-bus-intercom-3"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-du-reseau-de-bus-intercom-3",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3736,7 +4202,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_bergeracoise-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-ca-bergeracoise-1"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-ca-bergeracoise-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3745,7 +4212,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=buss-cdasaintes",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-buss-saintes-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-buss-saintes-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3753,7 +4221,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=buss-cdasaintes",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-buss-saintes-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-buss-saintes-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3763,7 +4232,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_saintes-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-sai-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-sai-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -3772,7 +4242,8 @@
             "url": "https://static.data.gouv.fr/resources/cherpa-horaires-lignes-regulieres/20250114-084550/gtfs-20250113-au-20251228.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/cherpa-horaires-lignes-regulieres"
+                "url": "https://transport.data.gouv.fr/datasets/cherpa-horaires-lignes-regulieres",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3780,7 +4251,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?src=true&dataset=agglopaysdissoire",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/cherpa-horaires-lignes-regulieres"
+                "url": "https://transport.data.gouv.fr/datasets/cherpa-horaires-lignes-regulieres",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3790,7 +4262,8 @@
             "url": "https://static.data.gouv.fr/resources/transports-urbains-tus-ville-de-soissons/20240827-074729/transports-urbains-soissonnais-tus2-v4-gtfs-2024-08-23-16-47-10.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/transports-urbains-soissonnais-tus"
+                "url": "https://transport.data.gouv.fr/datasets/transports-urbains-soissonnais-tus",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3799,7 +4272,8 @@
             "url": "https://static.data.gouv.fr/resources/transports-urbains-tad-ville-de-soissons/20241217-142349/gtfs-soissons-tad.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/transports-urbains-tad-ville-de-soissons"
+                "url": "https://transport.data.gouv.fr/datasets/transports-urbains-tad-ville-de-soissons",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3808,8 +4282,19 @@
             "url": "https://static.data.gouv.fr/resources/giverny-vernon-gare-sncf/20240419-091207/pt-th-offer-sngonavettegiverny-gtfs-20240413-382-opendata.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/giverny-vernon-gare-sncf"
+                "url": "https://transport.data.gouv.fr/datasets/giverny-vernon-gare-sncf",
+                "spdx-identifier": "etalab-2.0"
             }
+        },
+        {
+            "name": "giverny-vernon-gare-sncf",
+            "type": "url",
+            "url": "https://proxy.transport.data.gouv.fr/resource/giverny-vernon-gtfs-rt",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/giverny-vernon-gare-sncf",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "spec": "gtfs-rt"
         },
         {
             "name": "sngo-vernon-les-andelys-seine-normandie-agglo",
@@ -3817,7 +4302,8 @@
             "url": "https://static.data.gouv.fr/resources/sngo-vernon-les-andelys-seine-normandie-agglo/20241226-134226/pt-th-offer-sngo-gtfs-20241219-337-opendata.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/sngo-vernon-les-andelys-seine-normandie-agglo"
+                "url": "https://transport.data.gouv.fr/datasets/sngo-vernon-les-andelys-seine-normandie-agglo",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3825,7 +4311,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/sngo-vernon-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/sngo-vernon-les-andelys-seine-normandie-agglo"
+                "url": "https://transport.data.gouv.fr/datasets/sngo-vernon-les-andelys-seine-normandie-agglo",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3835,16 +4322,18 @@
             "url": "https://static.data.gouv.fr/resources/transport-du-reseau-urbain-agglobus-et-de-transports-scolaires-gtfs/20241227-084110/gtfs-rodezagglo.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/transport-du-reseau-urbain-agglobus-et-de-transports-scolaires-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/transport-du-reseau-urbain-agglobus-et-de-transports-scolaires-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
             "name": "transports-urbains-st-cyr-s-mer",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/transports-urbains-st-cyr-s-mer/20240118-110542/sud-sainte-baume-janvier2024-st-cyr.zip",
+            "url": "https://static.data.gouv.fr/resources/transports-urbains-st-cyr-s-mer/20250401-095332/sud-sainte-baume-janvier2025-st-cyr.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/transports-urbains-st-cyr-s-mer"
+                "url": "https://transport.data.gouv.fr/datasets/transports-urbains-st-cyr-s-mer",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3853,7 +4342,8 @@
             "url": "https://static.data.gouv.fr/resources/transports-urbains-bandol-sanary-s-mer/20240118-110453/gtfs-20240109-140140-tdv-bandol-sanary-janv24.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/transports-urbains-bandol-sanary-s-mer"
+                "url": "https://transport.data.gouv.fr/datasets/transports-urbains-bandol-sanary-s-mer",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3862,7 +4352,8 @@
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=CYPRE&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-mobi-communaute-de-communes-du-pays-de-valois"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-mobi-communaute-de-communes-du-pays-de-valois",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3870,7 +4361,8 @@
             "type": "url",
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=CYPRE&dataFormat=gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-mobi-communaute-de-communes-du-pays-de-valois"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-mobi-communaute-de-communes-du-pays-de-valois",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3880,7 +4372,8 @@
             "url": "https://pysae.com/api/v2/groups/cavalaire/gtfs/pub",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-cavalaire-ete"
+                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-cavalaire-ete",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3889,17 +4382,9 @@
             "url": "https://pysae.com/api/v2/groups/cavalaire/gtfs/pub",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-cavalaire-sur-mer-hiver"
+                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-cavalaire-sur-mer-hiver",
+                "spdx-identifier": "etalab-2.0"
             }
-        },
-        {
-            "name": "golfe-de-saint-tropez-donnees-mobilite-tc-cavalaire-sur-mer-hiver",
-            "type": "url",
-            "url": "https://pysae.com/api/v2/groups/cavalaire-h/gtfs-rt",
-            "license": {
-                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-cavalaire-sur-mer-hiver"
-            },
-            "spec": "gtfs-rt"
         },
         {
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-ligne-de-la-croix-valmer",
@@ -3907,7 +4392,8 @@
             "url": "https://pysae.com/api/v2/groups/croix-valmer/gtfs/pub",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-ligne-de-la-croix-valmer"
+                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-ligne-de-la-croix-valmer",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3916,7 +4402,8 @@
             "url": "https://pysae.com/api/v2/groups/rayol-canadel/gtfs/pub",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-ligne-le-rayol-canadel-sur-mer"
+                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-ligne-le-rayol-canadel-sur-mer",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3925,7 +4412,8 @@
             "url": "https://pysae.com/api/v2/groups/keolis-hH93/gtfs/pub",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-ligne-cogolin"
+                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-ligne-cogolin",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3934,7 +4422,8 @@
             "url": "https://pysae.com/api/v2/groups/suma-22ua/gtfs/pub",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-navette-estivale-grimaud"
+                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-navette-estivale-grimaud",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3943,7 +4432,8 @@
             "url": "https://pysae.com/api/v2/groups/keolis-yr25/gtfs/pub",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-navette-estivale-ramatuelle"
+                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-navette-estivale-ramatuelle",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3952,7 +4442,8 @@
             "url": "https://pysae.com/api/v2/groups/st-tropez/gtfs/pub",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-navette-reguliere-saint-tropez"
+                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-navette-reguliere-saint-tropez",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3960,7 +4451,8 @@
             "type": "url",
             "url": "https://pysae.com/api/v2/groups/st-tropez/gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-navette-reguliere-saint-tropez"
+                "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-navette-reguliere-saint-tropez",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -3970,7 +4462,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-reseau-fablio-lignes-regulieres/20250107-111116/gtfs-2025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-reseau-fablio-lignes-regulieres"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-reseau-fablio-lignes-regulieres",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3979,7 +4472,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0010-0000/fluo-grand-est-sdz-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0010-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0010-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -3988,17 +4482,9 @@
             "url": "https://static.data.gouv.fr/resources/reseau-nemus/20240902-073541/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-nemus"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-nemus",
+                "spdx-identifier": "etalab-2.0"
             }
-        },
-        {
-            "name": "reseau-nemus",
-            "type": "url",
-            "url": "https://flers-agglo.plateforme-2cloud.com/api/gtfsrt/2.0/tripupdates/FLERS-5197-3181-6523/bin?network=FA",
-            "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-nemus"
-            },
-            "spec": "gtfs-rt"
         },
         {
             "name": "donnees-theoriques-du-reseau-urbain-de-flers-agglo-au-format-gtfs",
@@ -4006,7 +4492,8 @@
             "url": "https://static.data.gouv.fr/resources/donnees-theoriques-du-reseau-urbain-de-flers-agglo-au-format-gtfs/20250207-155842/matawan-gtfs-nemus-urbain-du-25-12-24-au-06-07-25.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-urbain-de-flers-agglo-au-format-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-urbain-de-flers-agglo-au-format-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4014,7 +4501,8 @@
             "type": "url",
             "url": "https://flers-agglo.plateforme-2cloud.com/api/gtfsrt/2.0/tripupdates/FLERS-5197-3181-6523/bin?network=104",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-urbain-de-flers-agglo-au-format-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-urbain-de-flers-agglo-au-format-gtfs",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4024,7 +4512,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-surf/20250218-101156/gtfs-20250218-110627-surf.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-surf"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-surf",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4032,7 +4521,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/surf-fougeres-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-surf"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-surf",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4042,7 +4532,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-du-reseau-lyneo/20241008-131246/reseau-lyneo-maj-08-10-2024.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-lyneo"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-lyneo",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4051,7 +4542,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=cavaillon",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-cavaillon-c-mon-bus-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-cavaillon-c-mon-bus-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4059,7 +4551,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=cavaillon",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-cavaillon-c-mon-bus-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-cavaillon-c-mon-bus-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4069,7 +4562,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-transport-urbain-de-bernay/20241217-142157/bernay-ibus-gtfs-18122024.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-transport-urbain-de-bernay"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-transport-urbain-de-bernay",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4077,7 +4571,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?src=true&dataset=bernay",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-transport-urbain-de-bernay"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-transport-urbain-de-bernay",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4087,7 +4582,8 @@
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=PASSTHELLE&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-pass-thelle-bus-communaute-de-communes-thelloise"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-pass-thelle-bus-communaute-de-communes-thelloise",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4095,7 +4591,8 @@
             "type": "url",
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=PASSTHELLE&dataFormat=gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-pass-thelle-bus-communaute-de-communes-thelloise"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-pass-thelle-bus-communaute-de-communes-thelloise",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4105,7 +4602,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-couralin-grand-dax-1/20241231-095818/gtfs-dax-couralin-2024-12.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-couralin-grand-dax-1"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-couralin-grand-dax-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4114,7 +4612,8 @@
             "url": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/tbk/exports/gtfs-complet.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/tbk-offre-theorique-et-temps-reel-du-reseau-de-transports-du-pays-de-quimperle"
+                "url": "https://transport.data.gouv.fr/datasets/tbk-offre-theorique-et-temps-reel-du-reseau-de-transports-du-pays-de-quimperle",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4122,7 +4621,8 @@
             "type": "url",
             "url": "https://pysae.com/api/v2/groups/quimperle/gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/tbk-offre-theorique-et-temps-reel-du-reseau-de-transports-du-pays-de-quimperle"
+                "url": "https://transport.data.gouv.fr/datasets/tbk-offre-theorique-et-temps-reel-du-reseau-de-transports-du-pays-de-quimperle",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4132,7 +4632,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-de-transport-du-grand-dole/20250213-140456/gtfs-gdm.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-du-grand-dole"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-du-grand-dole",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4140,34 +4641,28 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/tgd-dole-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-du-grand-dole"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-du-grand-dole",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
         {
-            "name": "gtfs-move-vendome--80373",
-            "type": "http",
-            "url": "https://static.data.gouv.fr/resources/gtfs-move-vendome/20240704-072243/move-fb-chartrain-publie-v29.zip",
-            "fix": true,
-            "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-move-vendome"
-            }
-        },
-        {
-            "name": "gtfs-move-vendome--82832",
+            "name": "gtfs-move-vendome",
             "type": "http",
             "url": "https://app.pysae.com/api/v2/groups/vendome/gtfs/676e649e1b7a2efbadbbe403",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-move-vendome"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-move-vendome",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
-            "name": "gtfs-move-vendome--82832",
+            "name": "gtfs-move-vendome",
             "type": "url",
             "url": "https://pysae.com/api/v2/groups/vendome/gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-move-vendome"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-move-vendome",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4177,7 +4672,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-transport-urbain-du-nord-grande-terre-1/20240910-105739/urbain-cangt-v5-3-gtfs-2024-06-24-18-06-18-2-.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-transport-urbain-du-nord-grande-terre-1"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-transport-urbain-du-nord-grande-terre-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4186,7 +4682,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0015-0000/fluo-grand-est-transavold-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0015-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0015-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4194,7 +4691,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/fluo-transavold-saint-avold-gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0015-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0015-0000-1",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4204,7 +4702,8 @@
             "url": "https://mobi-iti-pdl.okina.fr/static/mobiiti_les_sables_d_olonne/gtfs_imported-id_oleane.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/lignes-arrets-et-horaires-theorique-du-reseau-de-transport-gtfs-et-netex-les-sables-dolonne-agglomeration"
+                "url": "https://transport.data.gouv.fr/datasets/lignes-arrets-et-horaires-theorique-du-reseau-de-transport-gtfs-et-netex-les-sables-dolonne-agglomeration",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4213,7 +4712,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0012-0000/fluo-grand-est-epy-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0012-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0012-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4221,7 +4721,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/fluo-mouveo-eprenay-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0012-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0012-0000-1",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4231,7 +4732,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=auch-alliance",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-alliance-auch-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-alliance-auch-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4239,17 +4741,19 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=auch-alliance",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-alliance-auch-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-alliance-auch-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
         {
             "name": "offre-de-transports-urbain-du-reseau-amelys-gtfs",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/offre-de-transports-urbain-du-reseau-amelys-gtfs/20250227-113127/gtfs-26-02-2025-au-06-04-2025.zip",
+            "url": "https://static.data.gouv.fr/resources/offre-de-transports-urbain-du-reseau-amelys-gtfs/20250331-100231/gtfs-maj-avril-2025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-urbain-du-reseau-amelys-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-urbain-du-reseau-amelys-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4258,7 +4762,8 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/CORALIE.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/coralie-concarneau-cornouaille-agglomeration-transport"
+                "url": "https://transport.data.gouv.fr/datasets/coralie-concarneau-cornouaille-agglomeration-transport",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4267,7 +4772,8 @@
             "url": "https://gtfs-rt.infra-hubup.fr/cagtd/current/revision/gtfs",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reels-du-reseau-de-transports-lagglo-en-bus-communaute-dagglomeration-gap-tallard-durance"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reels-du-reseau-de-transports-lagglo-en-bus-communaute-dagglomeration-gap-tallard-durance",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4275,7 +4781,8 @@
             "type": "url",
             "url": "https://gtfs-rt.infra-hubup.fr/cagtd/realtime",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reels-du-reseau-de-transports-lagglo-en-bus-communaute-dagglomeration-gap-tallard-durance"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reels-du-reseau-de-transports-lagglo-en-bus-communaute-dagglomeration-gap-tallard-durance",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4284,10 +4791,11 @@
             "type": "http",
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=loire-atlantique915785",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-de-la-navette-velo-du-pont-de-saint-nazaire-gtfs"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-de-la-navette-velo-du-pont-de-saint-nazaire-gtfs",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "yceo-arrets-horaires-et-lignes-urbaines-et-scolaires-gtfs-1",
@@ -4295,7 +4803,8 @@
             "url": "https://app.mecatran.com/utw/ws/gtfsfeed/static/stran-merge?apiKey=2e6071036d276153761f0c090b4a45420e047612&type=gtfs_stran",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/yceo-arrets-horaires-et-lignes-urbaines-et-scolaires-gtfs-1"
+                "url": "https://transport.data.gouv.fr/datasets/yceo-arrets-horaires-et-lignes-urbaines-et-scolaires-gtfs-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4304,7 +4813,8 @@
             "url": "https://static.data.gouv.fr/resources/transport-urbain/20240821-150857/tu-v1.9-01092024-30062025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/transport-urbain"
+                "url": "https://transport.data.gouv.fr/datasets/transport-urbain",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4313,7 +4823,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-de-transport-urbains-dignois/20240603-093334/rtud-v8-gtfs-2024-06-03-11-20-05.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-urbains-dignois"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-urbains-dignois",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4326,30 +4837,32 @@
             }
         },
         {
-            "name": "gtfs-reseau-scolaire-coqueligo-septembre-a-novembre-2024",
+            "name": "gtfs-reseau-transport-urbain-coqueligo--82905",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/gtfs-reseau-scolaire-coqueligo-septembre-a-novembre-2024/20240905-130447/coqueligo-coqueligo-scolaire-v7-gtfs-2024-09-03-10-09-07.zip",
+            "url": "https://static.data.gouv.fr/resources/gtfs-reseau-transport-urbain-coqueligo/20250326-140706/coqueligo-coqueligo-scolaire-v9-3-gtfs-2025-03-26-15-02-00.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-reseau-scolaire-coqueligo-septembre-a-novembre-2024"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-reseau-transport-urbain-coqueligo",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
-            "name": "gtfs-reseau-urbain-coqueligo-septembre-a-novembre-2024",
+            "name": "gtfs-reseau-transport-urbain-coqueligo--82906",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/gtfs-reseau-urbain-coqueligo-septembre-a-novembre-2024/20240905-125710/coqueligo-coqueligo-urbain-v5-6-gtfs-2024-09-03-10-07-46.zip",
+            "url": "https://static.data.gouv.fr/resources/gtfs-reseau-transport-urbain-coqueligo/20250326-140518/coqueligo-coqueligo-urbain-v5-12-gtfs-2025-03-26-15-01-38.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-reseau-urbain-coqueligo-septembre-a-novembre-2024"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-reseau-transport-urbain-coqueligo",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
-            "name": "coqueligo-tad",
+            "name": "gtfs-transports-a-la-demande-tad-coqueligo",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/coqueligo-tad/20230901-143121/coqueligo-coqueligo-tad-gtfs-2023-09-01-16-26-38.zip",
+            "url": "https://static.data.gouv.fr/resources/gtfs-transports-a-la-demande-tad-coqueligo/20250326-140933/coqueligo-coqueligo-tad-v3-gtfs-2025-03-26-15-08-21.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/coqueligo-tad"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-transports-a-la-demande-tad-coqueligo"
             }
         },
         {
@@ -4358,7 +4871,8 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/ARBUS.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/ar-bus-landerneau-daoulas-transport"
+                "url": "https://transport.data.gouv.fr/datasets/ar-bus-landerneau-daoulas-transport",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4366,7 +4880,8 @@
             "type": "url",
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/gtfsrt/ARBUS.GtfsRt.pb",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/ar-bus-landerneau-daoulas-transport"
+                "url": "https://transport.data.gouv.fr/datasets/ar-bus-landerneau-daoulas-transport",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4376,7 +4891,8 @@
             "url": "https://static.data.gouv.fr/resources/cosibus-coutances-mer-et-bocage/20241008-145255/pt-th-offer-cosibus-gtfs-20241008-874-opendata.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/cosibus-coutances-mer-et-bocage"
+                "url": "https://transport.data.gouv.fr/datasets/cosibus-coutances-mer-et-bocage",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4385,7 +4901,8 @@
             "url": "https://static.data.gouv.fr/resources/amibus-intercom-de-la-vire-au-noireau/20240927-093538/pt-th-offer-amibus-gtfs-20240817-303-opendata.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/amibus-intercom-de-la-vire-au-noireau"
+                "url": "https://transport.data.gouv.fr/datasets/amibus-intercom-de-la-vire-au-noireau",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4394,7 +4911,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-pondibus/20240902-123351/gtfs-20240902-pondibus.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-pondibus"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-pondibus",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4402,29 +4920,21 @@
             "type": "url",
             "url": "https://pysae.com/api/v2/groups/pondibus/gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-pondibus"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-pondibus",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
         {
-            "name": "offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs--82659",
+            "name": "offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs/20250306-075830/cb-urbain-gtfs-20250306.zip",
+            "url": "https://static.data.gouv.fr/resources/offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs/20250324-115939/coteetbus-20250324.zip",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs"
-            }
-        },
-        {
-            "name": "offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs--82660",
-            "type": "http",
-            "url": "https://static.data.gouv.fr/resources/offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs/20250321-114848/coteetbus-20250306.zip",
-            "fix": true,
-            "skip": true,
-            "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "skip": true
         },
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-sablons-bus-communaute-de-communes-des-sablons",
@@ -4432,7 +4942,8 @@
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=SABLONS&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-sablons-bus-communaute-de-communes-des-sablons"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-sablons-bus-communaute-de-communes-des-sablons",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4440,7 +4951,8 @@
             "type": "url",
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=SABLONS&dataFormat=gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-sablons-bus-communaute-de-communes-des-sablons"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-sablons-bus-communaute-de-communes-des-sablons",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4468,7 +4980,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0026-0000/fluo-grand-est-isibus-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0026-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0026-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4477,7 +4990,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0027-0000/fluo-grand-est-movia-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0027-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0027-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4485,7 +4999,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/fluo-colibri-terres-touloises-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0027-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0027-0000-1",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4495,7 +5010,8 @@
             "url": "https://static.data.gouv.fr/resources/deepmob-dieppe-maritime/20241023-131021/pt-th-offer-deepmob-gtfs-20241023-833-opendata.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/deepmob-dieppe-maritime"
+                "url": "https://transport.data.gouv.fr/datasets/deepmob-dieppe-maritime",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4503,7 +5019,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/deepmob-dieppe-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/deepmob-dieppe-maritime"
+                "url": "https://transport.data.gouv.fr/datasets/deepmob-dieppe-maritime",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4513,7 +5030,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-arvi/20240902-115437/telechargement.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-arvi"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-arvi",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4522,7 +5040,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/montesquieu-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-cc-montesquieu"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-cc-montesquieu",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4531,7 +5050,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-2-2-2/20250123-093414/gtfs-heures-dec-2024.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/jeu-de-donnee-spl-estival-2025"
+                "url": "https://transport.data.gouv.fr/datasets/jeu-de-donnee-spl-estival-2025",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4540,7 +5060,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=reseau-titus",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-titus-rosny-sous-bois-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-titus-rosny-sous-bois-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4548,17 +5069,19 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=reseau-titus",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-titus-rosny-sous-bois-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-titus-rosny-sous-bois-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
         {
             "name": "offre-transport-en-commun-du-reseau-transpor-gtfs",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/offre-transport-en-commun-du-reseau-transpor-gtfs/20250106-082225/transp-or-hiver-2024-2025-sans-tad-gtfs-2025-01-06-09-22-00.zip",
+            "url": "https://static.data.gouv.fr/resources/offre-transport-en-commun-du-reseau-transpor-gtfs/20250413-184900/transp-or-hiver-2024-2025-maj-horaire-l2-sans-tad-gtfs-2025-04-13-20-48-13.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-transport-en-commun-du-reseau-transpor-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/offre-transport-en-commun-du-reseau-transpor-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4566,7 +5089,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/transpor-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-transport-en-commun-du-reseau-transpor-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/offre-transport-en-commun-du-reseau-transpor-gtfs",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4576,7 +5100,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0029-0000/fluo-grand-est-lan-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-linggo-en-ville-petr-du-pays-de-langres"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-linggo-en-ville-petr-du-pays-de-langres",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4585,7 +5110,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=figeac",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-figeac-le-bus-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-figeac-le-bus-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4593,7 +5119,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=figeac",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-figeac-le-bus-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-figeac-le-bus-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4603,7 +5130,8 @@
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=CCAC&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-airemob-communaute-de-communes-de-laire-cantilienne"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-airemob-communaute-de-communes-de-laire-cantilienne",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4611,7 +5139,8 @@
             "type": "url",
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=CCAC&dataFormat=gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-airemob-communaute-de-communes-de-laire-cantilienne"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-airemob-communaute-de-communes-de-laire-cantilienne",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4621,7 +5150,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche/20240923-134747/dsp24data-gtfs-2024-09-23-15-45-06.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4630,16 +5160,18 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche/20241016-085959/sco24data-gtfs-2024-10-16-10-39-46.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
             "name": "donnees-du-reseau-alterneo",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/donnees-du-reseau-alterneo/20250313-050828/gtfs-cineo-20250313-20261231.zip",
+            "url": "https://static.data.gouv.fr/resources/donnees-du-reseau-alterneo/20250328-054051/gtfs-cineo-20250328-20260328.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-du-reseau-alterneo"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-du-reseau-alterneo",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4647,7 +5179,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/alterneo-civis-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-du-reseau-alterneo"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-du-reseau-alterneo",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4666,7 +5199,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_du_marsan-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-mdm-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-mdm-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4675,7 +5209,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_tulle-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-tut-nva-m-1"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-tut-nva-m-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4684,7 +5219,8 @@
             "url": "https://static.data.gouv.fr/resources/donnees-gtfs-du-reseau-de-transports-public-du-grand-cahors/20240904-142139/gtfs-2024-2025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-gtfs-du-reseau-de-transports-public-du-grand-cahors"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-gtfs-du-reseau-de-transports-public-du-grand-cahors",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4693,7 +5229,8 @@
             "url": "https://static.data.gouv.fr/resources/elios-transports-urbains-du-grand-villeneuvois/20240904-064009/gtfs-20240820-110043-vsl-annee-scolaire-2024-2025-a-compter-du-02-09-2024.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/elios-transports-urbains-du-grand-villeneuvois"
+                "url": "https://transport.data.gouv.fr/datasets/elios-transports-urbains-du-grand-villeneuvois",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4702,16 +5239,18 @@
             "url": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/tul-gares/exports/medias.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-urbain-de-laon-tul-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-urbain-de-laon-tul-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
             "name": "donnees-du-reseau-evad-1",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/donnees-du-reseau-evad-1/20241216-142501/evad-du-15122024-au-30032025.zip",
+            "url": "https://static.data.gouv.fr/resources/donnees-du-reseau-evad-1/20250408-114035/evad-1702-au-0405.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-du-reseau-evad-1"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-du-reseau-evad-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4720,7 +5259,8 @@
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=TOHM&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tohm-communaute-de-communes-des-pays-doise-et-dhalatte"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tohm-communaute-de-communes-des-pays-doise-et-dhalatte",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4728,7 +5268,8 @@
             "type": "url",
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=TOHM&dataFormat=gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tohm-communaute-de-communes-des-pays-doise-et-dhalatte"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tohm-communaute-de-communes-des-pays-doise-et-dhalatte",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4738,7 +5279,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0022-0000/fluo-grand-est-lesit-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0022-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0022-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4747,7 +5289,8 @@
             "url": "https://exs.sud.cityway.fr/gtfs.aspx?key=SUD&operatorCode=ORANGE",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/transport-en-commun-de-la-ville-dorange-ccpop-1"
+                "url": "https://transport.data.gouv.fr/datasets/transport-en-commun-de-la-ville-dorange-ccpop-1",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4756,7 +5299,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0023-0000/fluo-grand-est-lebus-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0023-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0023-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4764,7 +5308,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/fluo-lebus-pontamousson-gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0023-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0023-0000-1",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4774,7 +5319,8 @@
             "url": "https://exs.mlt4.cityway.fr/gtfs.aspx?operatorCode=CCDSV&key=OPENDATA",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/saonibus-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-la-cc-dsv"
+                "url": "https://transport.data.gouv.fr/datasets/saonibus-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-la-cc-dsv",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4783,7 +5329,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-le-vib/20250303-161323/gtfs-20250303-160142-levib-hp-pan-du-25-02-25-au-30-06-25.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-le-vib"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-le-vib",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4791,7 +5338,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/le-vib-vierzon-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-le-vib"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-le-vib",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4810,7 +5358,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=maybus",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-maybus-mayenne-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-maybus-mayenne-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4818,7 +5367,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=maybus",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-maybus-mayenne-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-maybus-mayenne-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4828,7 +5378,8 @@
             "url": "https://static.data.gouv.fr/resources/arrets-lignes-regulieres-reseau-de-transport-urbain-a-autun/20241217-163652/gtfs-20240703-111144-bfc-sud.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/arrets-lignes-regulieres-reseau-de-transport-urbain-a-autun"
+                "url": "https://transport.data.gouv.fr/datasets/arrets-lignes-regulieres-reseau-de-transport-urbain-a-autun",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4837,7 +5388,8 @@
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=LIBBUS&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-libbus-communaute-de-communes-du-pays-noyonnais"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-libbus-communaute-de-communes-du-pays-noyonnais",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4845,7 +5397,8 @@
             "type": "url",
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=LIBBUS&dataFormat=gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-libbus-communaute-de-communes-du-pays-noyonnais"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-libbus-communaute-de-communes-du-pays-noyonnais",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4855,7 +5408,8 @@
             "url": "https://static.data.gouv.fr/resources/ecla-lons-agglo-mobilites/20241016-094016/gtfs-ecla-l1-l2-l3-l4-30-09-2024.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/ecla-lons-agglo-mobilites"
+                "url": "https://transport.data.gouv.fr/datasets/ecla-lons-agglo-mobilites",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4864,7 +5418,8 @@
             "url": "https://static.data.gouv.fr/resources/offre-de-transport-du-reseau-libellus-gtfs/20250318-124833/18032025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-libellus-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-libellus-gtfs",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4873,7 +5428,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0003-0000/fluo-grand-est-tub-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0003-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0003-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4881,7 +5437,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/fluo-tub-bar-le-duc-gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0003-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0003-0000-1",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4891,7 +5448,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0020-0000/fluo-grand-est-ccselestat-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-elsa-petr-selestat-alsace-centrale"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-elsa-petr-selestat-alsace-centrale",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4900,7 +5458,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=oloron",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-oloron-sainte-marie-la-navette-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-oloron-sainte-marie-la-navette-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4908,7 +5467,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=oloron",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-oloron-sainte-marie-la-navette-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-oloron-sainte-marie-la-navette-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4918,7 +5478,8 @@
             "url": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/jalle_eau_bourde-aggregated-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-cc-jalles-eau-bourde"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-cc-jalles-eau-bourde",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4927,7 +5488,8 @@
             "url": "https://app.mecatran.com/utw/ws/gtfsfeed/static/aubenas?apiKey=6527571c533049035b6a0d41252853243b1f2a68",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4935,7 +5497,8 @@
             "type": "url",
             "url": "https://gtfs-rt.infra-hubup.fr/toutenbus/realtime",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4954,7 +5517,8 @@
             "url": "https://static.data.gouv.fr/resources/horaires-theoriques-du-reseau-moova-communaute-dagglomeration-de-vesoul-gtfs/20241203-211628/gtfs-03-12-2024-08-01-moova.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-moova-communaute-dagglomeration-de-vesoul-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-moova-communaute-dagglomeration-de-vesoul-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4962,7 +5526,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/moova-vesoul-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-moova-communaute-dagglomeration-de-vesoul-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-moova-communaute-dagglomeration-de-vesoul-gtfs",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4972,7 +5537,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-reso/20250319-175629/gtfs-hordbord-174615-reso.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-reso"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-reso",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -4980,7 +5546,8 @@
             "type": "url",
             "url": "https://pysae.com/api/v2/groups/transdev-8z2Q/gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-reso"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-reso",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -4990,7 +5557,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-lagglo-bus-de-lagglo-foix-varilhes/20240904-064754/gtfs-20240903-154223.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-lagglo-bus-de-lagglo-foix-varilhes"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-lagglo-bus-de-lagglo-foix-varilhes",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -4999,7 +5567,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-brevibus/20250211-134639/gtfs-20250211-141900-brevibus-hors-bord-correction-noms-de-ligne-.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-brevibus"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-brevibus",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -5007,7 +5576,8 @@
             "type": "url",
             "url": "https://pysae.com/api/v2/groups/brevibus/gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-brevibus"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-brevibus",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -5017,7 +5587,8 @@
             "url": "https://static.data.gouv.fr/resources/agglobus/20241216-125701/241216-agglobus-janvier-2025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/agglobus"
+                "url": "https://transport.data.gouv.fr/datasets/agglobus",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5026,7 +5597,8 @@
             "url": "https://static.data.gouv.fr/resources/fiches-horaires-reseau-urbain-mio-ccmillaugrandscausses/20241015-081908/gtfs-20241010-164303-mil2401-v6.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fiches-horaires-reseau-urbain-mio-ccmillaugrandscausses"
+                "url": "https://transport.data.gouv.fr/datasets/fiches-horaires-reseau-urbain-mio-ccmillaugrandscausses",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5044,7 +5616,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=sel-et-vermois",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-de-la-navette-de-sel-et-vermois-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-de-la-navette-de-sel-et-vermois-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -5052,7 +5625,28 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=sel-et-vermois",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-de-la-navette-de-sel-et-vermois-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-de-la-navette-de-sel-et-vermois-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "offre-de-transport-du-reseau-de-la-communaute-de-communes-des-pays-du-sel-et-du-vermois",
+            "type": "http",
+            "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0054-0000/fluo-grand-est-selverm-gtfs.zip",
+            "fix": true,
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-de-la-communaute-de-communes-des-pays-du-sel-et-du-vermois",
+                "spdx-identifier": "etalab-2.0"
+            }
+        },
+        {
+            "name": "offre-de-transport-du-reseau-de-la-communaute-de-communes-des-pays-du-sel-et-du-vermois",
+            "type": "url",
+            "url": "https://proxy.transport.data.gouv.fr/resource/fluo-sel-et-vermois-gtfs-rt-trip-update",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-de-la-communaute-de-communes-des-pays-du-sel-et-du-vermois",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -5062,7 +5656,8 @@
             "url": "https://static.data.gouv.fr/resources/donnees-de-mobilite/20250108-100107/gtfs-20250108-085353-villeo.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-de-mobilite"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-de-mobilite",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5071,7 +5666,8 @@
             "url": "https://data.centrevaldeloire.fr/api/explore/v2.1/catalog/datasets/ville-damboise-offre-theorique-mobilite-reseau-urbain/files/f24d8861791d49837c8500cbf4c8c99f",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/ville-damboise-offre-theorique-mobilite-reseau-urbain"
+                "url": "https://transport.data.gouv.fr/datasets/ville-damboise-offre-theorique-mobilite-reseau-urbain",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -5080,7 +5676,8 @@
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=LEBUS&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-le-bus-communaute-de-communes-du-clermontois"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-le-bus-communaute-de-communes-du-clermontois",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5088,7 +5685,8 @@
             "type": "url",
             "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=LEBUS&dataFormat=gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-le-bus-communaute-de-communes-du-clermontois"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-le-bus-communaute-de-communes-du-clermontois",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -5116,7 +5714,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0025-0000/fluo-grand-est-tmm-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0025-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0025-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5125,7 +5724,8 @@
             "url": "https://static.data.gouv.fr/resources/vikibus-yvetot-normandie/20250109-124650/pt-th-offer-vikibus-gtfs-20250108-677-opendata.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/vikibus-yvetot-normandie"
+                "url": "https://transport.data.gouv.fr/datasets/vikibus-yvetot-normandie",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5134,7 +5734,8 @@
             "url": "https://exs.mlt4.cityway.fr/gtfs.aspx?operatorCode=3CM&key=OPENDATA",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/tico-bus-horaires-theoriques-du-reseau-de-transport-urbain-tico"
+                "url": "https://transport.data.gouv.fr/datasets/tico-bus-horaires-theoriques-du-reseau-de-transport-urbain-tico",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -5143,7 +5744,8 @@
             "url": "https://api.mlt4.cityway.fr/dataflow/tad/download?provider=3CM",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/tico-bus-horaires-theoriques-du-reseau-de-transport-urbain-tico"
+                "url": "https://transport.data.gouv.fr/datasets/tico-bus-horaires-theoriques-du-reseau-de-transport-urbain-tico",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -5152,7 +5754,8 @@
             "url": "https://static.data.gouv.fr/resources/moca-communaute-de-communes-caux-austreberthe/20241226-134004/pt-th-offer-moca-gtfs-20241219-373-opendata-1-.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/moca-communaute-de-communes-caux-austreberthe"
+                "url": "https://transport.data.gouv.fr/datasets/moca-communaute-de-communes-caux-austreberthe",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5160,7 +5763,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/moca-caux-austreberthe-gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/moca-communaute-de-communes-caux-austreberthe"
+                "url": "https://transport.data.gouv.fr/datasets/moca-communaute-de-communes-caux-austreberthe",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -5170,7 +5774,8 @@
             "url": "https://api.mlt4.cityway.fr/dataflow/offre-tc/download?provider=MIRIBEL&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/colibri-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-la-ccmp"
+                "url": "https://transport.data.gouv.fr/datasets/colibri-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-la-ccmp",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -5178,7 +5783,8 @@
             "type": "url",
             "url": "https://api.mlt4.cityway.fr/dataflow/horaire-tr/download?provider=MIRIBEL&dataFormat=GTFS-RT&dataProfil=OPENDATA",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/colibri-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-la-ccmp"
+                "url": "https://transport.data.gouv.fr/datasets/colibri-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-la-ccmp",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -5188,7 +5794,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-cvlmobilite-plan-de-transport-theorique-ligne-a-format-gtfs/20250105-184842/cvlm-lignea-05012025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-cvlmobilite-plan-de-transport-theorique-ligne-a-format-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-cvlmobilite-plan-de-transport-theorique-ligne-a-format-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5197,7 +5804,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0006-0000/fluo-grand-est-cht-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0006-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0006-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5206,7 +5814,8 @@
             "url": "https://static.data.gouv.fr/resources/horaires-theoriques-du-reseau-neobus-communaute-de-communes-de-louest-vosgien-gtfs/20250106-125602/gtfs-sadapnfc-neobus.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-neobus-communaute-de-communes-de-louest-vosgien-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-neobus-communaute-de-communes-de-louest-vosgien-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5215,7 +5824,8 @@
             "url": "https://static.data.gouv.fr/resources/lignes-maritimes-de-corse-du-sud-de-la-collectivite-de-corse/20241001-080142/lignes-maritimes-de-corse-du-sud-de-la-collectivite-de-corse.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/lignes-maritimes-de-corse-du-sud-de-la-collectivite-de-corse"
+                "url": "https://transport.data.gouv.fr/datasets/lignes-maritimes-de-corse-du-sud-de-la-collectivite-de-corse",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5223,10 +5833,11 @@
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/gtfs-transport-horaires-des-lignes-de-la-communaute-de-communes-corse-du-sud-a-berlina/20250210-084612/a-berlina-horaires.zip",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-des-lignes-de-la-communaute-de-communes-corse-du-sud-a-berlina"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-des-lignes-de-la-communaute-de-communes-corse-du-sud-a-berlina",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "reseau-a-citadina-porto-vecchio-horaires-theoriques-et-temps-reel",
@@ -5234,7 +5845,8 @@
             "url": "https://pysae.com/api/v2/groups/porto-vecchio/gtfs/pub",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-a-citadina-porto-vecchio-horaires-theoriques-et-temps-reel"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-a-citadina-porto-vecchio-horaires-theoriques-et-temps-reel",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5242,7 +5854,8 @@
             "type": "url",
             "url": "https://pysae.com/api/v2/groups/porto-vecchio/gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-a-citadina-porto-vecchio-horaires-theoriques-et-temps-reel"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-a-citadina-porto-vecchio-horaires-theoriques-et-temps-reel",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -5252,7 +5865,8 @@
             "url": "https://static.data.gouv.fr/resources/donnees-de-transport-en-commun-reseau-altigo-communaute-de-communes-du-brianconnais-format-gtfs/20250318-133659/altigo-gtfs-2025-03-18-14-32-31.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-de-transport-en-commun-reseau-altigo-communaute-de-communes-du-brianconnais-format-gtfs"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-de-transport-en-commun-reseau-altigo-communaute-de-communes-du-brianconnais-format-gtfs",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5261,7 +5875,8 @@
             "url": "https://data.centrevaldeloire.fr/api/explore/v2.1/catalog/datasets/issoudun-offre-theorique-mobilite-reseau-urbain/files/2772f7c18af1fbb5f66c8dfc785da579",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/issoudun-offre-theorique-mobilite-reseau-urbain"
+                "url": "https://transport.data.gouv.fr/datasets/issoudun-offre-theorique-mobilite-reseau-urbain",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -5270,7 +5885,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0041-0000/fluo-grand-est-obernai-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0041-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0041-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5279,7 +5895,8 @@
             "url": "https://static.data.gouv.fr/resources/transport-urbain-du-bassin/20250217-154406/transports-urbains-du-bassin-version-2-6-gtfs-2024-12-16-11-39-36.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/transport-urbain-du-bassin"
+                "url": "https://transport.data.gouv.fr/datasets/transport-urbain-du-bassin",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5288,7 +5905,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-urbain-nosbus/20250227-153712/gtfs-nosbus-20240706-85-a-bord-hors-bord.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-nosbus"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-nosbus",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -5296,7 +5914,8 @@
             "type": "url",
             "url": "https://pysae.com/api/v2/groups/nosbus/gtfs-rt",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-nosbus"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-nosbus",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -5306,7 +5925,8 @@
             "url": "https://www.korrigo.bzh/ftp/OPENDATA/TUDBUS.gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/tudbus-douarnenez-communaute-transport"
+                "url": "https://transport.data.gouv.fr/datasets/tudbus-douarnenez-communaute-transport",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -5315,7 +5935,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=iledere75923021",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-respire-ile-de-re-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-respire-ile-de-re-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -5323,7 +5944,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=iledere75923021",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-respire-ile-de-re-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-respire-ile-de-re-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -5333,7 +5955,8 @@
             "url": "https://static.data.gouv.fr/resources/navette-chorges-chanteloube-ete-2024-reseau-vai/20240719-122610/vai-ccsp-navette-chorges-chanteloube-ete-2024.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/navette-chorges-chanteloube-ete-2024-reseau-vai"
+                "url": "https://transport.data.gouv.fr/datasets/navette-chorges-chanteloube-ete-2024-reseau-vai",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5342,7 +5965,8 @@
             "url": "https://static.data.gouv.fr/resources/navettes-stations-hiver-2024-2025-reseau-vai/20241128-112245/navettes-stations-vai-hiver-2024-2025.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/navettes-stations-hiver-2024-2025-reseau-vai"
+                "url": "https://transport.data.gouv.fr/datasets/navettes-stations-hiver-2024-2025-reseau-vai",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5351,7 +5975,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-vai-embrun/20250122-094601/transports-vai-embrun.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-vai-embrun"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-vai-embrun",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5360,7 +5985,8 @@
             "url": "https://static.data.gouv.fr/resources/offre-de-transports-jybus-a-rumilly/20240820-074009/gtfs-jybus.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-jybus-a-rumilly"
+                "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-jybus-a-rumilly",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5369,28 +5995,30 @@
             "url": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=HOPLA&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-hopla-communaute-de-communes-de-la-plaine-destrees"
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-hopla-communaute-de-communes-de-la-plaine-destrees",
+                "spdx-identifier": "etalab-2.0"
             }
+        },
+        {
+            "name": "donnees-theoriques-du-reseau-hopla-communaute-de-communes-de-la-plaine-destrees",
+            "type": "url",
+            "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=HOPLA&dataFormat=gtfs-rt",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-hopla-communaute-de-communes-de-la-plaine-destrees",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "spec": "gtfs-rt"
         },
         {
             "name": "horaires-theoriques-et-temps-reel-des-navettes-de-la-ligne-bagneres-la-mongie-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=bigorre-mongie",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-de-la-ligne-bagneres-la-mongie-gtfs-gtfs-rt"
-            }
-        },
-        {
-            "name": "horaires-theoriques-et-temps-reel-des-navettes-de-la-ligne-bagneres-la-mongie-gtfs-gtfs-rt",
-            "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=bigorre-mongie",
-            "skip": true,
-            "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-de-la-ligne-bagneres-la-mongie-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-de-la-ligne-bagneres-la-mongie-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
-            "spec": "gtfs-rt"
+            "skip": true
         },
         {
             "name": "horaires-theoriques-et-temps-reel-du-reseau-sarlatbus-gtfs-gtfs-rt",
@@ -5398,7 +6026,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=Sarlat",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-sarlatbus-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-sarlatbus-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -5406,7 +6035,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=Sarlat",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-sarlatbus-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-sarlatbus-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -5416,7 +6046,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=tum",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-transports-urbains-mendois-mende-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-transports-urbains-mendois-mende-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -5425,7 +6056,8 @@
             "url": "https://static.data.gouv.fr/resources/navettes-bourg-saint-maurice/20250224-084057/gtfs-24-01-2025-bsm.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/navettes-bourg-saint-maurice"
+                "url": "https://transport.data.gouv.fr/datasets/navettes-bourg-saint-maurice",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5433,10 +6065,11 @@
             "type": "http",
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=tignes",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-de-la-station-de-tignes-gtfs-gtfs-rt"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-de-la-station-de-tignes-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "skip": true
         },
         {
             "name": "horaires-theoriques-et-temps-reel-des-navettes-de-la-station-de-tignes-gtfs-gtfs-rt",
@@ -5444,7 +6077,8 @@
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=tignes",
             "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-de-la-station-de-tignes-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-de-la-station-de-tignes-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -5453,10 +6087,11 @@
             "type": "http",
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=valdisere",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-de-val-disere-gtfs-gtfs-rt"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-de-val-disere-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "skip": true
         },
         {
             "name": "horaires-theoriques-et-temps-reel-des-navettes-de-val-disere-gtfs-gtfs-rt",
@@ -5464,7 +6099,8 @@
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=valdisere",
             "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-de-val-disere-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-de-val-disere-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -5498,16 +6134,17 @@
         {
             "name": "gtfs-reseau-chamonix-mobilite",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/gtfs-reseau-chamonix-mobilite/20250103-143233/gtfs-oura-v20241216.zip",
+            "url": "https://static.data.gouv.fr/resources/gtfs-reseau-chamonix-mobilite/20250404-144839/gtfs-2015-chamonix-mobilit.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-reseau-chamonix-mobilite"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-reseau-chamonix-mobilite",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
             "name": "bagnoles-de-lorne",
             "type": "http",
-            "url": "https://static.data.gouv.fr/resources/bagnoles-de-lorne/20250210-080631/pt-th-offer-bagnoles-gtfs-20250206-854-opendata.zip",
+            "url": "https://static.data.gouv.fr/resources/bagnoles-de-lorne/20250403-141059/pt-th-offer-bagnoles-gtfs-20250403-747-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/bagnoles-de-lorne"
@@ -5519,7 +6156,8 @@
             "url": "https://static.data.gouv.fr/resources/les-navettes-du-giffre-horaires-hiver-2023-2024/20240119-105247/gtfs-les-navettes-du-giffre-2024-v1-valide-pan.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/les-navettes-du-giffre-horaires-hiver-2023-2024"
+                "url": "https://transport.data.gouv.fr/datasets/les-navettes-du-giffre-horaires-hiver-2023-2024",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5528,7 +6166,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0030-0000/fluo-grand-est-smd-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0030-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0030-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5537,7 +6176,8 @@
             "url": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0011-0000/fluo-grand-est-tiv-gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0011-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0011-0000-1",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5545,7 +6185,8 @@
             "type": "url",
             "url": "https://proxy.transport.data.gouv.fr/resource/fluo-rezo-verdun-gtfs-rt-trip-update",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0011-0000-1"
+                "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0011-0000-1",
+                "spdx-identifier": "etalab-2.0"
             },
             "spec": "gtfs-rt"
         },
@@ -5554,10 +6195,11 @@
             "type": "http",
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=alpe-huez",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-hivernales-de-lalpe-dhuez-gtfs-gtfs-rt"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-hivernales-de-lalpe-dhuez-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "skip": true
         },
         {
             "name": "horaires-theoriques-et-temps-reel-des-navettes-hivernales-de-lalpe-dhuez-gtfs-gtfs-rt",
@@ -5565,7 +6207,8 @@
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=alpe-huez",
             "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-hivernales-de-lalpe-dhuez-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-hivernales-de-lalpe-dhuez-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -5574,10 +6217,11 @@
             "type": "http",
             "url": "https://static.data.gouv.fr/resources/gtfs-transport-horaires-des-lignes-de-la-communaute-dile-rousse-balagne-a-balanina/20250210-084351/a-balanina-horaires.zip",
             "fix": true,
-            "skip": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-des-lignes-de-la-communaute-dile-rousse-balagne-a-balanina"
-            }
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-des-lignes-de-la-communaute-dile-rousse-balagne-a-balanina",
+                "spdx-identifier": "etalab-2.0"
+            },
+            "skip": true
         },
         {
             "name": "gtfs-pybus-le-reseau-urbain-de-parthenay",
@@ -5585,7 +6229,8 @@
             "url": "https://pysae.com/api/v2/groups/parthenay/gtfs/675464600aa7a35621cdd070",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-pybus-le-reseau-urbain-de-parthenay"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-pybus-le-reseau-urbain-de-parthenay",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5594,7 +6239,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=coeur-de-tarentaise",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-coeur-de-tarentaise-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-coeur-de-tarentaise-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -5602,7 +6248,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=coeur-de-tarentaise",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-coeur-de-tarentaise-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-coeur-de-tarentaise-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -5612,7 +6259,8 @@
             "url": "https://static.data.gouv.fr/resources/meribus-hiver/20241227-091327/gtfs-27-12-24.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/meribus-hiver"
+                "url": "https://transport.data.gouv.fr/datasets/meribus-hiver",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5621,7 +6269,8 @@
             "url": "https://static.data.gouv.fr/resources/reseau-de-transports-collectifs-de-la-ccgq/20250220-120844/gtfs.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transports-collectifs-de-la-ccgq"
+                "url": "https://transport.data.gouv.fr/datasets/reseau-de-transports-collectifs-de-la-ccgq",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5630,7 +6279,8 @@
             "url": "https://static.data.gouv.fr/resources/gtfs-noirmoutier-gratibus-ete-2023/20240704-071709/noirmoutier-2024-final-v2.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/gtfs-noirmoutier-gratibus-ete"
+                "url": "https://transport.data.gouv.fr/datasets/gtfs-noirmoutier-gratibus-ete",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {
@@ -5639,7 +6289,8 @@
             "url": "https://zenbus.net/gtfs/static/download.zip?dataset=valmorel",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-de-la-station-de-ski-valmorel-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-de-la-station-de-ski-valmorel-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             }
         },
         {
@@ -5647,7 +6298,8 @@
             "type": "url",
             "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=valmorel",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-de-la-station-de-ski-valmorel-gtfs-gtfs-rt"
+                "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-de-la-station-de-ski-valmorel-gtfs-gtfs-rt",
+                "spdx-identifier": "ODbL-1.0"
             },
             "spec": "gtfs-rt"
         },
@@ -5657,7 +6309,8 @@
             "url": "https://static.data.gouv.fr/resources/skibus-courchevel-hiver/20250124-142220/gtfs-24-01-2025-courchevel.zip",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/skibus-courchevel-hiver"
+                "url": "https://transport.data.gouv.fr/datasets/skibus-courchevel-hiver",
+                "spdx-identifier": "etalab-2.0"
             }
         },
         {

--- a/src/generate-france.py
+++ b/src/generate-france.py
@@ -115,13 +115,17 @@ if __name__ == "__main__":
             "81806": "81461",
         },
         "versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs": {
-            "82161": "82877",
+            "82161": "82951",
         },
         "horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin": {
             "79830": "79831"
         },
         "gtfs-move-vendome": {
             "80381": "82832"
+        },
+        "gtfs-sankeo": {
+            "82901": "82900",
+            "82273": "82902"
         },
     }
 
@@ -177,12 +181,16 @@ if __name__ == "__main__":
                     "type": "http",
                     "url": resource["original_url"],
                     "fix": True,
+                    "license": {},
                 }
                 if dataset["slug"] in skip:
                     source["skip"] = True
                 if "page_url" in dataset:
-                    source["license"] = {}
                     source["license"]["url"] = dataset["page_url"]
+                if dataset["licence"] == "odc-odbl":
+                    source["license"]["spdx-identifier"] = "ODbL-1.0"
+                if dataset["licence"] in ["lov2", "fr-lo"]:
+                    source["license"]["spdx-identifier"] = "etalab-2.0"
                 out.append(source)
 
             def cond(r) -> bool:
@@ -232,8 +240,13 @@ if __name__ == "__main__":
                         source["url"] = resource["original_url"]
                         if dataset["slug"] in skip:
                             source["skip"] = True
+                        source["license"] = {}
                         if "page_url" in dataset:
-                            source["license"] = {"url": dataset["page_url"]}
+                            source["license"]["url"] = dataset["page_url"]
+                        if dataset["licence"] == "odc-odbl":
+                            source["license"]["spdx-identifier"] = "ODbL-1.0"
+                        if dataset["licence"] in ["lov2", "fr-lo"]:
+                            source["license"]["spdx-identifier"] = "etalab-2.0"
                         source["spec"] = "gtfs-rt"
                         out.append(source)
                     else:


### PR DESCRIPTION
Quick fix to add the spdx license identifiers to FR (so we can merge safely before #1044).
This should also improve downstream issues by providing more accurate license info, see https://github.com/Traewelling/traewelling/issues/3338 .

Small things I am not 100% sure about (cc @jbruechert):
- Etalab Open License 1.0 can be safely marked as Etalab Open License 2.0, they should be compatible so shouldn't be an issue, see https://www.etalab.gouv.fr/licence-ouverte-open-licence/. Here citation of compatibility mention of the 2.0 version : `This licence has been designed to be compatible with any free licence that at least
requires an acknowledgement of authorship, and specifically with the previous
version of this licence as well as with the following licences`
- The ODbL-1.0 used on the https://transport.data.gouv.fr portal, seems to have an additionnal conditions to make the 4.4 Share Alike less restrictive https://doc.transport.data.gouv.fr/le-point-d-acces-national/cadre-juridique/conditions-dutilisation-des-donnees/licence-odbl, so the more restrictive ODbL-1.0 identifier should be fine IMHO (as it is also what the API shows anyway (`odc-odbl`))