### PR TITLE
Fix retrieving the Finish Digitraffic GTFS file

### DIFF
--- a/feeds/fi.json
+++ b/feeds/fi.json
@@ -35,7 +35,12 @@
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://www.digitraffic.fi/en/railway-traffic/"
             },
-            "fix": true
+            "fix": true,
+            "http-options": {
+                "headers": {
+                    "accept-encoding": "gzip"
+                }
+            }
         },
         {
             "name": "digitraffic",


### PR DESCRIPTION
That insists on an Accept-Encoding header set to gzip now, for transferring a zip-compressed file...

Fixes #1255