### PR TITLE
Re-add upcoming events section to the website

### DIFF
--- a/website/content/_index.html
+++ b/website/content/_index.html
@@ -51,39 +51,42 @@ routing service that does not stop at borders.</p>
 <p>If you know where to find public transport data for your region, or if you are a public transport operator, you can help by adding the feed to our data set.</p>
 <a class="btn btn-primary theme-button text-black" href="https://transitous.org/doc#adding-a-region"><i class="bi bi-arrow-right m-1"></i>Contributor Documentation</a>
 
-<!--
 <h2>Upcoming Events</h2>
 <p>Want to meet the Transitous community in person? Some of us will be at the following events:</p>
 <ul>
+  <li><a href="https://events.ccc.de/congress/2025/infos/startpage.html">39C3</a>, Dec 27-30 2025, Hamburg, Germany.</li>
+  <li><a href="https://fosdem.org/2026">FOSDEM</a>, Jan 31-Feb 1 2026, Brussels, Belgium.</li>
+  <li><a href="https://fossgis-konferenz.de/2026">FOSSGIS-Konferenz</a>, Mar 25-28, Göttungen, Germany.</li>
+  <li><a href="https://wiki.openstreetmap.org/wiki/State_of_the_Map_2026">State of the Map</a>, Aug 28-30, Paris, France.</li>
 </ul>
--->
+
 <h2>Conference Talks and Presentations</h2>
 <p>Looking for an overview of how this project works? There are several public talks from conferences and meetups that you can watch.</p>
 
-<h3>2024</h3>
-<ul>
-  <li>
-     🇬🇧 <a target="_blank" href="https://meet.systect.de/playback/presentation/2.3/d941f8412ff350b73e9084e0fd1da86394aff088-1708540821542" >Transitous - Open Transport Meetup<i class="bi bi-box-arrow-right m-2"></i></a>
-  </li>
-  <li>
-     🇩🇪 <a target="_blank" href="https://media.ccc.de/v/38c3-transitous-offener-routingdienst-fr-ffentliche-verkehrsmittel" >offener Routingdienst für öffentliche Verkehrsmittel - 38C3<i class="bi bi-box-arrow-right m-2"></i></a>
-  </li>
-</ul>
 <h3>2025</h3>
 <ul>
   <li>
-     🇬🇧 <a target="_blank" href="https://fosdem.org/2025/schedule/event/fosdem-2025-4105-gnome-maps-meets-transitous-meets-motis/" >GNOME Maps meets Transitous meets MOTIS - FOSDEM<i class="bi bi-box-arrow-right m-2"></i></a>
+     🇬🇧 <a target="_blank" href="https://github.com/public-transport/open-transport-community-conference/wiki/2025-Session-Notes:-Transitous">Session Notes: Transitous – Open Transport Community Conference<i class="bi bi-box-arrow-right m-2"></i></a>
   </li>
   <li>
-     🇬🇧 <a target="_blank" href="https://meet.systect.de/playback/presentation/2.3/d941f8412ff350b73e9084e0fd1da86394aff088-1739990087983" >Transitous Import Pipeline - Open Transport Meetup<i class="bi bi-box-arrow-right m-2"></i></a>
+     🇩🇪 <a target="_blank" href="https://pretalx.com/fossgis2025/talk/TJVVDZ/" >Transitous - Freies Public Transport Routing - FOSSGIS<i class="bi bi-box-arrow-right m-2"></i></a>
   </li>
   <li>
      🇩🇪 <a target="_blank" href="https://pretalx.com/fossgis2025/talk/HGUKFM/" >Barrierefreies Routing mit MOTIS - FOSSGIS<i class="bi bi-box-arrow-right m-2"></i></a>
   </li>
   <li>
-     🇩🇪 <a target="_blank" href="https://pretalx.com/fossgis2025/talk/TJVVDZ/" >Transitous - Freies Public Transport Routing - FOSSGIS<i class="bi bi-box-arrow-right m-2"></i></a>
+     🇬🇧 <a target="_blank" href="https://meet.systect.de/playback/presentation/2.3/d941f8412ff350b73e9084e0fd1da86394aff088-1739990087983" >Transitous Import Pipeline - Open Transport Meetup<i class="bi bi-box-arrow-right m-2"></i></a>
   </li>
-    <li>
-        🇬🇧 <a target="_blank" href="https://github.com/public-transport/open-transport-community-conference/wiki/2025-Session-Notes:-Transitous">Session Notes: Transitous – Open Transport Community Conference<i class="bi bi-box-arrow-right m-2"></i></a>
-    </li>
+  <li>
+     🇬🇧 <a target="_blank" href="https://fosdem.org/2025/schedule/event/fosdem-2025-4105-gnome-maps-meets-transitous-meets-motis/" >GNOME Maps meets Transitous meets MOTIS - FOSDEM<i class="bi bi-box-arrow-right m-2"></i></a>
+  </li>
+</ul>
+<h3>2024</h3>
+<ul>
+  <li>
+     🇩🇪 <a target="_blank" href="https://media.ccc.de/v/38c3-transitous-offener-routingdienst-fr-ffentliche-verkehrsmittel" >offener Routingdienst für öffentliche Verkehrsmittel - 38C3<i class="bi bi-box-arrow-right m-2"></i></a>
+  </li>
+  <li>
+     🇬🇧 <a target="_blank" href="https://meet.systect.de/playback/presentation/2.3/d941f8412ff350b73e9084e0fd1da86394aff088-1708540821542" >Transitous - Open Transport Meetup<i class="bi bi-box-arrow-right m-2"></i></a>
+  </li>
 </ul>


### PR DESCRIPTION
We don't have confirmed talks at those events (yet), but at least people of the team attending.

Also, reverse the sorting of the talks section to have the newest ones first.