### PR TITLE
Add unofficial intercity feeds for Serbia

### DIFF
--- a/feeds/rs.json
+++ b/feeds/rs.json
@@ -78,12 +78,12 @@
             "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/pancevo_gtfs.zip?job=pancevo"
         },
         {
-            "name": "Autoprevoz_Cacak",
+            "name": "Autoprevoz-Cacak",
             "type": "http",
             "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/apcacak_gtfs.zip?job=cacak"
         },
         {
-            "name": "Kavim_Jedinstvo_Vranje",
+            "name": "Kavim-Jedinstvo-Vranje",
             "type": "http",
             "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/kjvranje_gtfs.zip?job=vranje"
         }

--- a/feeds/rs.json
+++ b/feeds/rs.json
@@ -66,6 +66,26 @@
             "type": "url",
             "spec": "gtfs-rt",
             "url": "https://rt.buslogic.baguette.pirnet.si/jgsp_ns/rt.pb"
+        },
+        {
+            "name": "Litas",
+            "type": "http",
+            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/litas_gtfs.zip?job=litas_rs"
+        },
+        {
+            "name": "Pantransport",
+            "type": "http",
+            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/pancevo_gtfs.zip?job=pancevo"
+        },
+        {
+            "name": "Autoprevoz_Cacak",
+            "type": "http",
+            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/apcacak_gtfs.zip?job=cacak"
+        },
+        {
+            "name": "Kavim_Jedinstvo_Vranje",
+            "type": "http",
+            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/kjvranje_gtfs.zip?job=vranje"
         }
     ]
 }

--- a/feeds/rs.json
+++ b/feeds/rs.json
@@ -70,7 +70,8 @@
         {
             "name": "Litas",
             "type": "http",
-            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/litas_gtfs.zip?job=litas_rs"
+            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/litas_gtfs.zip?job=litas_rs",
+            "drop-too-fast-trips": false
         },
         {
             "name": "Pantransport",
@@ -81,12 +82,14 @@
         {
             "name": "Autoprevoz-Cacak",
             "type": "http",
-            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/apcacak_gtfs.zip?job=cacak"
+            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/apcacak_gtfs.zip?job=cacak",
+            "drop-too-fast-trips": false
         },
         {
             "name": "Kavim-Jedinstvo-Vranje",
             "type": "http",
-            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/kjvranje_gtfs.zip?job=vranje"
+            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/kjvranje_gtfs.zip?job=vranje",
+            "drop-too-fast-trips": false
         }
     ]
 }

--- a/feeds/rs.json
+++ b/feeds/rs.json
@@ -75,7 +75,8 @@
         {
             "name": "Pantransport",
             "type": "http",
-            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/pancevo_gtfs.zip?job=pancevo"
+            "url": "https://gitlab.com/vekejsn/gtfs-generators/-/jobs/artifacts/main/raw/pancevo_gtfs.zip?job=pancevo",
+            "drop-too-fast-trips": false
         },
         {
             "name": "Autoprevoz-Cacak",


### PR DESCRIPTION
Adds feeds for Litas, Autoprevoz Čačak, Kavim Jedinstvo and Pantransport.