### PR TITLE
Add upcoming events section to the website

### DIFF
--- a/website/content/_index.html
+++ b/website/content/_index.html
@@ -45,6 +45,12 @@ routing service that does not stop at borders.</p>
 <p>If you know where to find public transport data for your region, or if you are a public transport operator, you can help by adding the feed to our data set.</p>
 <a class="btn btn-primary theme-button text-black" href="https://transitous.org/doc#adding-a-region"><i class="bi bi-arrow-right m-1"></i>Contributor Documentation</a>
 
+<h2>Upcoming Events</h2>
+<p>Want to meet the Transitous community in person? Some of us will be at the following events:</p>
+<ul>
+  <li><a href="https://open-transport.org">Open Transport Community Conference</a>, Oct 17/18 2025, Vienna, Austria.</li>
+</ul>
+
 <h2>Conference Talks and Presentations</h2>
 <p>Looking for an overview of how this project works? There are several public talks from conferences and meetups that you can watch.</p>
 


### PR DESCRIPTION
Usually we have at least one already scheduled event some of us are attending, between Congress, FOSDEM, FOSSGIS Konferenz, OTCC and hack weekends, without even including things like Guadec/Akademy that are more specific for some of the Transitous-using apps.