### PR TITLE
nz: add goBay (Hawke's Bay)

### DIFF
--- a/feeds/nz.json
+++ b/feeds/nz.json
@@ -136,6 +136,16 @@
             "name": "eBus",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-nsn~nz"
+        },
+        {
+            "name": "goBay",
+            "type": "http",
+            "spec": "gtfs",
+            "url": "https://data.trilliumtransit.com/gtfs/hbrc-nz/hbrc-nz.zip",
+            "license": {
+                "spdx_identifier": "CC-BY-4.0",
+                "url": "https://www.gobay.co.nz/general-transit-feed-specification/"
+            }
         }
     ]
 }


### PR DESCRIPTION
this PR should bring our NZ static feed coverage on par with Transit :-)

RT feeds are a different story though... some emailing and/or FOI-ing might be in order for the future