### PR TITLE
Add VRS gtfs feed

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -11,6 +11,10 @@
         {
             "name": "Max Buchholz",
             "github": "1Maxnet1"
+        },
+        {
+            "name": "Pingu",
+            "github": "PinguDEV-original"
         }
     ],
     "sources": [
@@ -210,6 +214,14 @@
             "name": "NextbikeLeipzig",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-nextbike~leipzig~gbfs"
+        },
+        {
+            "name": "VRS",
+            "type": "http",
+            "url": "https://download.vrs.de/gtfs/GTFS_VRS_mit_SPNV_hID_GlobalID.zip",
+            "license": {
+                "spdx-identifier": "DL-DE-ZERO-2.0"
+            }
         }
     ]
 }


### PR DESCRIPTION
This pull request adds a GTFS feed for the german transport association called VRS.  
It covers the room around Bonn and Cologne.  