### PR TITLE
sk: add feeds and replace low-quality TransData sources

### DIFF
--- a/feeds/sk.json
+++ b/feeds/sk.json
@@ -119,6 +119,11 @@
             "name": "SAD-Zvolen",
             "type": "http",
             "url": "https://transiq.xhyrom.dev/gtfs/sk/sad-zvolen-as.zip"
+        },
+        {
+            "name": "Slovak-Lines-Express",
+            "type": "http",
+            "url": "https://transiq.xhyrom.dev/gtfs/sk/slovak-lines-express-as.zip"
         }
     ]
 }


### PR DESCRIPTION
This PR adds additional Slovak feeds and improves overall data quality.

* **Added** feeds that are automatically scraped and converted from XLSX to GTFS.
  Source: http://portal.cp.sk/.
* **Removed** GTFS feeds from **TransData** due to poor quality and replaced them with our own converted versions (e.g., SADZA, SADPD, SADLC).

The scraping and conversion are handled by [transiq/cis](https://github.com/xhyrom/transiq/tree/main/cis).