### PR TITLE
Shared Mobility feeds for Romania

### DIFF
--- a/feeds/ro.json
+++ b/feeds/ro.json
@@ -101,14 +101,12 @@
         {
             "name": "Dej-Velo-City",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-dej~velo~city~gbfs",
-            "fix": true
+            "transitland-atlas-id": "f-dej~velo~city~gbfs"        
         },
         {
             "name": "Hunedoara-public-bike-system",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-hunedoara~gbfs",
-            "fix": true
+            "transitland-atlas-id": "f-hunedoara~gbfs"
         },
         {
             "name": "Iași",
@@ -130,8 +128,7 @@
         {
             "name": "Moinesti-public-bike-system",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-moinesti~gbfs",
-            "fix": true
+            "transitland-atlas-id": "f-moinesti~gbfs"
         },
         {
             "name": "Oradea",
@@ -146,15 +143,13 @@
         {
             "name": "Sântana-Velo",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-velo~sântana~gbfs",
-            "fix": true
+            "transitland-atlas-id": "f-velo~sântana~gbfs"
         },
         {
             "name": "Sibiu-BikeCity",
             "type": "url",
             "url": "https://sibiu.publicbikesystem.net/customer/gbfs/v2/gbfs.json",
-            "spec": "gbfs",
-            "fix": true
+            "spec": "gbfs"
         },
         {
             "name": "Sinaia",
@@ -209,8 +204,7 @@
             "name": "Târgu-Mures-public-bike-system",
             "type": "url",
             "url": "https://targumures.publicbikesystem.net/customer/gbfs/v2/gbfs.json",
-            "spec": "gbfs",
-            "fix": true
+            "spec": "gbfs"
         },
         {
             "name": "Zalău",


### PR DESCRIPTION
Added shared mobility feeds about half are provided by NextBike and the other half by another operator. The feeds by the later operator have generated [some errors on the mobility database ](https://storage.googleapis.com/mobilitydata-gbfs-snapshots-prod/gbfs-sibiu_bikecity/2.3/report_summary_20250709002718.json) however this shouldn't be an issues since it's caused by the way the operator defines the enums and the fix option should be able to fix this. (I am unable to test this since on my local machine I get the recent license errors).

There was also [another NextBike feed](https://mobilitydatabase.org/feeds/gbfs/gbfs-nextbike_rc) I wanted to add however for some reason it seems to have some elements in Germany? This is definitely not right so until I can investigate I'll hold it off.