### PR TITLE
Move Open Transport Community Conference to recent events

### DIFF
--- a/website/content/_index.html
+++ b/website/content/_index.html
@@ -50,12 +50,12 @@ routing service that does not stop at borders.</p>
 <p>If you know where to find public transport data for your region, or if you are a public transport operator, you can help by adding the feed to our data set.</p>
 <a class="btn btn-primary theme-button text-black" href="https://transitous.org/doc#adding-a-region"><i class="bi bi-arrow-right m-1"></i>Contributor Documentation</a>
 
+<!--
 <h2>Upcoming Events</h2>
 <p>Want to meet the Transitous community in person? Some of us will be at the following events:</p>
 <ul>
-  <li><a href="https://open-transport.org">Open Transport Community Conference</a>, Oct 17/18 2025, Vienna, Austria.</li>
 </ul>
-
+-->
 <h2>Conference Talks and Presentations</h2>
 <p>Looking for an overview of how this project works? There are several public talks from conferences and meetups that you can watch.</p>
 
@@ -82,4 +82,7 @@ routing service that does not stop at borders.</p>
   <li>
      🇩🇪 <a target="_blank" href="https://pretalx.com/fossgis2025/talk/TJVVDZ/" >Transitous - Freies Public Transport Routing - FOSSGIS<i class="bi bi-box-arrow-right m-2"></i></a>
   </li>
+    <li>
+        🇬🇧 <a target="_blank" href="https://github.com/public-transport/open-transport-community-conference/wiki/2025-Session-Notes:-Transitous">Session Notes: Transitous – Open Transport Community Conference<i class="bi bi-box-arrow-right m-2"></i></a>
+    </li>
 </ul>


### PR DESCRIPTION
I've moved the Open Transport Community Conference to the recent events and commented the upcoming events block out.