### PR TITLE
Add MVG as Munich transport provider

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -15,6 +15,11 @@
     ],
     "sources": [
         {
+            "name": "MVG",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2333"
+        },
+        {
             "name": "DELFI",
             "type": "http",
             "url": "https://www.opendata-oepnv.de/ht/de/datensaetze/sharing?tx_vrrkit_view%5Bsharing%5D=eyJkYXRhc2V0IjoiZGV1dHNjaGxhbmR3ZWl0ZS1zb2xsZmFocnBsYW5kYXRlbi1ndGZzIn0",


### PR DESCRIPTION
To improve the accuracy of itineraries in Munich, the MVG entry from the Mobility Database should be added. 

I am not quite sure on which license to use, the MVG website does not specify any information about the license of their timetable data. 