### PR TITLE
website: api: Pin documentation link to deployed version and remove duplicated info

### DIFF
--- a/website/content/api.html
+++ b/website/content/api.html
@@ -11,9 +11,6 @@ SPDX-FileCopyrightText: 2024 Jonah Brüchert <jbb@kaidan.im>
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-The API provided by Transitous can be used for free, but we recommend that you let us know if you use it, so your use case can be considered in future decisions.
-You can do that by <a href="https://github.com/public-transport/transitous/blob/b2d184b51cb4cf20fb48d0b76420ba57f4d3fce0/website/content/_index.html#L30">adding your app to our website</a> and/or letting us know in our <a href="https://matrix.to/#/%23transitous:matrix.spline.de">Matrix channel</a>.
-
 <h2>Usage Policy</h2>
 
 <p>Transitous is provided by a community of volunteers to fulfill the needs of Free and Open Source applications and other non-profit activities.
@@ -59,7 +56,7 @@ We will make a decision on a case-by-case basis.
 
 <p>Our API endpoint is located at <code>https://api.transitous.org/api/</code>.</p>
 
-<a class="btn btn-primary text-black" href="https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/motis-project/motis/refs/heads/master/openapi.yaml">API Documentation</a>
+<a class="btn btn-primary text-black" href="https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/motis-project/motis/refs/tags/v2.1.6/openapi.yaml">API Documentation</a>
 
 <h2>Client Libraries</h2>
 <div class="mt-4 app-card-row">


### PR DESCRIPTION
This is also part of the usage policy, I don't see a reason to duplicate
it.
