### PR TITLE
nz: fix Flamingo Christchurch feed

### DIFF
--- a/feeds/nz.json
+++ b/feeds/nz.json
@@ -31,7 +31,7 @@
             "name": "Flamingo-Christchurch",
             "type": "url",
             "spec": "gbfs",
-            "url": "https://data.rideflamingo.com/gbfs/3/wellington/gbfs.json"
+            "url": "https://data.rideflamingo.com/gbfs/3/christchurch/gbfs.json"
         },
         {
             "name": "Flamingo-Dunedin",


### PR DESCRIPTION
duplicated the Wellington feed instead of actually adding the Christchurch feed