### PR TITLE
Add IPA pronunciation link for Transitous

### DIFF
--- a/website/content/_index.html
+++ b/website/content/_index.html
@@ -20,7 +20,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 }
 </style>
 
-<p>Transitous is a community-run provider-neutral international public transport routing service.</p>
+<p>Transitous [<a target="_blank" href="https://ipa-reader.com/?text=%CB%88t%C9%B9%C3%A6n.s%C9%AA%CA%83%C9%99s">ˈtɹæn.sɪʃəs<i class="bi bi-box-arrow-right ms-1"></i></a>] is a community-run provider-neutral international public transport routing service.</p>
+
 
 <p>Using openly available data and a FOSS routing engine we operate a free to use
 routing service that does not stop at borders.</p>


### PR DESCRIPTION
At the Open Transport Community Conference there was talk about how unsure some people are about how exactly the name is pronounced.
I've added a phonetic transcription for the pronunciation, as I remember it from the conference as being "correct".