### PR TITLE
Add new RT feeds and ŁKA

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -527,7 +527,8 @@
             "url": "https://cdn.zbiorkom.live/gtfs-rt/lodz.pb",
             "license": {
                 "spdx-identifier": "MIT"
-            }
+            },
+            "fix": true
         },
         {
             "name": "Białystok",


### PR DESCRIPTION
- ŁKA - switch to two feeds:
   - one for trains: sanitized, with colors and properly marked rail replacement buses
   - and one for buses: sanitized, with RT from zbiorkom
- New RT feeds for cities around Warsaw
- New feed for Świnoujście