### PR TITLE
Remove useless agency URL in DELFI feed

### DIFF
--- a/scripts/de-DELFI.lua
+++ b/scripts/de-DELFI.lua
@@ -45,3 +45,9 @@ function process_trip(trip)
     trip:set_display_name(trip:get_route():get_short_name() .. ' (' .. remove_leading_zeros(trip:get_short_name()) .. ')')
   end
 end
+
+function process_agency(agency)
+  if agency:get_url() == "https://www.delfi.de" then
+    agency:set_url("")
+  end
+end


### PR DESCRIPTION
DELFI currently sets its own URL here unconditionally, instead of passing on the URLs matching the agency name. As DELFI is merely an aggregator without passenger-facing value this pollutes the agency URL field for actual user-facing usage.