### PR TITLE
nz: Te Huia deduplication script

### DIFF
--- a/feeds/nz.json
+++ b/feeds/nz.json
@@ -114,7 +114,8 @@
         {
             "name": "BUSIT",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-busit~nz"
+            "transitland-atlas-id": "f-busit~nz",
+            "script": "nz-BUSIT.lua"
         },
         {
             "name": "Baybus",

--- a/scripts/nz-BUSIT.lua
+++ b/scripts/nz-BUSIT.lua
@@ -1,0 +1,9 @@
+-- SPDX-FileCopyrightText: applecuckoo <nufjoysb@duck.com>
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+function process_route(route)
+    -- skip Te Huia in favour of AT feed
+    if route:get_short_name() == "TE_HUIA" then
+        return false
+    end
+end


### PR DESCRIPTION
self-explanatory, removes Te Huia from the BUSIT feed in favour of the AT feed