### PR TITLE
au: add Tasmania and Transperth feeds

### DIFF
--- a/feeds/au.json
+++ b/feeds/au.json
@@ -11,6 +11,10 @@
         {
             "name": "David Wales",
             "github": "daviewales"
+        },
+        {
+            "name": "applecuckoo",
+            "github": "applecuckoo"
         }
     ],
     "sources": [
@@ -164,6 +168,23 @@
             "name": "Public-Transit-Victoria-(PTV)",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-r1-ptv"
+        },
+        {
+            "name": "Tasmanian-Department-of-State-Growth",
+            "type": "http",
+            "spec": "gtfs",
+            "url": "https://www.transport.tas.gov.au/public_transport/gtfs-data",
+            "function": "data_tasmania_latest_resource",
+            "license": {
+                "spdx_identifier": "CC-BY-4.0"
+            },
+            "fix": true
+        },
+        {
+            "name": "Transperth",
+            "type": "mobility-database",
+            "mdb-id": "mdb-1086",
+            "fix": true
         }
     ]
 }

--- a/src/region_helpers.py
+++ b/src/region_helpers.py
@@ -81,3 +81,13 @@ def data_slupsk_latest_resource(source: HttpSource) -> HttpSource:
     source.url = f"{base_url}/{gtfs_link}"
 
     return source
+
+def data_tasmania_latest_resource(source: HttpSource) -> HttpSource:
+    from bs4 import BeautifulSoup
+    
+    html = requests.get(source.url).text
+
+    soup = BeautifulSoup(html, "lxml")
+    source.url = soup.find("a", href=lambda x: x and x.endswith(".zip"))["href"]
+
+    return source


### PR DESCRIPTION
self explanatory, also add myself as a co-maintainer of the feed file

Transperth is now being added through the Mobility Database instead of being added directly.