### PR TITLE
Add GTFS-Flex support

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -129,6 +129,23 @@ This example applies the updates to the `lviv` feed:
 ]
 ```
 
+### On-demand feeds
+
+GTFS-Flex feeds can be added in the same way as regular GTFS feeds, just the `spec` field has to be set to `gtfs-flex`.
+
+Example:
+```json
+{
+    "name": "opentransportdataswiss-flex",
+    "type": "http",
+    "spec": "gtfs-flex",
+    "url": "https://data.opentransportdata.swiss/en/dataset/gtfsflex/permalink",
+    "license": {
+        "url": "https://opentransportdata.swiss/de/terms-of-use/"
+    }
+}
+```
+
 ### Shared Mobility feeds
 
 GBFS feeds contains realtime information like vehicle availability and characteristics for shared Mobility (e.g. Bikesharing).

--- a/feeds/ch.json
+++ b/feeds/ch.json
@@ -31,6 +31,15 @@
             "headers": {
                 "authorization": "Bearer eyJvcmciOiI2NDA2NTFhNTIyZmEwNTAwMDEyOWJiZTEiLCJpZCI6IjFmZjIzNTNmMDNiNTQyMzk4ZDdhN2M2NzMyNzczYTFmIiwiaCI6Im11cm11cjEyOCJ9"
             }
+        },
+        {
+            "name": "opentransportdataswiss-flex",
+            "type": "http",
+            "spec": "gtfs-flex",
+            "url": "https://data.opentransportdata.swiss/en/dataset/gtfsflex/permalink",
+            "license": {
+                "url": "https://opentransportdata.swiss/de/terms-of-use/"
+            }
         }
     ]
 }

--- a/src/generate-motis-config.py
+++ b/src/generate-motis-config.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
                             source = resolved_source
 
                     match source.spec:
-                        case "gtfs":
+                        case source.spec if source.spec in ["gtfs", "gtfs-flex"]:
                             schedule_file = \
                                 f"{region_name}_{source.name}.gtfs.zip"
                             name = f"{region_name}-{source.name}"


### PR DESCRIPTION
This is almost identical to static GTFS feeds, the only reason we need it to be a different type is that gtfsclean can't handle Flex feeds, so we need to skip that in post-processing.

Also, add the Swiss GTFS-Flex feed so we have something to test with.