### PR TITLE
Update ba.json, hr.json, rs.json & si.json

### DIFF
--- a/feeds/ba.json
+++ b/feeds/ba.json
@@ -29,7 +29,8 @@
         {
             "name": "Mostar",
             "type": "http",
-            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/mobus_gtfs.zip?job=mostar"
+            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/mobus_gtfs.zip?job=mostar",
+            "fix": true
         }
     ]
 }

--- a/feeds/ba.json
+++ b/feeds/ba.json
@@ -29,7 +29,7 @@
         {
             "name": "Mostar",
             "type": "http",
-            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/zadar_gtfs.zip?job=zadar"
+            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/mobus_gtfs.zip?job=mostar"
         }
     ]
 }

--- a/feeds/hr.json
+++ b/feeds/hr.json
@@ -152,7 +152,7 @@
             "name": "zadar",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://owncloud.cesnet.cz/index.php/s/hoLRLvxxORnoPOw/download"
+            "url": "https://rt.gtfs.baguette.pirnet.si/gtfs-rt/liburnijaZadar/trip_updates.pb"
         },
         {
             "name": "karlovac",

--- a/feeds/hr.json
+++ b/feeds/hr.json
@@ -146,7 +146,7 @@
         {
             "name": "zadar",
             "type": "http",
-            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/zadar_gtfs.zip?job=zadar",
+            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/zadar_gtfs.zip?job=zadar"
         },
         {
             "name": "zadar",

--- a/feeds/hr.json
+++ b/feeds/hr.json
@@ -147,7 +147,6 @@
             "name": "zadar",
             "type": "http",
             "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/zadar_gtfs.zip?job=zadar",
-            "fix": true
         },
         {
             "name": "zadar",

--- a/feeds/hr.json
+++ b/feeds/hr.json
@@ -146,7 +146,8 @@
         {
             "name": "zadar",
             "type": "http",
-            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/zadar_gtfs.zip?job=zadar"
+            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/zadar_gtfs.zip?job=zadar",
+            "fix": true
         },
         {
             "name": "zadar",
@@ -157,7 +158,8 @@
         {
             "name": "karlovac",
             "type": "http",
-            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/karlovac_gtfs.zip?job=karlovac"
+            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/karlovac_gtfs.zip?job=karlovac",
+            "fix": true
         }
     ]
 }

--- a/feeds/hr.json
+++ b/feeds/hr.json
@@ -24,6 +24,12 @@
             }
         },
         {
+            "name": "hz",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "http://rt.gtfs.baguette.pirnet.si/gtfs-rt/HZPP/trip_updates.pb"
+        },
+        {
             "name": "zet",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u25k-zagrebačkielektričnitramvaj",
@@ -65,6 +71,12 @@
             "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/split_gtfs.zip?job=split"
         },
         {
+            "name": "split",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "http://rt.gtfs.baguette.pirnet.si/gtfs-rt/prometSplit/trip_updates.pb"
+        },
+        {
             "name": "rijeka",
             "type": "http",
             "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/autotrolej_gtfs.zip?job=rijeka",
@@ -77,6 +89,12 @@
             "name": "sisak",
             "type": "http",
             "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/ap_sisak_gtfs.zip?job=sisak"
+        },
+        {
+            "name": "sisak",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "http://rt.gtfs.baguette.pirnet.si/gtfs-rt/apSisak/trip_updates.pb"
         },
         {
             "name": "dubrovnik-libertas",

--- a/feeds/rs.json
+++ b/feeds/rs.json
@@ -9,7 +9,8 @@
         {
             "name": "Srbijavoz",
             "type": "http",
-            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/srbijavoz_gtfs.zip?job=srbijavoz"
+            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/srbijavoz_gtfs.zip?job=srbijavoz",
+            "fix": true
         },
         {
             "name": "Srbijavoz",

--- a/feeds/rs.json
+++ b/feeds/rs.json
@@ -9,14 +9,13 @@
         {
             "name": "Srbijavoz",
             "type": "http",
-            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/srbijavoz_gtfs.zip?job=srbijavoz",
+            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/srbijavoz_merged.zip?job=srbijavoz_merge",
             "fix": true
         },
         {
             "name": "Srbijavoz",
             "type": "url",
-            "spec": "gtfs-rt",
-            "url": "http://rt.gtfs.baguette.pirnet.si/gtfs-rt/Srbijavoz/trip_updates.pb"
+            "url": "http://rt.gtfs.baguette.pirnet.si/gtfs-rt/Srbijavoz_ghl/trip_updates.pb"
         },
         {
             "name": "Subotica",

--- a/feeds/rs.json
+++ b/feeds/rs.json
@@ -9,7 +9,13 @@
         {
             "name": "Srbijavoz",
             "type": "http",
-            "url": "https://jbb.ghsq.de/gtfs/rs-srbijavoz.gtfs.zip"
+            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/srbijavoz_gtfs.zip?job=srbijavoz"
+        },
+        {
+            "name": "Srbijavoz",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "http://rt.gtfs.baguette.pirnet.si/gtfs-rt/Srbijavoz/trip_updates.pb"
         },
         {
             "name": "Subotica",

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -74,7 +74,7 @@
         {
             "name": "maribor",
             "type": "http",
-            "url": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/marprom_official/latest/marprom_gtfs.zip",
+            "url": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/marprom_official/latest/marprom_gtfs.zip"
         },
         {
             "name": "maribor",
@@ -85,7 +85,7 @@
         {
             "name": "celje",
             "type": "http",
-            "url": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/CELEBUS/latest/celje.zip",
+            "url": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/CELEBUS/latest/celje.zip"
         },
         {
             "name": "celje",

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -74,7 +74,8 @@
         {
             "name": "maribor",
             "type": "http",
-            "url": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/marprom_official/latest/marprom_gtfs.zip"
+            "url": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/marprom_official/latest/marprom_gtfs.zip",
+            "fix": true
         },
         {
             "name": "maribor",
@@ -85,7 +86,8 @@
         {
             "name": "celje",
             "type": "http",
-            "url": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/CELEBUS/latest/celje.zip"
+            "url": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/CELEBUS/latest/celje.zip",
+            "fix": true
         },
         {
             "name": "celje",

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -75,7 +75,6 @@
             "name": "maribor",
             "type": "http",
             "url": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/marprom_official/latest/marprom_gtfs.zip",
-            "fix": true
         },
         {
             "name": "maribor",
@@ -87,7 +86,6 @@
             "name": "celje",
             "type": "http",
             "url": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/CELEBUS/latest/celje.zip",
-            "fix": true
         },
         {
             "name": "celje",

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -10,12 +10,18 @@
             "name": "nap",
             "type": "http",
             "url": "https://b2b.nap.si/data/b2b.gtfs",
-            "url-override": "https://jbb.ghsq.de/gtfs/si-nap.gtfs.zip",
+            "url-override": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/IJPP/latest/ijpp_gtfs.zip",
             "fix": true,
             "license": {
                 "spdx-identifier": "CC-BY-SA-4.0",
                 "url": "https://nap.si/en/datasets_details?id=6fc3966a-5e3f-cf10-1df3-70d3af14d03d"
             }
+        },
+        {
+            "name": "nap",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://rt.gtfs.derp.si/sources/ijpp/trip_updates"
         },
         {
             "name": "lpp",
@@ -64,6 +70,28 @@
                 "spdx-identifier": "CC-BY-SA-4.0",
                 "url": "https://nap.si/en/datasets_details?id=7110f4c4-3581-4b91-a826-6843ee4d7201"
             }
+        },
+        {
+            "name": "maribor",
+            "type": "http",
+            "url": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/marprom_official/latest/marprom_gtfs.zip"
+        },
+        {
+            "name": "maribor",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://rt.gtfs.derp.si/sources/marprom/trip_updates"
+        },
+        {
+            "name": "celje",
+            "type": "http",
+            "url": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/CELEBUS/latest/celje.zip"
+        },
+        {
+            "name": "celje",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://rt.gtfs.derp.si/sources/celje/trip_updates"
         }
     ]
 }


### PR DESCRIPTION
Fixes:
- Mostar GTFS URL

Changes:
- Srbijavoz GTFS to different merged source between OeBB HAFAS & w3.srbvoz.rs
- IJPP GTFS to use a processed version, that is more user friendly
- Liburnija Zadar GTFS-RT source

Adds:
- HŽPP GTFS-RT
- Split GTFS-RT
- Sisak GTFS-RT
- IJPP GTFS-RT
- Maribor GTFS & GTFS-RT
- Celje GTFS & GTFS-RT
- Srbijavoz GTFS-RT