### PR TITLE
Fix grouping of subdivisions

### DIFF
--- a/src/generate-attribution.py
+++ b/src/generate-attribution.py
@@ -173,7 +173,7 @@ def get_region_data(code: str) -> dict:
 
 
 def attribute_sort_key(attr):
-    return (attr[1].get("country_name", ""), attr[1].get("subdivision_name", ""), attr[1].get("human_name", ""), attr[1].get("filename", ""))
+    return (attr[1].get("country_name", ""), attr[1].get("subdivision_name", ""), attr[1].get("human_name", "").lower(), attr[1].get("filename", "").lower())
 
 
 if __name__ == "__main__":

--- a/website/layouts/shortcodes/source-table.html
+++ b/website/layouts/shortcodes/source-table.html
@@ -16,7 +16,7 @@ summary h3 {
 </style>
 
 {{ $lastCountry := "_initial_" }}
-{{ $lastSubdivision := "_initial_" }}
+{{ $lastSubdivision := "" }}
 {{ range $index, $source := $.Site.Data.license }}
   {{ $country := .country_name }}
   {{ $subdivision := .subdivision_name }}
@@ -24,9 +24,9 @@ summary h3 {
   <!--If new region, open a new <details> section -->
   {{ if ne $country $lastCountry }}
     <!-- If it's not the first <details> section, first close the previous one -->
-    {{ if ne $lastSubdivision "_initial_" }}
+    {{ if $lastSubdivision }}
       </details>
-      {{ $lastSubdivision = "_initial_" }}
+      {{ $lastSubdivision = "" }}
     {{ end }}
     {{ if ne $lastCountry "_initial_" }}
       </details>
@@ -36,7 +36,7 @@ summary h3 {
   {{ end }}
 
   {{ if ne $subdivision $lastSubdivision }}
-    {{ if ne $lastSubdivision "_initial_" }}
+    {{ if $lastSubdivision }}
       </details>
     {{ end }}
     {{ if $subdivision }}


### PR DESCRIPTION
With the new sorting the empty subdivisions come first, which the previous code didn't handle properly.

Also, sort feed names case-insensitively.