### PR TITLE
sk: add SAD Žilina

### DIFF
--- a/feeds/sk.json
+++ b/feeds/sk.json
@@ -33,7 +33,7 @@
             "name": "sadza",
             "type": "http",
             "fix": true,
-            "url": "https://gtfs.transdata.sk/SADZA/gtfs.zip",
+            "url": "https://gtfs.transdata.sk/SADZA/gtfs.zip"
         },
         {
             "name": "sadpd",


### PR DESCRIPTION
https://github.com/xhyrom/transiq/commit/f1fe7d7e0d0915d08b306805fd7ebe40c3d8263d

Use my own mirror as the data source. This allows me to build a scraper for other companies and potentially replace this source if it becomes restricted, as has happened with others.

The current data comes from [TransData](https://www.transdata.sk/), the company behind [Ubian](https://ubian.sk/). I also found [gtfs.transdata.sk](https://gtfs.transdata.sk), where some of this data is accessible without authorization.