### PR TITLE
Add support for MOTIS v2.2 import scripts

### DIFF
--- a/src/generate-motis-config.py
+++ b/src/generate-motis-config.py
@@ -33,6 +33,7 @@ if __name__ == "__main__":
     arguments = parser.parse_args()
 
     feed_dir = Path("feeds/")
+    script_dir = Path("scripts/")
 
     atlas = transitland.Atlas.load(Path("transitland-atlas/"))
     mdb = mobilitydatabase.Database.load()
@@ -118,6 +119,8 @@ if __name__ == "__main__":
                                 }
                             if source.default_timezone is not None:
                                 config["timetable"]["datasets"][name]["default_timezone"] = source.default_timezone
+                            if os.path.exists(os.path.join(script_dir, f"{name}.lua")):
+                                config["timetable"]["datasets"][name]["script"] = f"{script_dir}/{name}.lua"
 
                         case "gtfs-rt" if isinstance(source, metadata.UrlSource):
                             name = f"{region_name}-{source.name}"
@@ -153,3 +156,7 @@ if __name__ == "__main__":
 
         with open("out/config.yml", "w") as fo:
             yaml.dump(config, fo)
+
+    # copy scripts
+    shutil.rmtree("out/scripts", ignore_errors=True)
+    shutil.copytree(script_dir, "out/scripts")


### PR DESCRIPTION
The idea here is to have a top-level folder "scripts" containing scripts named after the feeds they are for.

The upside of this is that we don't need to maintain a separate configuration, and common code needed for multiple feeds can be factored out into a shared file.

The downside is that any deviation in the naming will make this silently ignore the script.