### PR TITLE
usage policy: Improve browser-related rules

### DIFF
--- a/website/content/api.html
+++ b/website/content/api.html
@@ -19,7 +19,7 @@ We provide the service on a best-effort basis and reserve the right to stop prov
 <h3>Resource Usage</h3>
 
 <p>Our hosting resources are limited.
-Please contact us before doing any potentially resource-intensive operations, such as many requests (also from different users) or primarily difficult to calculate requests (such as routing, isochrones).
+Please contact us before using any potentially resource-intensive API endpoints, doing many requests (also from different users) or primarily doing difficult to calculate requests (such as routing, isochrones) in your project.
 Generally, if your requests take long, they are difficult to calculate.</p>
 
 <p>We'll try to find ways to accommodate your use. Should we hit the limits of what we can handle with our current resources,
@@ -34,12 +34,20 @@ there's also the option to <a href="/doc/#running-a-transitous-instance-locally"
 <ul>
 <li>Contact us <a href="https://matrix.to/#/%23transitous:matrix.spline.de">in our Matrix Channel</a> to make sure we can handle your
 expected resource usage and so we are aware of your usecases. This also allows us to contact you in case we want to coordinate breaking changes.</li>
-<li>Make sure your send HTTP <code>User-Agent</code> or <code>X-Client-Identification</code> headers with every request, at least containing the following information:</li>
-<ul>
-    <li>Name of the application</li>
-    <li>Version of the client implementation</li>
-    <li>A way of contact (e-mail address or website URL)</li>
-</ul>
+<li>
+    <p>
+        Make sure your send HTTP <code>User-Agent</code> headers with every request, at least containing the following information:
+        <ul>
+            <li>Name of the application</li>
+            <li>Version of the client implementation</li>
+            <li>A way of contact (e-mail address or website URL)</li>
+        </ul>
+    </p>
+    <p>
+    If it is not possible to send a <code>User-Agent</code> header, because your application runs inside a browser, the <code>Referer</code> header is a sufficient replacement.
+    However, please make sure to add contact information to your website in this case.
+    </p>
+</li>
 <li>You may <a href="https://github.com/public-transport/transitous/blob/b2d184b51cb4cf20fb48d0b76420ba57f4d3fce0/website/content/_index.html#L30">add your application to the Transitous website</a></li>
 </ul>
 


### PR DESCRIPTION
The header we currently recommend can not be sent in practice, because
our OPTIONS response does not allow it.
