### PR TITLE
nz: fix Flamingo naming

### DIFF
--- a/feeds/nz.json
+++ b/feeds/nz.json
@@ -22,37 +22,37 @@
             "url": "https://jbb.ghsq.de/gtfs/at/legacy"
         },
                 {
-            "name": "Flamingo",
+            "name": "Flamingo-Auckland",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-flamingo~auckland~gbfs"
         },
         {
-            "name": "Flamingo",
+            "name": "Flamingo-Dunedin",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-flamingo~dunedin~gbfs"
         },
         {
-            "name": "Flamingo",
+            "name": "Flamingo-Palmerston-North",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-flamingo~palmerston~north~gbfs"
         },
         {
-            "name": "Flamingo",
+            "name": "Flamingo-Porirua",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-flamingo~porirua~gbfs"
         },
         {
-            "name": "Flamingo",
+            "name": "Flamingo-Waimakariri",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-flamingo~waimakariri~district~gbfs"
         },
         {
-            "name": "Flamingo",
+            "name": "Flamingo-Wellington",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-flamingo~wellington~gbfs"
         },
         {
-            "name": "Flamingo",
+            "name": "Flamingo-Tauranga",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-flamingo~tauranga~gbfs"
         },


### PR DESCRIPTION
self explanatory, fixes the naming of the Flamingo feeds so that all of them actually show up