### PR TITLE
Add GTFS feed for Zakroczym

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -15,7 +15,8 @@
         {
             "name": "Alexander Dubis",
             "github": "gtfscc"
-    ]
+        }
+    ],
     "sources": [
         {
             "name": "PKP-Intercity",


### PR DESCRIPTION
This pull request adds a GTFS feed for the Zakroczym Municipality Public Transport.
Feed covers Zakroczym Municipality and parts of Nowy Dwór Mazowiecki.