### PR TITLE
Update King County Metro to MobilityDatabase feed, adding RT support

### DIFF
--- a/feeds/us-wa.json
+++ b/feeds/us-wa.json
@@ -53,11 +53,6 @@
             "skip-reason": "api-key must be set in query params (url-override?)"
         },
         {
-            "name": "Seattle-Childrens-Hospital-Shuttle",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-c23p1-seattlechildrenshospitalshuttle"
-        },
-        {
             "name": "Everett-Transit",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-c290-everetttransit"

--- a/feeds/us-wa.json
+++ b/feeds/us-wa.json
@@ -12,15 +12,20 @@
     "sources": [
         {
             "name": "Metro-Transit",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-c23-metrokingcounty"
+            "type": "mobility-database",
+            "mdb-id": "mdb-1330"
         },
         {
             "name": "Metro-Transit",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-kingcountymetro~rt",
-            "skip": true,
-            "skip-reason": "api-key must be set in query params (url-override?)"
+            "type": "mobility-database",
+            "spec": "gtfs-rt",
+            "mdb-id": "mdb-1540"
+        },
+        {
+            "name": "Metro-Transit",
+            "type": "mobility-database",
+            "spec": "gtfs-rt",
+            "mdb-id": "mdb-1541"
         },
         {
             "name": "Sound-Transit",


### PR DESCRIPTION
### Overview
The [transitland-atlas feed for King County Metro](https://www.transit.land/feeds/f-c23-metrokingcounty) points to the Sound Transit API which requires a Sound Transit API key, but King County Metro publishes real-time feeds independently, and these are included in the mobilitydatabase.org dataset. The static feed for KCM has been updated in tandem with the real-time feeds to prevent potential compatibility issues.

### Potential issues
In addition to publishing schedules for its own vehicles, Sound Transit [consolidates feeds](Consolidated GTFS Schedule File Set) for the entire Seattle metro area, so if there are trips in other agencies included in `f-c23-metrokingcounty` that aren't in `mdb-1330` it is, in principle, possible that Transitous will lose coverage for those trips. There's also [mdb-267](https://mobilitydatabase.org/feeds/gtfs/mdb-267) but on account of that being a consolidated feed I'm worried it'll de-sync with the real-time feeds, which are explicitly marked on mobilitydata.org as being associated with `mdb-1330`.

However!!! I am not concerned about this because I downloaded both static feeds (`mdb-1330` and `f-c23-metrokingcounty`) and  and compared their `agency.txt` and found them to be identical.

`mdb-1330`'s agency.txt reads:

```csv
agency_id,agency_name,agency_url,agency_timezone,agency_lang,agency_phone,agency_fare_url,agency_email
1,Metro Transit,https://kingcounty.gov/en/dept/metro,America/Los_Angeles,EN,206-553-3000,https://kingcounty.gov/en/dept/metro/fares-and-payment/prices,
23,City of Seattle,https://www.seattle.gov/transportation/getting-around/transit/streetcar,America/Los_Angeles,EN,206-684-7623,https://www.seattle.gov/transportation/getting-around/transit/streetcar/fares-and-orca-card,
40,Sound Transit,https://www.soundtransit.org,America/Los_Angeles,en,1-888-889-6368,https://www.soundtransit.org/ride-with-us/how-to-pay/fares,main@soundtransit.org
```

while `f-c23-metrokingcounty`'s agency.txt reads

```csv
agency_id,agency_name,agency_url,agency_timezone,agency_lang,agency_phone,agency_fare_url
1,Metro Transit,https://kingcounty.gov/en/dept/metro,America/Los_Angeles,EN,206-553-3000,https://kingcounty.gov/en/dept/metro/fares-and-payment/prices
23,City of Seattle,https://www.seattle.gov/transportation/getting-around/transit/streetcar,America/Los_Angeles,EN,206-684-7623,https://www.seattle.gov/transportation/getting-around/transit/streetcar/fares-and-orca-card
40,Sound Transit,http://www.soundtransit.org/,America/Los_Angeles,EN,1-888-889-6368,https://www.soundtransit.org/ride-with-us/how-to-pay/fares
```

### Links for convenience:
New static feed https://mobilitydatabase.org/feeds/gtfs/mdb-1330
New realtime feed 1 (trip updates): https://mobilitydatabase.org/feeds/gtfs_rt/mdb-1540
New realtime feed 2 (service alerts): https://mobilitydatabase.org/feeds/gtfs_rt/mdb-1541

I haven't yet tested these changes locally. It looks involved so I hope it's okay to rely on CI for this.