### PR TITLE
Add license for JDF merged and remove Bean Shuttle

### DIFF
--- a/feeds/cz.json
+++ b/feeds/cz.json
@@ -65,11 +65,6 @@
             "fix": true
         },
         {
-            "name": "Bean-Shuttle",
-            "type": "mobility-database",
-            "mdb-id": "mdb-2036"
-        },
-        {
             "name": "PMDP",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-plzen",
@@ -85,7 +80,10 @@
         {
             "name": "JDF-merged",
             "type": "http",
-            "url": "https://github.com/KoblizekXD/gtfs-processor/raw/refs/heads/gtfs/files/latest.zip"
+            "url": "https://github.com/KoblizekXD/gtfs-processor/raw/refs/heads/gtfs/files/latest.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            }
         },
         {
             "name": "IDZK",


### PR DESCRIPTION
I've added the CC0 license to JDF merged feed (same reason and license as for CZPTT) and removed Bean Shuttle, as it does not hold a license for regular lines and also destinations and origin points are in fact not fixed... it's just a shuttle minibus!