### PR TITLE
Add scripts for Polish trains

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -73,7 +73,7 @@
         {
             "name": "Koleje-Mazowieckie",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-u3-kolejemazowieckie"
+            "transitland-atlas-id": "f-u3-kolejemazowieckie",
             "script": "pl-Koleje-Mazowieckie.lua"
         },
         {

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -26,7 +26,8 @@
             "url": "https://gtfs.kasznia.net/rt/pkpic.pb",
             "license": {
                 "spdx-identifier": "CC-BY-4.0"
-            }
+            },
+            "script": "pl-PKP-Intercity.lua"
         },
         {
             "name": "PKP-Intercity-Germany",
@@ -40,7 +41,8 @@
             "name": "PolRegio",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-pol~regio~pl",
-            "fix": true
+            "fix": true,
+            "script": "pl-PolRegio.lua"
         },
         {
             "name": "PolRegio",
@@ -72,6 +74,7 @@
             "name": "Koleje-Mazowieckie",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u3-kolejemazowieckie"
+            "script": "pl-Koleje-Mazowieckie.lua"
         },
         {
             "name": "Koleje-Mazowieckie",
@@ -161,7 +164,8 @@
             "url": "https://cdn.zbiorkom.live/gtfs/pkp-skmw.zip",
             "license": {
                 "spdx-identifier": "MIT"
-            }
+            },
+            "script": "pl-SKM-Warszawa.lua"
         },
         {
             "name": "SKM-Warszawa",
@@ -294,7 +298,8 @@
             "name": "PKP-SKM",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u3t-skm~trojmiasto",
-            "fix": true
+            "fix": true,
+            "script": "pl-PKP-SKM.lua"
         },
         {
             "name": "PKP-SKM",
@@ -815,7 +820,8 @@
             },
             "display-name-options": {
                 "copy-trip-names-matching": "^RJ.*"
-            }
+            },
+            "script": "pl-RegioJet.lua"
         },
         {
             "name": "RegioJet",

--- a/scripts/pl-Koleje-Mazowieckie.lua
+++ b/scripts/pl-Koleje-Mazowieckie.lua
@@ -1,0 +1,14 @@
+function process_route(route)
+    if route:get_id() == "ZL" then
+        route:set_clasz(10)
+        route:set_route_type(700)
+	elseif string.find(route:get_id(), "Z") then
+		route:set_clasz(10)
+		route:set_route_type(714) --rail replacement bus
+	elseif string.find(route:get_id(), "RE") then
+		route:set_clasz(5)
+	else
+		route:set_clasz(6)
+	end
+	return true
+end

--- a/scripts/pl-Koleje-Mazowieckie.lua
+++ b/scripts/pl-Koleje-Mazowieckie.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Transitous Contributors
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
 function process_route(route)
     if route:get_id() == "ZL" then
         route:set_clasz(10)

--- a/scripts/pl-PKP-Intercity.lua
+++ b/scripts/pl-PKP-Intercity.lua
@@ -1,0 +1,19 @@
+function process_route(route)
+  if string.find(route:get_short_name(), "ZKA") then
+    route:set_route_type(714) -- rail replacement bus
+    route:set_clasz(10)
+  elseif route:get_short_name() == "EIP" then
+    route:set_route_type(101)
+    route:set_clasz(1)
+  elseif route:get_short_name() == "EN" then
+    route:set_route_type(102)
+    route:set_clasz(4)
+  else
+    route:set_route_type(102)
+    route:set_clasz(2)
+  end
+end
+
+function process_trip(trip)
+  trip:set_display_name(trip:get_route():get_short_name() .. " " .. trip:get_short_name())
+end

--- a/scripts/pl-PKP-Intercity.lua
+++ b/scripts/pl-PKP-Intercity.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Transitous Contributors
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
 function process_route(route)
   if string.find(route:get_short_name(), "ZKA") then
     route:set_route_type(714) -- rail replacement bus

--- a/scripts/pl-PKP-SKM.lua
+++ b/scripts/pl-PKP-SKM.lua
@@ -1,0 +1,7 @@
+function process_route(route)
+	route:set_clasz(7)
+end
+
+function process_trip(trip)
+  trip:set_display_name("S1")
+end

--- a/scripts/pl-PKP-SKM.lua
+++ b/scripts/pl-PKP-SKM.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Transitous Contributors
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
 function process_route(route)
 	route:set_clasz(7)
 end

--- a/scripts/pl-PolRegio.lua
+++ b/scripts/pl-PolRegio.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Transitous Contributors
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
 function process_trip(trip)
 	if trip:get_route():get_short_name() == "REG" then
 		trip:set_display_name("R " .. trip:get_short_name())

--- a/scripts/pl-PolRegio.lua
+++ b/scripts/pl-PolRegio.lua
@@ -1,0 +1,18 @@
+function process_trip(trip)
+	if trip:get_route():get_short_name() == "REG" then
+		trip:set_display_name("R " .. trip:get_short_name())
+	else
+		trip:set_display_name(trip:get_route():get_short_name() .. " " .. trip:get_short_name())
+	end
+end
+
+function process_route(route)
+	if route:get_short_name() == "REG" then
+		route:set_clasz(6)
+	elseif route:get_short_name() == "IR" then
+		route:set_clasz(5)
+	elseif route:get_short_name() == "ZKA REG" then
+		route:set_clasz(10)
+		route:set_route_type(714) -- rail replacement bus
+	end
+end

--- a/scripts/pl-RegioJet.lua
+++ b/scripts/pl-RegioJet.lua
@@ -1,0 +1,7 @@
+function process_route(route):
+    if route:get_id() == "WEB/11755" then
+        route:set_clasz(4)
+    else
+        route:set_clasz(2)
+    end
+end

--- a/scripts/pl-RegioJet.lua
+++ b/scripts/pl-RegioJet.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Transitous Contributors
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
 function process_route(route):
     if route:get_id() == "WEB/11755" then
         route:set_clasz(4)

--- a/scripts/pl-SKM-Warszawa.lua
+++ b/scripts/pl-SKM-Warszawa.lua
@@ -1,0 +1,3 @@
+function process_route(route)
+	route:set_clasz(7)
+end

--- a/scripts/pl-SKM-Warszawa.lua
+++ b/scripts/pl-SKM-Warszawa.lua
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Transitous Contributors
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
 function process_route(route)
 	route:set_clasz(7)
 end


### PR DESCRIPTION
Scripts for polish trains:
- PKP Intercity:
    - differentiate clasz(High speed for EIP, Long distance for other), rail replacement bus
    - better display name, in format `IC 1234 Train Name`, `EIP 1245` etc.
- Koleje Mazowieckie: differentiate clasz (Regio Express as Regional fast, regio as regional), rail replacement bus
- PKP SKM: route name (`S1`) and correct clasz (~Sbahn)
- Polregio: differentiate clasz (Regio as regional, InterRegio as Regional Fast), rail replacement bus
- RegioJet: differentiate clasz (Night route as night, other as as Long Distance), as mentioned in https://github.com/public-transport/transitous/pull/1498#issuecomment-3314778637 (cc: @Lach-anonym)
- SKM Warszawa: correct clasz (~Sbahn)