### PR TITLE
Custom PKP DE feed for Berlin - Poland trains

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -21,23 +21,11 @@
         },
         {
             "name": "PKP-Intercity-Germany",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-germany~long~distance~rail",
-            "drop-agency-names": [
-                "DB Fernverkehr (Codesharing)",
-                "HZZP",
-                "DB Fernverkehr AG",
-                "ZSSK",
-                "ÖBB",
-                "Ceske Drahy",
-                "MAV",
-                "Nederlandse Spoorwegen",
-                "Trenitalia",
-                "SBB",
-                "Dänische Staatsbahnen",
-                "SNCF",
-                "SÜWEX"
-            ]
+            "type": "http",
+            "url": "https://kasmar00.github.io/gtfs-pkp-de/latest.zip",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            }
         },
         {
             "name": "PolRegio",


### PR DESCRIPTION
What?

Support Berlin - Warsaw/Kraków/Gdansk/Przemyśl trains in trainsitous

Why?

#1083 didn't help as it was supposed to. I missed the fact gtfs.de contains those trains in two parts: Berlin - Rzepin (operated by DB) and Rzepin - Warsaw (operated by PKP), therefore adding gtfs.de feed with all but PKP Intercity agencies filtered out resulted in just polish parts of those trains. I double checked and I couldn't find the german part of the trains anywhere else (DELFI feed, PKP Intercity feed, VBB feed).

How?

Add a custom feed based on gtfs.de, but only with the Berlin - Poland trains. Feed is generated daily by a script: https://github.com/kasmar00/gtfs-pkp-de. In the near future I plan to merge those split journeys into one (probably based on data from regular PKP Intercity feed, but that needs some programming)