### PR TITLE
Add alerts GTFS-RT feed for Poznań

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -280,6 +280,12 @@
             "transitland-atlas-id": "f-u3k4-poznan~rt"
         },
         {
+            "name": "Poznań",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://bimba.apiote.xyz/gtfs-rt/pl-poznan_alerts.pb"
+        },
+        {
             "name": "Szczecin",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u36r-zditmszczecin"


### PR DESCRIPTION
This is a GTFS-RT feed converted from a custom API of Poznań ZTM. I'm trying not to overload their servers so that they won't block me, and so far the feed is updated every 12 hours. I can see that nginx adds automatically etag and last-modified headers.

I didn't know if I should fill out the license field—my converted feed is available freely, their API is sort of hidden in there website code. 

Let me know if anything is not as it should be. 