### PR TITLE
hk: replace Transport Department feed with community feed

### DIFF
--- a/feeds/hk.json
+++ b/feeds/hk.json
@@ -3,13 +3,21 @@
         {
             "name": "Gordon Leung",
             "github": "pi-cla"
+        },
+        {
+            "name": "applecuckoo",
+            "github": "applecuckoo"
         }
     ],
     "sources": [
         {
             "name": "Hong-Kong-Transit",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-hong~kong~en"
+            "type": "http",
+            "url": "https://feed.justusewheels.com/hk.gtfs.zip",
+            "license": {
+                "spdx_identifier": "ODbL-1.0",
+                "url": "https://github.com/wheelstransit/hongkong-community-gtfs/tree/main?tab=readme-ov-file#license"
+            }
         }
     ]
 }


### PR DESCRIPTION
cc @anscg

adds the [Hong Kong Community GTFS](https://github.com/wheelstransit/hongkong-community-gtfs) feed to replace the current Transport Department feed