### PR TITLE
Update br.json

### DIFF
--- a/feeds/br.json
+++ b/feeds/br.json
@@ -32,7 +32,7 @@
         {
             "name": "sao-paulo",
             "type": "mobility-database",
-            "mdb-id": "mdb-8"
+            "mdb-id": "mdb-8",
             "license": {
                 "spdx-identifier": "CC-BY-4.0"
             }


### PR DESCRIPTION
This PR adds the São Paulo SPTrans GTFS static feed to the Brazil (`br.json`) region file.

- Source: http://www.sptrans.com.br/umbraco/Surface/PerfilDesenvolvedor/BaixarGTFS
- License: CC-BY-4.0
- Maintainer: Heus Sueh (@Heus-Sueh)