### PR TITLE
Add Swiss GBFS feed

### DIFF
--- a/feeds/ch.json
+++ b/feeds/ch.json
@@ -40,6 +40,15 @@
             "license": {
                 "url": "https://opentransportdata.swiss/de/terms-of-use/"
             }
+        },
+        {
+            "name": "sharedmobility-ch",
+            "type": "url",
+            "url": "https://sharedmobility.ch/v2/gbfs",
+            "spec": "gbfs",
+            "headers": {
+                "authorization": "public-transport-backends@kde.org"
+            }
         }
     ]
 }


### PR DESCRIPTION
Unlike their previous version this one doesn't use extensions anymore that MOTIS doesn't support and seems to work fine from a quick local test.