### PR TITLE
au-nsw: shut off RT data

### DIFF
--- a/feeds/au-nsw.json
+++ b/feeds/au-nsw.json
@@ -17,469 +17,7 @@
             "fix": true,
             "license": {
                 "spdx_identifier": "CC-BY-4.0"
-            },
-            "drop-agency-names": [
-                "Rover Coaches",
-                "Hunter Valley Buses",
-                "Port Stephens Coaches",
-                "Blue Mountains Transit",
-                "Premier Charters",
-                "Premier Illawarra",
-                "Coastal Liner",
-                "Dions Bus Service",
-                "Transit Systems",
-                "Busways R1",
-                "Transit Systems NSW SW",
-                "Transit Systems NSW",
-                "CDC NSW R4",
-                "Busways North West",
-                "Keolis Downer Northern Beaches",
-                "Transdev John Holland",
-                "U-Go Mobility",
-                "CDC NSW R14",
-                "Busways OMR6",
-                "RedBus CDC NSW",
-                "Newcastle Transport",
-                "Langley's Coaches",
-                "Dubbo Buslines",
-                "Forbes Buslines",
-                "Western Road Liners",
-                "Ogdens Coaches",
-                "KS Hall Pty Ltd",
-                "AW & CE Mulligan",
-                "D J & C L Wesley",
-                "Courtys Bus Services Pty Ltd",
-                "McWhirter's Bus Service",
-                "CLMM PTY LTD",
-                "Tooraweenah Road Bus Services Pty Ltd",
-                "T R & J M Lewis",
-                "Havercroft Buslines Pty Ltd",
-                "Coolah Valley Buses Pty Ltd",
-                "Jack James & Sons",
-                "David Wright",
-                "Walsh Buslines Pty Ltd",
-                "B & L Imrie Pty Ltd",
-                "Beveridge, Darren",
-                "GTM Buses Pty Ltd",
-                "CM & LM Ward",
-                "CB and DJ Nash Pty Ltd",
-                "Geographical Computing Pty Ltd",
-                "HAASE, Ian",
-                "Warren Hogden",
-                "J A Twomey Pty Ltd",
-                "J.M. SAMS & J.L. SAMS",
-                "John Matthews",
-                "Kagram Pty Ltd",
-                "Lajeanca Pty Ltd",
-                "MW Leeson Pty Ltd",
-                "McConnachie Bus Service",
-                "N Best",
-                "NRC Buses Pty Ltd",
-                "PA & SN Livingstone",
-                "PM & SJ Gray Bus Services Pty Ltd",
-                "RH Buses Pty Ltd",
-                "S A & K Edwards Pty Ltd",
-                "SK & JM Ward Pty Ltd",
-                "Tyack, Kelly",
-                "Skelly's Bus Services",
-                "Paul Jeffery",
-                "Beers Bus Charters Pty Ltd",
-                "A & M A Sciberras",
-                "B & C Stewart",
-                "Condobolin Buses",
-                "Cumnock Bus Company Pty Ltd",
-                "DKCH O'Connor Pty Ltd",
-                "Merv Hennock and Sons Pty Ltd",
-                "Fuller Bros",
-                "Prugger's Bus and Coach Service",
-                "Aronui Pty Ltd",
-                "Vanes Bus Service",
-                "W A Darcy",
-                "Curr Buses Pty Ltd",
-                "Deaman, Troy",
-                "GJ & AF Parker",
-                "Grindrod Bus Run Ltd Pty Ltd",
-                "Manna Station Pty Ltd",
-                "Matthews, Lyndon",
-                "BR & PA Stephens",
-                "Belubula Bus Lines Pty Ltd",
-                "Bushtrack Bus Company Pty Ltd",
-                "Cabonne Bus Lines",
-                "ET & DF Wright & Sons Pty Ltd",
-                "Gooloogong Bus Service",
-                "Moss Mayfield Pty Ltd",
-                "Grace Coaches",
-                "P & N Buses Pty Ltd",
-                "M J & M L McEVOY PTY LTD",
-                "D.A & W.K. Brett",
-                "Leighjay Pty Ltd",
-                "10 Bridges. RD & SA. Pty Ltd",
-                "BTL Mechanical Pty Ltd",
-                "Bakers Buses Pty Ltd",
-                "Bulzomi Bros Pty Ltd",
-                "Masman, Alan",
-                "McAtamney Buses",
-                "Milezaway Pty Ltd",
-                "Patbeau Disel Jockeys Pty Ltd",
-                "R & J Buses Pty Ltd",
-                "Spence's Coaches Western",
-                "Stanton, Reginald",
-                "Cutler, Susan Lee",
-                "Moore's Bus Lines Pty Ltd",
-                "Nation, Jake",
-                "Lowmac Enterprises Pty Ltd",
-                "BusBiz",
-                "Warnock, Judy Masman",
-                "Capcalgrey Pty Ltd",
-                "CDC Broken Hill Pty Ltd",
-                "CDC Mildura Pty Ltd",
-                "Edwards Coaches Pty Ltd",
-                "Masons Services NSW Pty Ltd",
-                "Macphersons Tamworth",
-                "Hannafords Coaches",
-                "Edwards Coaches",
-                "Tamworth Buslines",
-                "Howard's Bus & Charter",
-                "Arandale, Daniel",
-                "Tablelands Bus Service",
-                "Crisps Bus Lines Pty Ltd",
-                "GW&CA HILLIER PTY LTD",
-                "Gavin Cameron Hann & Renae Maree Hann",
-                "P J & L M Mulcahy",
-                "Camorose Pty Ltd",
-                "Mark Cook",
-                "Compass Swift Pty Ltd",
-                "Duncans Bus Services Pty Ltd",
-                "Frost, Tony",
-                "G J & G Driver Pty Ltd",
-                "Gavne Enterprises Pty Ltd",
-                "Glen Innes Bus Services",
-                "Hancock Rural Pty Ltd",
-                "JND Ventures Pty Ld",
-                "K.C.Galvin & Co Pty Ltd",
-                "Barraba Bus Lines Pty Ltd",
-                "The Oxley Explorer",
-                "Yallaroi Crop Spraying Pty Ltd",
-                "AK Quinn Pty Ltd",
-                "Boonoona Design Pty Ltd",
-                "O'Dempseys Charters and Local Tours",
-                "Brejoel Pty Ltd",
-                "Brodbeck Bus Lines Pty Ltd",
-                "Byrne Bus",
-                "Caraboo Farming Services Pty Ltd",
-                "Jamalon Pty Ltd",
-                "Caskey Bus Service Pty Ltd",
-                "Cobbs Bus Service",
-                "Craginview Pty Ltd",
-                "Attunga Buslines Pty Ltd",
-                "Emmapo Pty Ltd",
-                "Gallagher, Ian V, Elizabeth K & Patrick T",
-                "GB & SL Howlett Pty Ltd",
-                "Haires Bus Service Pty Ltd",
-                "Hawkins Coach Lines Pty Ltd",
-                "Berrigal Creek Bus",
-                "Hill, Robert",
-                "Kisti Lee Hodge",
-                "Holmes Bus Service",
-                "Hopes Bus Service Pty Limited",
-                "Jillett, Michael",
-                "Wytaliba Bus Service",
-                "Kingstown Bus Company Pty Ltd",
-                "Lister Johnson Pty Ltd",
-                "LKD Investments Group Pty Ltd",
-                "Lynette Evans Pty Ltd",
-                "Marla Bus Service Pty Ltd",
-                "M J & K Holstein",
-                "Mulcahy Bus Company",
-                "Bendemeer Express",
-                "R & N Bilsborough Pty Ltd",
-                "Rose Enterprises (NSW) Pty Ltd",
-                "Smith, Robert Charles & Phae Maree",
-                "Coliver Bus Service Pty Ltd",
-                "Wittens Bus Service Pty Ltd",
-                "Denman Buses",
-                "Farrugia Transportation Pty Ltd",
-                "Moona Bus Committee",
-                "McCoskers Bus Service Pty Ltd",
-                "McNamara, Sacha",
-                "Wahha Bloodstock Pty Ltd",
-                "Spindlebox Pty Ltd",
-                "Woolomin Bus Services Pty Ltd",
-                "DKD Bus Services Pty Ltd",
-                "Forest Coach Lines",
-                "Hayne Buses Pty Ltd",
-                "Jenlai Pty Limited",
-                "AC & JM Longworth",
-                "O'Neills Bus Service",
-                "A G & P L Beveridge",
-                "Toomey Bus Transport Pty Ltd",
-                "Cavanagh Bus & Coach",
-                "Atwal Bus",
-                "Lemitscom Pty Ltd",
-                "BNA Buses",
-                "WG & JA Weick Bus Service",
-                "Keough's Bus Service",
-                "Baldwin's Bus Service",
-                "Natureland Bus Service",
-                "Newcombe Coach Lines",
-                "Sahdra Bus Lines",
-                "Busways",
-                "Lawrence Bus Service",
-                "S L and S L Hardwick Pty Ltd",
-                "IL & CM Kennedy",
-                "San Isidore Buses",
-                "Allen's Coaches",
-                "Makeham's Coaches",
-                "Junee Buses",
-                "Busabout Wagga",
-                "Ecclestons Buses Gundagai Pty Ltd",
-                "M.A & L.A Lott",
-                "J & L.M Grange Pty Ltd",
-                "Chamberlain's Buses",
-                "Jandryona Pty Ltd",
-                "Kelly Coaches",
-                "Bandy Bus Service Pty Ltd",
-                "Griffith Buslines",
-                "C & J Robertson Pty Ltd",
-                "MIA Coaches",
-                "Evans, Marie",
-                "Allen, Daniel",
-                "BBB Buses Pty Ltd",
-                "Chostill Pty Ltd",
-                "CLC & Co Pty Ltd",
-                "DA & C Harper",
-                "Ruralbus",
-                "DR & MT Milne Pty Ltd",
-                "K A Englert",
-                "Ferguson Buses Pty Ltd",
-                "Reid Bus services",
-                "Poomah Buses Pty Ltd",
-                "J & M Davies Pty Ltd",
-                "JW & VE Wright",
-                "Steeles Bus Pty Ltd",
-                "Reardon Bus Co Pty Ltd",
-                "Lyons Bus Service",
-                "Tallimba Bus Service",
-                "WR & MR Imrie Bus Services",
-                "Chandler's Buses Pty Ltd",
-                "Narrandera CRC",
-                "NB & AJ Rees Pty Ltd",
-                "S A Hetherington Pty Ltd",
-                "Salzke Spurr Bus Lines",
-                "SM & RM Maguire",
-                "Temora Buses",
-                "Tregear Buses Pty Ltd",
-                "Whitepool Pty Ltd",
-                "Windeira Pty Ltd",
-                "Celis Bus Service",
-                "Hillston Bus Services Pty Ltd",
-                "GD & DK Bock Pty Ltd",
-                "Ian Ross Contracting Pty Ltd",
-                "JM & NC Findlay",
-                "Mahoney's Coaches Pty Ltd",
-                "Brettschneider Bus Service Pty Ltd",
-                "Hibberson Buses Pty Ltd",
-                "Crompton's Bus Service",
-                "PJ & LM Witenden",
-                "SDB Services Group Pty Ltd",
-                "Dan Simmons Pty Ltd",
-                "Thomas & Margaret Priestley",
-                "Flanagan's Buses",
-                "Beresford Buses",
-                "Scarlett Buses",
-                "Sapphire Coast Buslines",
-                "Bega Valley Coaches",
-                "AB & NJ Howard Dalton Bus",
-                "Baileys Garage",
-                "Beau n Co",
-                "Berrima Buslines",
-                "Bradclo Pty Ltd",
-                "Bush Enterprises",
-                "Bush's Yass - Charter Service",
-                "Merivale Buses Pty Ltd",
-                "RICAM Industries Pty Ltd",
-                "Intertrans",
-                "Lewis Buslines & Classic Motor Cruises Pty Ltd",
-                "McGrath's Buses",
-                "Medway Buses Pty Ltd",
-                "Morton Views",
-                "Patricia Pearsall",
-                "Remmit and Sons",
-                "RJ & KM Keefe",
-                "Robertson Bus Service Pty Ltd",
-                "Taylors Buses",
-                "Kemps of Yass Pty Ltd",
-                "Wilson's Coachlines",
-                "Kipley T & Wendy A Skelly",
-                "Daanhage Investments Pty Ltd",
-                "KM Skelly",
-                "Roadcoach Goulburn",
-                "PBC Goulburn",
-                "MS Gradidge Pty Ltd",
-                "Nowra Coaches",
-                "Shoalbus",
-                "Kennedy's Bus And Coach",
-                "Berry Bus Service",
-                "Eastern Australia Coaches",
-                "Ulladulla Buslines",
-                "Gerringong Buses",
-                "Picton Buslines",
-                "Sinclair Buses",
-                "Mutton Bus Services",
-                "Conroy's Bus Service",
-                "Newman's Bus Service",
-                "Bathurst Buslines",
-                "TF Palmer Holdings Pty Ltd",
-                "Dowd Bros Buses Pty Ltd",
-                "BJ and SM Ellis Pty Ltd",
-                "Lithgow Buslines",
-                "Lovering Pty Ltd",
-                "Riverside Bus Service Pty Ltd",
-                "Tupelo Lodge Pty Ltd",
-                "G & J Cameron Cowra Pty Ltd",
-                "Orange Buslines",
-                "Cooks Buses Orange",
-                "Apple City Tours",
-                "ESR Buses Pty Ltd",
-                "Booths Bus Line Pty Ltd",
-                "Sanja Holdings Pty Ltd",
-                "Campbell, Terrence",
-                "Garland Bus Committee",
-                "Sharon L Brown Pty Ltd",
-                "Tawilla Holdings Pty Ltd",
-                "Cowra Bus Service",
-                "Hillend School Bus",
-                "Dowsett Bus Service Pty Ltd",
-                "Oberon Bus Service",
-                "Wayne and Kath Holz Pty Ltd",
-                "Surfside Buslines",
-                "Alstonville Bus Service",
-                "Koonorigan Bus Service",
-                "Bangalow Transit Pty Ltd",
-                "Beaumont Buses",
-                "Halls Bus Company",
-                "Paznic Pty Ltd",
-                "Wittig Investments Pty Ltd",
-                "A.J.Treanor Pty Ltd",
-                "Bennetts Bus Service Pty Ltd",
-                "CB Buses Pty Ltd",
-                "Foscars Pty Ltd",
-                "G & N Bus Services Pty Ltd",
-                "G W Hughes Pty Ltd",
-                "Three Little Dudes Pty Ltd",
-                "Williams, Michael",
-                "Yamba & Maclean Buses Pty Ltd",
-                "Ballina Buslines",
-                "Northern Rivers Buslines",
-                "CCC Bus Service",
-                "CTC Buses",
-                "Cummins Pastoral Co. Pty Ltd",
-                "Gosel's Bus Service",
-                "J & B Buses",
-                "Kyogle Busco",
-                "Quinns Buses",
-                "MURPHY, Pamela",
-                "Simes Bros. Coaches",
-                "Dunoon Bus Service",
-                "Buslines Group Pty Limited",
-                "Clark's Buslines",
-                "Kellam Bus Lines Pty Ltd",
-                "CEDAR LOG TRADING PTY LTD",
-                "I R Steinhardt Pty Ltd",
-                "PA & TJ Beaumont Pty Ltd",
-                "AVN Co Pty Ltd",
-                "Kalang Bus",
-                "Canco Droughtmasters Pty Ltd",
-                "Collins Bus Service",
-                "Kindee Bus Service",
-                "Long Flat Bus Service Pty Ltd",
-                "M & M Bus Company Pty Ltd",
-                "Nambucca Bus Service",
-                "Cann's Bus Management",
-                "Lieschke Buslines",
-                "Waverley Bus Pty Ltd",
-                "Martins Albury",
-                "Kanes Buses",
-                "Dysons Buslines",
-                "Apple Transport Services Pty Ltd",
-                "EJP Buses Pty Ltd",
-                "Fallon's Bus Service Pty Ltd",
-                "Baldwin's Buses",
-                "Goode's Coaches Pty Ltd",
-                "Hannon, Pauline",
-                "Woods Bus Lines",
-                "Bunson Pty Ltd",
-                "Lake Brothers",
-                "Bookabus",
-                "Whitmore Bus Group (NSW) Pty Ltd",
-                "N and K Lieschke Pty Ltd",
-                "O'Connell's Coaches",
-                "TJ & TM Shea",
-                "WB & AK Davies Pty Ltd",
-                "Diesel Downs Nominees Pty Ltd",
-                "Hassett Buses Pty Ltd",
-                "James Newtons Bus Service Pty Ltd",
-                "Papworth's Bus Service Pty Ltd",
-                "Worrick John Shaw Pty Ltd",
-                "Wayne Fanning",
-                "Bungendore Bus & Coach",
-                "Lyn & Terry Hart Nerriga Buses",
-                "Qcity Transit",
-                "Braidwood Buses",
-                "Fairview Buses Pty Ltd",
-                "Cartys Bus Co Pty Ltd",
-                "Keirs Bus Service Pty Ltd",
-                "Keir's Bus Service Pty Ltd",
-                "Adaminaby Buses",
-                "Alpine Charters",
-                "Ayliffe Buses",
-                "Isabel Harrington",
-                "Myula Pty Ltd",
-                "Snowliner Coaches",
-                "V & H Motor Repairs",
-                "White, Michelle",
-                "TJ & FA Lomas",
-                "Bennys Buses",
-                "Demadrick Pty Ltd",
-                "Marshall's Bus & Coach Company Pty Ltd",
-                "Priors Bus Service",
-                "Cooma Coaches",
-                "Neibro Investments Pty Ltd",
-                "C.D Pitt & S.M Treacy-Pitt Pty Ltd",
-                "P & M Levett Pty Ltd",
-                "Baileys Bus Services",
-                "Denmans Buses",
-                "Gardner Buses",
-                "Lyall Earthmoving Contractors Pty Ltd",
-                "Linq Buslines",
-                "RPS Buses",
-                "Tinonee Bus Company",
-                "Eggins Comfort Coaches",
-                "Saxby's Singleton",
-                "Cowans Bus Service",
-                "JULDON BUSES",
-                "Rumbel Coaches",
-                "Sheltons Bus Service",
-                "Osborn's Buses",
-                "Forster Buslines",
-                "Wingham Buslines",
-                "Denman Transit Pty Ltd",
-                "Manly Fast Ferries",
-                "Intercity Train",
-                "NSW TrainLink",
-                "Sydney Ferries",
-                "Sydney Light Rail",
-                "Parramatta Light Rail",
-                "Sydney Metro",
-                "Sydney Trains",
-                "NSW Trains",
-                "Transit Systems West",
-                "Port Stephens",
-                "Buswasy Gosford",
-                "Redbus",
-                "Dions",
-                "Keolis Downer Hunter"
-            ]
+            }
         },
         {
             "name": "Transport-for-New-South-Wales-flex",
@@ -502,7 +40,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-metro",
@@ -514,7 +54,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-metro",
@@ -526,7 +68,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-sydney-trains",
@@ -540,7 +84,11 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "script": "au-nsw-sydney-trains.lua",
+            "drop-agency-names": ["NSW Trains"],
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-sydney-trains",
@@ -552,7 +100,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-sydney-trains",
@@ -564,7 +114,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-nsw-trains",
@@ -579,7 +131,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-nsw-trains",
@@ -591,7 +145,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-nsw-trains",
@@ -603,7 +159,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-sydney-ferries",
@@ -617,7 +175,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-sydney-ferries",
@@ -629,7 +189,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-sydney-ferries",
@@ -641,7 +203,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-mff",
@@ -655,7 +219,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-mff",
@@ -667,7 +233,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-mff",
@@ -679,7 +247,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-inner-west-lr",
@@ -693,7 +263,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-inner-west-lr",
@@ -705,7 +277,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-inner-west-lr",
@@ -717,7 +291,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-cbd-and-southeast-lr",
@@ -731,7 +307,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-cbd-and-southeast-lr",
@@ -743,7 +321,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-cbd-and-southeast-lr",
@@ -755,7 +335,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-parramatta-lr",
@@ -769,7 +351,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-parramatta-lr",
@@ -781,7 +365,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-parramatta-lr",
@@ -793,7 +379,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-newcastle-lr",
@@ -807,7 +395,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-newcastle-lr",
@@ -819,7 +409,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-newcastle-lr",
@@ -831,7 +423,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC001",
@@ -845,7 +439,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC001",
@@ -857,7 +453,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC001",
@@ -869,7 +467,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC002",
@@ -883,7 +483,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC002",
@@ -895,7 +497,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC002",
@@ -907,7 +511,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC003",
@@ -921,7 +527,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC003",
@@ -933,7 +541,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC003",
@@ -945,7 +555,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC004",
@@ -959,7 +571,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC004",
@@ -971,7 +585,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC004",
@@ -983,7 +599,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC008",
@@ -997,7 +615,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC008",
@@ -1009,7 +629,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC008",
@@ -1021,7 +643,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC009",
@@ -1035,7 +659,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC009",
@@ -1047,7 +673,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC009",
@@ -1059,7 +687,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC010",
@@ -1073,7 +703,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC010",
@@ -1085,7 +717,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC010",
@@ -1097,7 +731,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC011",
@@ -1111,7 +747,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC011",
@@ -1123,7 +761,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC011",
@@ -1135,7 +775,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC012",
@@ -1149,7 +791,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC012",
@@ -1161,7 +805,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-OSMBSC012",
@@ -1173,7 +819,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-SBSC006",
@@ -1187,7 +835,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-SBSC006",
@@ -1199,7 +849,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-SBSC006",
@@ -1211,7 +863,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC001",
@@ -1225,7 +879,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC001",
@@ -1237,7 +893,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC001",
@@ -1249,7 +907,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC002",
@@ -1263,7 +923,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC002",
@@ -1275,7 +937,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC002",
@@ -1287,7 +951,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC003",
@@ -1301,7 +967,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC003",
@@ -1313,7 +981,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC003",
@@ -1325,7 +995,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC004",
@@ -1339,7 +1011,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC004",
@@ -1351,7 +1025,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC004",
@@ -1363,7 +1039,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC007",
@@ -1377,19 +1055,23 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC007",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/GSBC007",
+            "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
                 "spdx_identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC007",
@@ -1401,7 +1083,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC008",
@@ -1415,7 +1099,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC008",
@@ -1427,7 +1113,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC008",
@@ -1439,7 +1127,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC009",
@@ -1453,7 +1143,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC009",
@@ -1465,7 +1157,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC009",
@@ -1477,7 +1171,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC010",
@@ -1491,7 +1187,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC010",
@@ -1503,7 +1201,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC010",
@@ -1515,7 +1215,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC014",
@@ -1529,7 +1231,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC014",
@@ -1541,7 +1245,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-GSBC014",
@@ -1553,7 +1259,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-NISC001",
@@ -1567,7 +1275,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-NISC001",
@@ -1579,7 +1289,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-NISC001",
@@ -1591,7 +1303,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-centralwestandorana",
@@ -1605,7 +1319,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-centralwestandorana",
@@ -1617,7 +1333,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-centralwestandorana",
@@ -1629,7 +1347,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-farwest",
@@ -1643,7 +1363,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-farwest",
@@ -1655,7 +1377,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-farwest",
@@ -1667,7 +1391,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-newenglandnorthwest",
@@ -1681,7 +1407,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-newenglandnorthwest",
@@ -1693,7 +1421,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-newenglandnorthwest",
@@ -1705,7 +1435,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-northcoast",
@@ -1719,7 +1451,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-northcoast",
@@ -1731,7 +1465,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-northcoast",
@@ -1743,7 +1479,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-riverinamurray",
@@ -1757,7 +1495,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-riverinamurray",
@@ -1769,7 +1509,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-riverinamurray",
@@ -1781,7 +1523,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-riverinamurray",
@@ -1795,7 +1539,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-riverinamurray",
@@ -1807,7 +1553,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-riverinamurray",
@@ -1819,7 +1567,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-southeasttablelands",
@@ -1833,7 +1583,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-southeasttablelands",
@@ -1845,7 +1597,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-southeasttablelands",
@@ -1857,7 +1611,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-sydneysurrounds",
@@ -1871,7 +1627,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-sydneysurrounds",
@@ -1883,7 +1641,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-sydneysurrounds",
@@ -1895,7 +1655,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-centralwestandorana2",
@@ -1909,7 +1671,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-centralwestandorana2",
@@ -1921,7 +1685,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-centralwestandorana2",
@@ -1933,7 +1699,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-northcoast2",
@@ -1947,7 +1715,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-northcoast2",
@@ -1959,7 +1729,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-northcoast2",
@@ -1971,7 +1743,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-northcoast3",
@@ -1985,7 +1759,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-northcoast3",
@@ -1997,7 +1773,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-northcoast3",
@@ -2009,7 +1787,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-riverinamurray2",
@@ -2023,7 +1803,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-riverinamurray2",
@@ -2035,7 +1817,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-riverinamurray2",
@@ -2047,7 +1831,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-southeasttablelands2",
@@ -2061,7 +1847,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-southeasttablelands2",
@@ -2073,7 +1861,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-southeasttablelands2",
@@ -2085,7 +1875,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-newcastlehunter",
@@ -2099,7 +1891,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-newcastlehunter",
@@ -2111,7 +1905,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-newcastlehunter",
@@ -2123,7 +1919,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-ReplacementBus",
@@ -2137,7 +1935,9 @@
                 "headers": {
                     "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-ReplacementBus",
@@ -2149,7 +1949,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         },
         {
             "name": "Transport-for-New-South-Wales-ReplacementBus",
@@ -2161,7 +1963,9 @@
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
-            }
+            },
+            "skip": true,
+            "skip-reason": "rate-limiting"
         }
     ]
 }

--- a/scripts/au-nsw-sydney-trains.lua
+++ b/scripts/au-nsw-sydney-trains.lua
@@ -1,0 +1,15 @@
+-- SPDX-FileCopyrightText: applecuckoo <nufjoysb@duck.com>
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+function process_route(route)
+    if route:get_id() == "RTTA_REV" or route:get_id() == "RTTA_DEF" then
+        -- reject non-revenue/out-of-service trips
+        return false
+    elseif string.find(route:get_id(), "^8[8-9]%d%u$") then
+        -- reject suburban charters
+        return false
+    elseif string.find(route:get_id(), "^[HNWC]H0[1-9]$") or string.find(route:get_id(), "^[HNWC]H[1-9]%d$") then
+        -- reject private hire intercity
+        return false
+    end
+end


### PR DESCRIPTION
as previously discussed both in #1597 and in Matrix we currently don't really have a good way to use the RT data without getting rate-limited. There are also a couple fixes to the Sydney Trains feed here to align this with TfNSW recommendations (dropping all trips available in the NSW Trains feed and non-revenue/private hire)

fixes #1597