### PR TITLE
Remove Flixbus from gb-great-britain

### DIFF
--- a/feeds/gb.json
+++ b/feeds/gb.json
@@ -17,7 +17,10 @@
             "fix": true,
             "license": {
                 "url": "https://transitous.org/sources-great-britain"
-            }
+            },
+            "drop-agency-names": [
+                "FlixBus"
+            ]
         },
         {
             "name": "great-britain",


### PR DESCRIPTION
Fix #1513 