### PR TITLE
Add GTFS feed for South Korea

### DIFF
--- a/feeds/kr.json
+++ b/feeds/kr.json
@@ -1,0 +1,19 @@
+{
+    "maintainers": [
+      {
+        "name": "SungjunPark",
+        "github": "parkss404"
+      }
+    ],
+    "sources": [
+      {
+        "name": "korea",
+        "type": "http",
+        "url": "https://www.dropbox.com/scl/fi/l1rnl88xnegpmiuy44kmc/GTFS_DataSet.zip?rlkey=jub5anlfpsdoi9mgfy4qp7x9w&dl=1",
+        "license": {
+          "url": "https://www.ktdb.go.kr"
+        }
+      }
+    ]
+  }
+  


### PR DESCRIPTION
[KR] Add nationwide GTFS feed for South Korea #1154

The feed was added to feeds/kr.json.