### PR TITLE
Add GTFS.de feed with Poland-Germany trains

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -20,6 +20,26 @@
             "transitland-atlas-id": "f-pkp~intercity~pl"
         },
         {
+            "name": "PKP-Intercity-Germany",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-germany~long~distance~rail",
+            "drop_agency-names": [
+                "DB Fernverkehr (Codesharing)",
+                "HZZP",
+                "DB Fernverkehr AG",
+                "ZSSK",
+                "ÖBB",
+                "Ceske Drahy",
+                "MAV",
+                "Nederlandse Spoorwegen",
+                "Trenitalia",
+                "SBB",
+                "Dänische Staatsbahnen",
+                "SNCF",
+                "SÜWEX"
+            ]
+        },
+        {
             "name": "PolRegio",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-pol~regio~pl",

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -23,7 +23,7 @@
             "name": "PKP-Intercity-Germany",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-germany~long~distance~rail",
-            "drop_agency-names": [
+            "drop-agency-names": [
                 "DB Fernverkehr (Codesharing)",
                 "HZZP",
                 "DB Fernverkehr AG",

--- a/src/transitland.py
+++ b/src/transitland.py
@@ -43,6 +43,7 @@ class Atlas:
             result.drop_shapes = source.drop_shapes
             result.fix_csv_quotes = source.fix_csv_quotes
             result.display_name_options = source.display_name_options
+            result.drop_agency_names = source.drop_agency_names
 
             if source.url_override:
                 result.url_override = source.url_override


### PR DESCRIPTION
**Why?**
PKP-Intercity feed has international trains ending at last station in Poland. Trains from Poland to Berlin are in the gtfs.de DB feed (but are not in the main german DELFI feed). It feels like a quick fix can be made, to have data for those trains.

Similar issue exists on trains for example from Poland to Czechia, but at the moment transitous has data for those trains in Czechia and uggests a transfer between them (while not ideal, no data is missing).

**How?**
Use `f-germany~long~distance~rail` (gtfs.de long distance feed) with all agencies but PKP Intercity filtered out.
This will cause only small duplication (double the PL-DE trains on Polish side), but will allow to navigate on full routes and on route parts inside Germany.

Small change was required to make `drop-agency-names` propagate properly.