### PR TITLE
Add Nextbike GBFS for Dresden, Leipzig and Halle

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -208,6 +208,6 @@
             "name": "MovemixHalle",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-movemix~bike~halle~de~gbfs"
-        },
+        }
     ]
 }

--- a/feeds/de.json
+++ b/feeds/de.json
@@ -193,6 +193,21 @@
             "name": "TeilAutoSchwäbischHall",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-teilauto~schwäbisch~hall~gbfs"
-        }
+        },
+        {
+            "name": "MOBIBikeDresden",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-mobibike~dresden~gbfs"
+        },
+        {
+            "name": "NextbikeLeipzig",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-nextbike~leipzig~gbfs"
+        },
+        {
+            "name": "MovemixHalle",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-movemix~bike~halle~de~gbfs"
+        },
     ]
 }

--- a/feeds/de.json
+++ b/feeds/de.json
@@ -144,7 +144,7 @@
             "transitland-atlas-id": "f-lime~frankfurt~gbfs"
         },
         {
-            "name": "NetxbikeFrankfurt",
+            "name": "NextbikeFrankfurt",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-nextbike~frankfurt~gbfs"
         },


### PR DESCRIPTION
This PR adds Transitland Feeds for Nextbike Cities Dresden, Leipzig and Halle. 🚴