### PR TITLE
Improve display names for international trips in the Swiss feed

### DIFF
--- a/feeds/ch.json
+++ b/feeds/ch.json
@@ -12,7 +12,8 @@
             "url": "https://data.opentransportdata.swiss/de/dataset/timetable-2025-gtfs2020/permalink",
             "license": {
                 "url": "https://opentransportdata.swiss/de/terms-of-use/"
-            }
+            },
+            "script": "ch-opentransportdataswiss.lua"
         },
         {
             "name": "opentransportdataswiss25",

--- a/scripts/ch-opentransportdataswiss.lua
+++ b/scripts/ch-opentransportdataswiss.lua
@@ -1,0 +1,19 @@
+-- SPDX-FileCopyrightText: Volker Krause <vkrause@kde.org>
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+function process_trip(trip)
+    -- dispaly names for international SBB EC/IC trips and DB ICEs
+    if trip:get_route():get_short_name() == "EC" or trip:get_route():get_short_name() == "IC" or trip:get_route():get_short_name() == "ICE" then
+        trip:set_display_name(trip:get_route():get_short_name() .. ' ' .. trip:get_short_name())
+    end
+
+    -- display names for SNCF trips
+    if trip:get_route():get_agency():get_id() == "87_LEX" then
+        if trip:get_route():get_route_type() == 101 then
+            trip:set_display_name("TGV " .. trip:get_short_name())
+        end
+        if trip:get_route():get_route_type() == 102 then
+            trip:set_display_name("IC " .. trip:get_short_name())
+        end
+    end
+end


### PR DESCRIPTION
Unlike the domestic trips, those don't have good route short names.