### PR TITLE
Keep additional GTFS fields that gtfsclean doesn't know about

### DIFF
--- a/src/fetch.py
+++ b/src/fetch.py
@@ -344,6 +344,7 @@ class Fetcher:
                     "--check-null-coords",
                     "--empty-agency-url-repl", "https://transitous.org",
                     "--remove-red-services",
+                    "--keep-additional-fields",
                     "--output", str(temp_file)]
             if source.fix:
                 command.append("--fix")


### PR DESCRIPTION
We need this e.g. for the `cars_allowed` field for ferries and car transport trains. It will also help with preserving Fares v2 related fields, although that needs more work to also preserve unknown files.