### PR TITLE
MOTIS config.yml: enable routed transfers + elevator updates

### DIFF
--- a/motis/config.yml
+++ b/motis/config.yml
@@ -37,7 +37,7 @@ timetable:
   update_interval: 60
   http_timeout: 30
   incremental_rt_update: false
-  max_footpath_length: 15
+  max_footpath_length: 12
   extend_missing_footpaths: true
 # The datasets are filled in by ./src/generate-motis-config.py
   datasets:


### PR DESCRIPTION
Changes are only tested with the German DELFI dataset and not in production. So if we could deploy this on a staging instance (requires OSM) for some time, it would be better.

Changes:

- Enable osr_footpath which currently enables walking, wheelchair, and car transfers (bike could also be added in the same way): https://github.com/motis-project/motis/blob/566820bb099bac4e918336b4e349e3aef9ab098b/src/import.cc#L412-L430
- Enable elevator status update which updates wheelchair footpaths
- Not sure why `max_footpath_length` is set to 20min as this caused performance problems in big cities like Paris in the past. This PR changes it back to 15, which is also the default value.