### PR TITLE
Add Pace (us-il) from Mobility Database

### DIFF
--- a/feeds/us-il.json
+++ b/feeds/us-il.json
@@ -7,6 +7,10 @@
         {
             "name": "Kurt Kremitzki",
             "github": "kkremitzki"
+        },
+        {
+            "name": "Ethan C",
+            "github": "ethanc8"
         }
     ],
     "sources": [
@@ -21,6 +25,11 @@
             "http-options": {
                 "fetch-interval-days": 1
             }
+        },
+        {
+            "name": "Pace",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2347"
         },
         {
             "name": "SMTD",


### PR DESCRIPTION
Pace is a bus service operating in the Chicago suburbs. They provide a GTFS static feed, which can be downloaded from [their website](https://www.pacebus.com/route-timetable-data-services) and is included in [Mobility Database](https://mobilitydatabase.org/feeds/gtfs/mdb-2347) and [Transitland](https://mobilitydatabase.org/feeds/gtfs/mdb-2347).