### PR TITLE
Ottawa's OCTranspo changed to direct feed

### DIFF
--- a/feeds/ca-on.json
+++ b/feeds/ca-on.json
@@ -231,14 +231,18 @@
         },
         {
             "name": "OCTranspo",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-f24-octranspo",
-            "fix": true
+            "type": "http",
+            "url": "https://oct-gtfs-emasagcnfmcgeham.z01.azurefd.net/public-access/GTFSExport.zip",
+            "http-options": {
+                "fetch-interval-days": 1
+            },
         },
         {
             "name": "OCTranspo",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-f24-octranspo~rt"
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://jbb.ghsq.de/gtfs/octranspo/TripUpdates",
+
         },
         {
             "name": "PCConnect",

--- a/feeds/ca-on.json
+++ b/feeds/ca-on.json
@@ -4,6 +4,10 @@
             "name": "Marcus Lundblad",
             "github": "mlundblad"
         }
+        {
+            "name": "Clinton Ignatov (OC Transpo)",
+            "github": "clintonthegeek"
+        }
     ],
     "sources": [
         {

--- a/feeds/ca-on.json
+++ b/feeds/ca-on.json
@@ -3,7 +3,7 @@
         {
             "name": "Marcus Lundblad",
             "github": "mlundblad"
-        }
+        },
         {
             "name": "Clinton Ignatov (OC Transpo)",
             "github": "clintonthegeek"

--- a/feeds/ca-on.json
+++ b/feeds/ca-on.json
@@ -235,11 +235,9 @@
         },
         {
             "name": "OCTranspo",
-            "type": "http",
-            "url": "https://oct-gtfs-emasagcnfmcgeham.z01.azurefd.net/public-access/GTFSExport.zip",
-            "http-options": {
-                "fetch-interval-days": 1
-            },
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-f24-octranspo",
+            "fix": true
         },
         {
             "name": "OCTranspo",

--- a/feeds/ca-on.json
+++ b/feeds/ca-on.json
@@ -242,7 +242,6 @@
             "type": "url",
             "spec": "gtfs-rt",
             "url": "https://jbb.ghsq.de/gtfs/octranspo/TripUpdates",
-
         },
         {
             "name": "PCConnect",

--- a/feeds/ca-on.json
+++ b/feeds/ca-on.json
@@ -243,7 +243,7 @@
             "name": "OCTranspo",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://jbb.ghsq.de/gtfs/octranspo/TripUpdates",
+            "url": "https://jbb.ghsq.de/gtfs/octranspo/TripUpdates"
         },
         {
             "name": "PCConnect",


### PR DESCRIPTION
I have amended the `ca-on.json` feed in two ways:
1) For the GTFS `.zip` file to be directly downloaded from OCTranspo's dedicated server.  to directly link to OC Transpo's official URL.
2) For the GTFS-RT data to be pulled from a proxy set up by JBB on the Transitous matrix channel, which obscures the secret API key necessary to download the data. The API key has been registered under my name and email address according to official processes and rules spelled out by [OCTranspo](https://www.octranspo.com/en/plan-your-trip/travel-tools/developers/dev-doc). 