### PR TITLE
Dropped BSAG Bremen and VOS Osnabrück from DELFI to use local GTFS feed

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -33,7 +33,8 @@
                 "SWO Mobil GmbH",
                 "FlixBus-de",
                 "EUROSTAR",
-                "Bremer Straßenbahn AG"
+                "Bremer Straßenbahn AG",
+                "Verkehrsgemeinschaft Osnabrück"
             ],
             "http-options": {
                 "fetch-interval-days": 2


### PR DESCRIPTION
BSAG Bremen offers higher data quality in VBN's GTFS dataset, in my experience, that's why I'd like to kick it out from DELFI.

The higher quality is noticeable with special trips which aren't always in DELFI's dataset.