### PR TITLE
Update the MOTIS version in the containerfile

### DIFF
--- a/ci/container/Containerfile
+++ b/ci/container/Containerfile
@@ -7,7 +7,7 @@ RUN GOPROXY=direct GOBIN=/usr/local/bin/ go install github.com/public-transport/
 
 FROM docker.io/debian:bookworm-slim
 
-ARG MOTIS_VERSION=v2.0.34
+ARG MOTIS_VERSION=v2.0.59
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends git python3-requests python3-pycountry wget bzip2 rsync openssh-client python3-ruamel.yaml && \

--- a/ci/container/Containerfile-devcontainer
+++ b/ci/container/Containerfile-devcontainer
@@ -6,7 +6,7 @@ RUN GOPROXY=direct GOBIN=/usr/local/bin/ go install github.com/public-transport/
 
 FROM docker.io/debian:bookworm-slim
 
-ARG MOTIS_VERSION=v2.0.34
+ARG MOTIS_VERSION=v2.0.59
 ARG USERNAME=transitous
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID


### PR DESCRIPTION
When someone follows the instructions for running an instance locally, it will miss out the recent bugfixes, so I think it makes sense to update the MOTIS version here as well