### PR TITLE
Skip GTFS-RT for Czech railways

### DIFF
--- a/feeds/cz.json
+++ b/feeds/cz.json
@@ -27,7 +27,9 @@
             "name": "CZPTT",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://owncloud.cesnet.cz/index.php/s/DQdSPwh0bJjtEWq/download"
+            "url": "https://owncloud.cesnet.cz/index.php/s/DQdSPwh0bJjtEWq/download",
+            "skip": true,
+            "skip-reason": "Feed does not return proper delays"
         },
         {
             "name": "PID",


### PR DESCRIPTION
The only results I've seen for Czech railway were trains on time (often falsely) or without data, so I'suggest to skip the feed until it's fixed