### PR TITLE
Add RT for LPP (SI) and Autotrolej (HR)

### DIFF
--- a/feeds/hr.json
+++ b/feeds/hr.json
@@ -86,6 +86,12 @@
             }
         },
         {
+            "name": "rijeka",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://rt-misc.ojpp-http.pirnet.si/autotrolej/trip-updates.pb"
+        },
+        {
             "name": "sisak",
             "type": "http",
             "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/ap_sisak_gtfs.zip?job=sisak"
@@ -136,12 +142,6 @@
             "name": "vela-luka",
             "type": "http",
             "url": "https://owncloud.cesnet.cz/index.php/s/Y5Xf2hAiP5z7q6U/download"
-        },
-        {
-            "name": "autotrolej",
-            "type": "http",
-            "url": "https://b2b.promet-info.hr/dc/b2b.gtfs.at",
-            "url-override": "https://jbb.ghsq.de/gtfs/hr-at.gtfs.zip"
         },
         {
             "name": "zadar",

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -32,6 +32,12 @@
             }
         },
         {
+            "name": "lpp",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://rt.gtfs.derp.si/sources/lpp/all"
+        },
+        {
             "name": "jesenice",
             "type": "http",
             "url": "https://b2b.nap.si/data/b2b.gtfs.jesenice",


### PR DESCRIPTION
- Adds trip updates and service alerts for LPP. Closes #651 
- Adds trip updates for Autotrolej and removes NAP feed (duplicate and outdated compared to other feed).