### PR TITLE
Update nl.json to solve #1347 and #1366

### DIFF
--- a/feeds/nl.json
+++ b/feeds/nl.json
@@ -18,8 +18,7 @@
             "license": {
                 "spdx-identifier": "CC0 1.0 Universal",
                 "url": "https://gtfs.openov.nl/LICENSE.TXT"
-            },
-        
+            }
         },
         {
             "name": "OpenOV",
@@ -59,6 +58,6 @@
             "type": "url",
             "spec": "gtfs-rt",
             "url": "https://gtfs.ovapi.nl/nl/trainUpdates.pb"
-        },
+        }
     ]
 }

--- a/feeds/nl.json
+++ b/feeds/nl.json
@@ -16,7 +16,7 @@
             "url" : "https://gtfs.openov.nl/gtfs-rt/gtfs-openov-nl.zip",
             "fix": true,
             "license": {
-                "spdx-identifier": "CC0 1.0 Universal",
+                "spdx-identifier": "CC0-1.0",
                 "url": "https://gtfs.openov.nl/LICENSE.TXT"
             }
         },

--- a/feeds/nl.json
+++ b/feeds/nl.json
@@ -44,6 +44,21 @@
             "type": "url",
             "spec": "gtfs-rt",
             "url": "https://gtfs.openov.nl/gtfs-rt/vehiclePositions.pb"
-        }
+        },
+        {
+            "name": "ovapi",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-u-nl",
+            "fix": true,
+            "keep-agency-names": [
+                "Eu Sleeper"
+            ]
+        },
+        {
+            "name": "ovapi",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://gtfs.ovapi.nl/nl/trainUpdates.pb"
+        },
     ]
 }

--- a/feeds/nl.json
+++ b/feeds/nl.json
@@ -3,32 +3,47 @@
         {
             "name": "Jonah Brüchert",
             "github": "jbruechert"
+        },
+        {
+            "name": "Sander van Hoogdalem",
+            "github": "sandervhoogdalem"
         }
     ],
     "sources": [
         {
-            "name": "ovapi",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-u-nl",
-            "fix": true
+            "name": "OpenOV",
+            "type": "http",
+            "url" : "https://gtfs.openov.nl/gtfs-rt/gtfs-openov-nl.zip",
+            "fix": true,
+            "license": {
+                "spdx-identifier": "CC0 1.0 Universal",
+                "url": "https://gtfs.openov.nl/LICENSE.TXT"
+            },
+        
         },
         {
-            "name": "ovapi",
+            "name": "OpenOV",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfs.ovapi.nl/nl/trainUpdates.pb"
+            "url": "https://gtfs.openov.nl/gtfs-rt/trainUpdates.pb"
         },
         {
-            "name": "ovapi",
+            "name": "OpenOV",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfs.ovapi.nl/nl/tripUpdates.pb"
+            "url": "https://gtfs.openov.nl/gtfs-rt/tripUpdates.pb"
         },
         {
-            "name": "ovapi",
+            "name": "OpenOV",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfs.ovapi.nl/nl/alerts.pb"
+            "url": "https://gtfs.openov.nl/gtfs-rt/alerts.pb"
+        },
+        {
+            "name": "OpenOV",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://gtfs.openov.nl/gtfs-rt/vehiclePositions.pb"
         }
     ]
 }

--- a/src/fetch.py
+++ b/src/fetch.py
@@ -376,6 +376,11 @@ class Fetcher:
                 for agency in source.drop_agency_names:
                     command.append("--drop-agency-names")
                     command.append(agency)
+            if source.keep_agency_names:
+                for agency in source.keep_agency_names:
+                    command.append("--keep-agency-names")
+                    command.append(agency)
+                command.append("--delete-orphans")
             if source.display_name_options:
                 if source.display_name_options.copy_trip_names_matching:
                     command.append("--copy-trip-names-matching")

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -51,6 +51,7 @@ class Source:
     drop_too_fast_trips: bool = True
     drop_shapes: bool = False
     drop_agency_names: List[str] = []
+    keep_agency_names: List[str] = []
     display_name_options: Optional[DisplayNameOptions] = None
 
     def __init__(self, parsed: Optional[dict] = None):
@@ -81,6 +82,8 @@ class Source:
                 self.drop_shapes = parsed["drop-shapes"]
             if "drop-agency-names" in parsed:
                 self.drop_agency_names = parsed["drop-agency-names"]
+            if "keep-agency-names" in parsed:
+                self.keep_agency_names = parsed["keep-agency-names"]
             if "display-name-options" in parsed:
                 self.display_name_options = \
                     DisplayNameOptions(parsed["display-name-options"])


### PR DESCRIPTION
Change the datasource from OVApi to OpenOV to solve issue #1347 and #1366.

With this change, the stoparea's are not longer available in the dataset. 

Issue #1366 will be solved because without the stoparea's, every stop with the same name will return their departures instead of just the one that is selected. 

Issue #1347 will also be solved because without the stoparea's, every stop will only return their departures and not the departures of locations on the other side of the country.