### PR TITLE
Replace the TCL Lyon feed and add missing operators of it

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -8376,7 +8376,53 @@
         {
             "name": "lyon-tcl",
             "type": "http",
-            "url": "https://gtech-transit-prod.apigee.net/v1/google/gtfs/odbl/lyon_tcl.zip?apikey=BasyG6OFZXgXnzWdQLTwJFGcGmeOs204&secret=gNo6F5PhQpsGRBCK"
+            "url": "https://gtfs.bus-tracker.fr/tcl.zip",
+            "license": {
+                "spdx-identifier": "ODbL-1.0"
+            }
+        },
+        {
+            "name": "lyon-tcl",
+            "type": "url",
+            "url": "https://gtfs.bus-tracker.fr/gtfs-rt/tcl",
+            "license": {
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "transports-faure-28bi",
+            "type": "http",
+            "url": "https://pysae.com/api/v2/groups/transports-faure-28bi/gtfs/pub",
+            "license": {
+                "spdx-identifier": "ODbL-1.0"
+            }
+        },
+        {
+            "name": "transports-faure-28bi",
+            "type": "url",
+            "url": "https://pysae.com/api/v2/groups/transports-faure-28bi/gtfs-rt",
+            "license": {
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "cars-faure-tcl",
+            "type": "http",
+            "url": "https://pysae.com/api/v2/groups/cars-faure-tcl/gtfs/pub",
+            "license": {
+                "spdx-identifier": "ODbL-1.0"
+            }
+        },
+        {
+            "name": "cars-faure-tcl",
+            "type": "url",
+            "url": "https://pysae.com/api/v2/groups/cars-faure-tcl/gtfs-rt",
+            "license": {
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "spec": "gtfs-rt"
         },
         {
             "name": "caen-la-mer-reseau-twisto-gtfs-siri",

--- a/src/generate-france.py
+++ b/src/generate-france.py
@@ -337,12 +337,58 @@ if __name__ == "__main__":
                 )
                 continue
 
-    # TCL(Lyon) official feed not available without API key
+    # TCL(Lyon) unofficial feed + suburban buses
     out.append(
         {
             "name": "lyon-tcl",
             "type": "http",
-            "url": "https://gtech-transit-prod.apigee.net/v1/google/gtfs/odbl/lyon_tcl.zip?apikey=BasyG6OFZXgXnzWdQLTwJFGcGmeOs204&secret=gNo6F5PhQpsGRBCK"
+            "url": "https://gtfs.bus-tracker.fr/tcl.zip",
+            "license": {
+                "spdx-identifier": "ODbL-1.0"
+            }
+        },
+        {
+            "name": "lyon-tcl",
+            "type": "url",
+            "url": "https://gtfs.bus-tracker.fr/gtfs-rt/tcl",
+            "license": {
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "transports-faure-28bi",
+            "type": "http",
+            "url": "https://pysae.com/api/v2/groups/transports-faure-28bi/gtfs/pub",
+            "license": {
+                "spdx-identifier": "ODbL-1.0"
+            }
+        },
+        {
+            "name": "transports-faure-28bi",
+            "type": "url",
+            "url": "https://pysae.com/api/v2/groups/transports-faure-28bi/gtfs-rt",
+            "license": {
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "cars-faure-tcl",
+            "type": "http",
+            "url": "https://pysae.com/api/v2/groups/cars-faure-tcl/gtfs/pub",
+            "license": {
+                "spdx-identifier": "ODbL-1.0"
+            }
+        },
+        {
+            "name": "cars-faure-tcl",
+            "type": "url",
+            "url": "https://pysae.com/api/v2/groups/cars-faure-tcl/gtfs-rt",
+            "license": {
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "spec": "gtfs-rt"
         },
     )
     # official feeds without available zip files at data.gouv.fr for some reason


### PR DESCRIPTION
There's a feed from the other open-source project, Bus Tracker, that also has a GTFS-RT feed for TCL Lyon and a coach operator from the same network, that apparently is not included in Transitous yet. I've asked the maintainer and they were fine to share the feeds for Transitous on open licenses, so I've modified the generation script and fr.json. I hope it will be fine