### PR TITLE
sk: add SAD Prievidza

### DIFF
--- a/feeds/sk.json
+++ b/feeds/sk.json
@@ -32,6 +32,7 @@
         {
             "name": "sadpd",
             "type": "http",
+            "fix": true,
             "url": "https://gtfs.transdata.sk/SADPD/gtfs.zip"
         }
     ]

--- a/feeds/sk.json
+++ b/feeds/sk.json
@@ -7,6 +7,10 @@
         {
             "name": "Marcus Lundblad",
             "github": "mlundblad"
+        },
+        {
+            "name": "Jozef Steinhübl",
+            "github": "xhyrom"
         }
     ],
     "sources": [
@@ -24,6 +28,11 @@
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u2s1vm0ergtc~bratislava",
             "url-override": "https://www.arcgis.com/sharing/rest/content/items/aba12fd2cbac4843bc7406151bc66106/data"
+        },
+        {
+            "name": "sadpd",
+            "type": "http",
+            "url": "https://transiq.xhyrom.dev/gtfs/sk/sadpd.zip"
         }
     ]
 }

--- a/feeds/sk.json
+++ b/feeds/sk.json
@@ -32,7 +32,7 @@
         {
             "name": "sadpd",
             "type": "http",
-            "url": "https://transiq.xhyrom.dev/gtfs/sk/sadpd.zip"
+            "url": "https://gtfs.transdata.sk/SADPD/gtfs.zip"
         }
     ]
 }


### PR DESCRIPTION
https://github.com/xhyrom/transiq/commit/f1fe7d7e0d0915d08b306805fd7ebe40c3d8263d

Use my own mirror as the data source. This allows me to build a scraper for other companies and potentially replace this source if it becomes restricted, as has happened with others.

The current data comes from [TransData](https://www.transdata.sk/), the company behind [Ubian](https://ubian.sk/). I also found [gtfs.transdata.sk](https://gtfs.transdata.sk), where some of this data is accessible without authorization.