### PR TITLE
Support Transitland feeds with multiple GTFS-RT URLs

### DIFF
--- a/src/fetch.py
+++ b/src/fetch.py
@@ -267,12 +267,12 @@ class Fetcher:
     def resolve_database_sources(self, source: Source) -> Source:
         match source:
             case TransitlandSource():
-                http_source = self.transitland_atlas.source_by_id(source)
+                http_source = self.transitland_atlas.sources_by_id(source)
                 if not http_source:
                     eprint("Error: Could not resolve", source.transitland_atlas_id)
                     sys.exit(1)
 
-                return http_source
+                return http_source[0]  # multi-source feeds only occur for GTFS-RT, which we don't handle here
             case MobilityDatabaseSource():
                 if not self.mobility_database:
                     self.mobility_database = mobilitydatabase.Database.load()

--- a/src/generate-motis-config.py
+++ b/src/generate-motis-config.py
@@ -98,45 +98,48 @@ if __name__ == "__main__":
                     if source.skip:
                         continue
 
+                    resolved_sources = []
                     match source:
                         case metadata.TransitlandSource():
-                            resolved_source = atlas.source_by_id(source)
-                            if not resolved_source:
+                            resolved_sources = atlas.sources_by_id(source)
+                            if not resolved_sources:
                                 eprint("Error: Could not resolve", source.transitland_atlas_id)
                                 sys.exit(1)
-                            source = resolved_source
                         case metadata.MobilityDatabaseSource():
                             resolved_source = mdb.source_by_id(source)
                             if not resolved_source:
                                 eprint("Error: Could not resolve", source.mdb_id)
                                 sys.exit(1)
-                            source = resolved_source
+                            resolved_sources = [resolved_source]
+                        case _:
+                            resolved_sources = [source]
 
-                    match source.spec:
-                        case source.spec if source.spec in ["gtfs", "gtfs-flex"]:
-                            schedule_file = \
-                                f"{region_name}_{source.name}.gtfs.zip"
-                            name = f"{region_name}-{source.name}"
-                            if (not arguments.skip_missing_files) or check_file_exist_in_out_folder(schedule_file):
-                                config["timetable"]["datasets"][name] = \
-                                    {
-                                        "path": schedule_file,
-                                        "extend_calendar": source.extend_calendar
-                                    }
-                                if source.default_timezone is not None:
-                                    config["timetable"]["datasets"][name]["default_timezone"] = source.default_timezone
-                                if source.script is not None:
-                                    if not os.path.exists(os.path.join(script_dir, source.script)):
-                                        eprint(f"Error: Import script {source.script} for {name} could not be found.")
-                                        sys.exit(1)
-                                    config["timetable"]["datasets"][name]["script"] = f"scripts/{source.script}"
-                            else:
-                                print("Warning: Skipping " + name + " as " + schedule_file + " is missing.")
-                                ignored_feeds.add(name)
+                    for source in resolved_sources:
+                        match source.spec:
+                            case source.spec if source.spec in ["gtfs", "gtfs-flex"]:
+                                schedule_file = \
+                                    f"{region_name}_{source.name}.gtfs.zip"
+                                name = f"{region_name}-{source.name}"
+                                if (not arguments.skip_missing_files) or check_file_exist_in_out_folder(schedule_file):
+                                    config["timetable"]["datasets"][name] = \
+                                        {
+                                            "path": schedule_file,
+                                            "extend_calendar": source.extend_calendar
+                                        }
+                                    if source.default_timezone is not None:
+                                        config["timetable"]["datasets"][name]["default_timezone"] = source.default_timezone
 
-                        case "gtfs-rt" if isinstance(source, metadata.UrlSource):
-                            name = f"{region_name}-{source.name}"
-                            if name not in ignored_feeds:
+                                    if source.script is not None:
+                                        if not os.path.exists(os.path.join(script_dir, source.script)):
+                                            eprint(f"Error: Import script {source.script} for {name} could not be found.")
+                                            sys.exit(1)
+                                        config["timetable"]["datasets"][name]["script"] = f"scripts/{source.script}"
+                                else:
+                                    print("Warning: Skipping " + name + " as " + schedule_file + " is missing.")
+                                    ignored_feeds.add(name)
+
+                            case "gtfs-rt" if isinstance(source, metadata.UrlSource):
+                                name = f"{region_name}-{source.name}"
                                 if name not in config["timetable"]["datasets"]:
                                     eprint(
                                         "Error: The name of a realtime (gtfs-rt) "
@@ -161,11 +164,11 @@ if __name__ == "__main__":
                                 config["timetable"]["datasets"][name]["rt"] \
                                     .append(rt_feed)
 
-                        case "gbfs" if isinstance(source, metadata.UrlSource):
-                            name = f"{region_name}-{source.name}"
-                            config["gbfs"]["feeds"][name] = {"url": source.url}
-                            if source.headers:
-                                config["gbfs"]["feeds"][name]["headers"] = source.headers
+                            case "gbfs" if isinstance(source, metadata.UrlSource):
+                                name = f"{region_name}-{source.name}"
+                                config["gbfs"]["feeds"][name] = {"url": source.url}
+                                if source.headers:
+                                    config["gbfs"]["feeds"][name]["headers"] = source.headers
 
         with open("out/config.yml", "w") as fo:
             yaml.dump(config, fo)


### PR DESCRIPTION
This gives us a whole bunch of additional GTFS-RT feeds, mostly service alerts but also a few more trip update ones.

This does not filter out vehicle position feeds, which would generate extra load for no benefit, so presumably we want to do that for now? There seem to be feeds with vehicle position data only currently being added, those would break as a result though.

Fixes #1328.