### PR TITLE
Bring back B-Bus feed

### DIFF
--- a/feeds/lt.json
+++ b/feeds/lt.json
@@ -80,8 +80,8 @@
         },
         {
             "name": "B-Bus",
-            "type": "http",
-            "url": "https://stops.lt/LVA/lva/gtfs.zip"
+            "type": "mobility-database",
+            "mdb-id": "mdb-2385"
         }
     ]
 }

--- a/feeds/lt.json
+++ b/feeds/lt.json
@@ -77,6 +77,11 @@
             "name": "traukiniai",
             "type": "http",
             "url": "https://stops.lt/traukiniai/traukiniai/gtfs.zip"
+        },
+        {
+            "name": "B-Bus",
+            "type": "http",
+            "url": "https://stops.lt/LVA/lva/gtfs.zip"
         }
     ]
 }


### PR DESCRIPTION
Ironically Visi Maršrutai doesn't have all the routes, I've checked the Panėvežys area and found out the suburban lines were missing. So I've decided to add the B-Bus company group feed again, but this time in the proper country.