### PR TITLE
Add Intercity RT and more zbiorkom.live feeds

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -20,6 +20,15 @@
             "transitland-atlas-id": "f-pkp~intercity~pl"
         },
         {
+            "name": "PKP-Intercity",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://gtfs.kasznia.net/rt/pkpic.pb",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            }
+        },
+        {
             "name": "PKP-Intercity-Germany",
             "type": "http",
             "url": "https://kasmar00.github.io/gtfs-pkp-de/latest.zip",
@@ -102,6 +111,15 @@
             "type": "url",
             "spec": "gtfs-rt",
             "url": "https://cdn.zbiorkom.live/gtfs-rt/warsaw.pb",
+            "license": {
+                "spdx-identifier": "MIT"
+            }
+        },
+        {
+            "name": "SKM-Warszawa",
+            "type":"http",
+            "spec": "gtfs",
+            "url": "https://cdn.zbiorkom.live/gtfs/pkp-skmw.zip",
             "license": {
                 "spdx-identifier": "MIT"
             }
@@ -649,6 +667,15 @@
             "type": "url",
             "spec": "gtfs-rt",
             "url": "https://cdn.zbiorkom.live/gtfs-rt/legnica.pb",
+            "license": {
+                "spdx-identifier": "MIT"
+            }
+        },
+        {
+            "name": "Grodziskie-Przewozy-Autobusowe",
+            "type": "http",
+            "spec": "gtfs",
+            "url": "https://cdn.zbiorkom.live/gtfs/warsaw-gpa.zip",
             "license": {
                 "spdx-identifier": "MIT"
             }


### PR DESCRIPTION
Adds:
- Realtime feed for PKP Intercity - generated based on zbiorkom.live data (trip updates and alerts). I had my own instance running with it for a few days and it looks alright.
- SKM Warszawa Feed (_Warsaw Sbahn_) - it was previously in `Warszawa` Feed but was moved to own feed by zbiorkom.live maintainer
- Grodziskie Przewozy Autobusowe - new feed from zbiorkom.live