### PR TITLE
no: Drop FlixBus from Entur feed

### DIFF
--- a/feeds/no.json
+++ b/feeds/no.json
@@ -13,7 +13,10 @@
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1
-            }
+            },
+            "drop-agency-names": [
+                "FlixBus"
+            ]
         },
         {
             "name": "Entur",


### PR DESCRIPTION
Since it's already present in eu.json
(with shapes and RT updates).

Closes #1548 