### PR TITLE
DE: Using the DELFI SIRI feeds

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -41,10 +41,10 @@
             "name": "DELFI",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "http://ipv4.stc.traines.eu/mirror/german-delfi-gtfs-rt/latest.gtfs-rt.pbf",
+            "url": "https://germany.motis-project.org/gtfsrt",
             "license": {
                 "spdx-identifier": "CC-BY-SA-4.0",
-                "url": "https://mobilithek.info/offers/858688352316981248"
+                "url": "https://germany.motis-project.org/LICENSE.txt"
             }
         },
         {


### PR DESCRIPTION
I think it's good enough to switch to the matched SIRI feeds (updated every 5 minutes only). This also still includes the data from the DELFI GTFS-RT Feed (updated every minute).
Not adding Service Alerts for the time being due to https://github.com/mfdz/GTFS-Issues/issues/189.