### PR TITLE
Update MOTIS API documentation to v2.7.0

### DIFF
--- a/website/content/api.html
+++ b/website/content/api.html
@@ -58,7 +58,7 @@ We will make a decision on a case-by-case basis.
 
 <p>API endpoints for Transitous' own development, such as the staging instance (<code>staging.api.transitous.org</code>), or internal API endpoints for direct access to servers behind the load balancer (<code>*.motis-project.org</code>, <code>*.motis-project.de</code>, <code>*.spline.de</code>), must not be used by applications.</p>
 
-<a class="btn btn-primary text-black" href="https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/motis-project/motis/refs/tags/v2.5.1/openapi.yaml">API Documentation</a>
+<a class="btn btn-primary text-black" href="https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/motis-project/motis/refs/tags/v2.7.0/openapi.yaml">API Documentation</a>
 
 <h2>Client Libraries</h2>
 <div class="mt-4 app-card-row">


### PR DESCRIPTION
That's the lowest version currently deployed on any of the instances.