### PR TITLE
Use gtfs.kasznia.net feed for PKP Intercity

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -16,9 +16,12 @@
     "sources": [
         {
             "name": "PKP-Intercity",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-pkp~intercity~pl",
-            "script": "pl-PKP-Intercity.lua"
+            "type": "http",
+            "url": "https://gtfs.kasznia.net/static/pkp-ic.zip",
+            "script": "pl-PKP-Intercity.lua",
+            "license":{
+                "spdx-identifier":"CC-BY-4.0"
+            }
         },
         {
             "name": "PKP-Intercity",


### PR DESCRIPTION
The feed is a fork of the original feed with:
- Added platforms with correct locations (if available) - original feed has a non standard field (`platform`) in stop_times.txt, this feed has a separate stop for each platform.
- Added “timing points” (`pickup_type=1` and `drop_off_type=1`) - stations that the train passes, without stopping and for which there's geographical and timing data. Source data from which the feed is created has various level of those timing points, sometimes they're stations, sometimes switch numbers with no good source of location data - those are excluded).

This gives better approximation to the actual shape of the trip (as Intercity trains have fewer stops than regional trains), while not polluting shape data with rough data.

Comparison (left - new feed, right - current feed):
<img width="3832" height="1971" alt="Screenshot 2025-10-15 190732" src="https://github.com/user-attachments/assets/16af7e07-c3cd-407c-a02e-cc88fcab1d05" />
