### PR TITLE
Update license for CZPTT feed in cz.json

### DIFF
--- a/feeds/cz.json
+++ b/feeds/cz.json
@@ -14,6 +14,9 @@
             "name": "CZPTT",
             "type": "http",
             "url": "https://data.jr.ggu.cz/results/latest/CZPTT_GTFS.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            },
             "fix": true
         },
         {


### PR DESCRIPTION
Recently, I asked lead maintainer of CZPTT feed on their jrutil GitLab repo about the license and while the answer wasn't as conclusive as I'd like it to be _(if only the ministry of transport had a proper license attached to source data)_, I believe the response goes give more than enough reason to make this a CC0.

https://gitlab.com/dvdkon/jrutil/-/issues/13#note_2469249024