### PR TITLE
au-vic: fix link to feed

### DIFF
--- a/feeds/au-vic.json
+++ b/feeds/au-vic.json
@@ -134,7 +134,7 @@
             }
         },
         {
-            "name": "Transport-Victoria-metro-buses",
+            "name": "Transport-Victoria-myki-buses",
             "type": "http",
             "spec": "gtfs",
             "url": "https://gitlab.com/applecuckoo/gtfs-fixes/-/jobs/artifacts/main/raw/vic-gtfs.zip?job=victoria-mirror#4/google_transit.zip",
@@ -144,7 +144,19 @@
             "fix": true
         },
         {
-            "name": "Transport-Victoria-metro-buses",
+            "name": "Transport-Victoria-myki-buses",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/bus/vehicle-positions",
+            "license": {
+                "spdx_identifier": "CC-BY-4.0"
+            },
+            "headers": {
+                "KeyId": "ffb807b0-9a50-4123-b4d7-ce762f81d84b"
+            }
+        },
+        {
+            "name": "Transport-Victoria-myki-buses",
             "type": "url",
             "spec": "gtfs-rt",
             "url": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/bus/trip-updates",


### PR DESCRIPTION
at some point they somehow managed to change the resource UUID even though it dates from 2015 - if it changes again then I might make a helper script based on the CKAN API so we can keep up with this.

~doesn't seem to be the cause of the 504 errors though... might be better to mirror this in the long term~ done now!

fixes #1495