### PR TITLE
bg: Replace Sofia GTFS feed with newly published official data

### DIFF
--- a/feeds/bg.json
+++ b/feeds/bg.json
@@ -3,13 +3,51 @@
         {
             "name": "Dimitar",
             "github": "Dimitar5555"
+        },
+        {
+            "name": "Petko",
+            "github": "ignisf"
         }
     ],
     "sources": [
         {
             "name": "sofia",
             "type": "http",
-            "url": "https://github.com/Dimitar5555/sofiatraffic-gtfs/raw/refs/heads/master/result.zip"
+            "url": "https://gtfs.sofiatraffic.bg/api/v1/static",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0",
+                "url": "https://www.sofia.bg/web/guest/transport-data"
+            }
+        },
+        {
+            "name": "sofia",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://gtfs.sofiatraffic.bg/api/v1/vehicle-positions",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0",
+                "url": "https://www.sofia.bg/web/guest/transport-data"
+            }
+        },
+        {
+            "name": "sofia",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://gtfs.sofiatraffic.bg/api/v1/alerts",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0",
+                "url": "https://www.sofia.bg/web/guest/transport-data"
+            }
+        },
+        {
+            "name": "sofia",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://gtfs.sofiatraffic.bg/api/v1/trip-updates",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0",
+                "url": "https://www.sofia.bg/web/guest/transport-data"
+            }
         },
         {
             "name": "bdz",

--- a/feeds/bg.json
+++ b/feeds/bg.json
@@ -14,6 +14,7 @@
             "name": "sofia",
             "type": "http",
             "url": "https://gtfs.sofiatraffic.bg/api/v1/static",
+            "fix": true,
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://www.sofia.bg/web/guest/transport-data"


### PR DESCRIPTION
Source: https://www.sofiatraffic.bg/en/info-center/gtfs-danni

Links are available in the Bulgarian version of the page https://www.sofiatraffic.bg/bg/info-center/gtfs-danni