### PR TITLE
nz: add Flamingo Christchurch

### DIFF
--- a/feeds/nz.json
+++ b/feeds/nz.json
@@ -28,6 +28,12 @@
             "transitland-atlas-id": "f-flamingo~auckland~gbfs"
         },
         {
+            "name": "Flamingo-Christchurch",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://data.rideflamingo.com/gbfs/3/wellington/gbfs.json"
+        },
+        {
             "name": "Flamingo-Dunedin",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-flamingo~dunedin~gbfs"


### PR DESCRIPTION
self-explanatory. This feed is set up as a `url` for now - a PR has been made to add this to the GBFS repo which should be downstreamed to Transitland Atlas and the Mobility Database.