### PR TITLE
Increase limits

### DIFF
--- a/motis/config.yml
+++ b/motis/config.yml
@@ -39,3 +39,12 @@ timetable:
 
 gbfs:
   feeds:
+
+limits:
+  stoptimes_max_results: 16384
+  plan_max_results: 256
+  plan_max_search_window_minutes: 5760
+  stops_max_results: 2048
+  onetoall_max_results: 524288
+  onetoall_max_travel_minutes: 2880
+  routing_max_timeout_seconds: 90


### PR DESCRIPTION
Proposition to increase some limits:
* `stoptimes_max_results` 256 -> 16384 (shouldn't require lots of processing power, responses about 10 MB)
* `onetoall_max_results` 2^16 -> 2^19 (responses about 90 MB)
* `onetoall_max_travel_minutes` 90 -> 2880 (query time still just a few seconds, because it's not much more expensive than a normal one-to-one query that goes similarly far)

The latter two allow an isochrone query for two day train travel across Europe with about 400k results with a query like this one (thanks to @MichaelKutzner !): `/api/experimental/one-to-all?one=48.836666588012065,2.347650720908547,0&maxTravelTime=2880&transitModes=HIGHSPEED_RAIL,LONG_DISTANCE,NIGHT_RAIL,REGIONAL_FAST_RAIL,REGIONAL_RAIL`

All others are the defaults. I have tested the limits and corresponding responses on the Transitous dataset without any issues. I think the main bottleneck could be the bandwidth. But I think there are many cool use cases for this (cf. https://github.com/motis-project/motis/pull/891, chronotrains.com, direkt.bahn.guru). If it gets too much we can still quickly reduce the limits again.