### PR TITLE
Link to latest gtfsclean release

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -189,7 +189,7 @@ You also need to have [gtfsclean](https://github.com/public-transport/gtfsclean)
 We provide a static build for linux so you don't need to build your own.
 
 ```
-wget -P ~/.local/bin https://github.com/public-transport/gtfsclean/releases/download/snapshot-4/gtfsclean
+wget -P ~/.local/bin https://github.com/public-transport/gtfsclean/releases/latest/download/gtfsclean
 chmod +x ~/.local/bin/gtfsclean
 ```
 


### PR DESCRIPTION
Snapshot 4 lacks the GTFS Flex support for example.