### PR TITLE
nz: add AT RT key and protobuf accept header

### DIFF
--- a/feeds/nz.json
+++ b/feeds/nz.json
@@ -15,8 +15,12 @@
             "name": "AT",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-auckland~transport~rt",
-            "skip": true,
-            "skip-reason": "api-key is missing"
+            "api-key": "5a8bd844b5c941a188a17d6ed968c070",
+            "http-options": {
+                "headers": {
+                    "Accept": "application/x-protobuf"
+                }
+            }
         },
         {
             "name": "Metlink",


### PR DESCRIPTION
cc @Hoverth

The `Accept: application/x-protobuf` header is there since by default AT's APIs will return a JSON version of the feed.