### PR TITLE
BlaBlaCar Bus trip display update

### DIFF
--- a/feeds/eu.json
+++ b/feeds/eu.json
@@ -32,6 +32,7 @@
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u0-ouibus",
             "url-override": "https://www.data.gouv.fr/api/1/datasets/r/fd54f81f-4389-4e73-be75-491133d011c3",
+            "script": "eu-blablacar-bus.lua",
             "fix": true
         },
         {

--- a/scripts/eu-blablacar-bus.lua
+++ b/scripts/eu-blablacar-bus.lua
@@ -1,0 +1,9 @@
+-- SPDX-FileCopyrightText: Transitous Contributors
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+require "scripts.motis"
+
+function process_trip(trip)
+    trip:set_display_name('BlaBlaCar Bus ' .. trip:get_short_name())
+    trip:set_headsign(route:get_long_name())
+end


### PR DESCRIPTION
I've set the BBC B trips display to also show the route number
Also I've modified the headsign to show the longer route name, it might make the headsigns much larger, but I think it's more comprehensive than what is already included in the feed, the last stop option for the script would be helpful here...