### PR TITLE
Drop Eurostar services from the DELFI feed

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -31,7 +31,8 @@
                 "Braunschweiger Verkehrs-GmbH",
                 "Kraftverkehrsgesellschaft mbH Braunschweig",
                 "SWO Mobil GmbH",
-                "FlixBus-de"
+                "FlixBus-de",
+                "EUROSTAR"
             ],
             "http-options": {
                 "fetch-interval-days": 2


### PR DESCRIPTION
We have a dedicated feed for Eurostar that has shapes, colors and at least partial realtime data.