### PR TITLE
Add Bikesharing providers from Frankfurt and Mainz

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -134,6 +134,27 @@
             "transitland-atlas-id": "f-vrnnextbike~rhine~neckar~gbfs"
         },
         {
+            "name": "meinRad",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-meinrad~mainz~gbfs"
+        },
+        {
+            "name": "LimeFrankfurt",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-lime~frankfurt~gbfs"
+        },
+        {
+            "name": "NetxbikeFrankfurt",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-nextbike~frankfurt~gbfs"
+        },
+        {
+            "name": "DottFrankfurt",
+            "type": "url",
+            "url": "https://gbfs.api.ridedott.com/public/v2/frankfurt/gbfs.json",
+            "spec": "gbfs"
+        },
+        {
             "name": "Deer",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-deer~germany~gbfs"


### PR DESCRIPTION
Note: Ridedott is currently not available in the transitland-atlas, therefore it is added as URL type. See also https://github.com/transitland/transitland-atlas/issues/1538