### PR TITLE
Add Chile

### DIFF
--- a/feeds/cl.json
+++ b/feeds/cl.json
@@ -3,6 +3,10 @@
         {
             "name": "Nedžad Beus",
             "github": "vekejsn"
+        },
+        {
+            "name": "Patrick Steil",
+            "github": "SteilDev"
         }
     ],
     "sources": [
@@ -16,6 +20,15 @@
             "type": "url",
             "spec": "gtfs-rt",
             "url": "https://rt.flix.baguette.pirnet.si/rt.pb"
+        },
+        {
+            "name": "ChileDTP",
+            "type": "http",
+            "url": "https://www.dtpm.cl/index.php/noticias/gtfs-vigente",
+            "function": "chile_dtp_downloader",
+            "license": {
+                "url": "https://www.dtpm.cl/index.php/homepage/sistema-de-transportes/datos-y-servicios"
+            }
         }
     ]
 }


### PR DESCRIPTION
I stumbeld across [[1]](https://hub.tumidata.org/en/dataset/gtfs-santiago-de-chile), which listed this (official) DTP GTFS provider [[2]](https://www.dtpm.cl/index.php/noticias/gtfs-vigente) as original source.
Again, no stable link to the latest GTFS file available, hence i wrote a method which downloads the latest feed based on the filename (based on the same starting prefix GTFS_YYYYMMDD). If this fails, it will return the link to the lexicografically largest feed.