### PR TITLE
Error message displayed when searching without selecting stations (UI)Add validation for station selection in view

### DIFF
--- a/website/src/Main.purs
+++ b/website/src/Main.purs
@@ -44,13 +44,16 @@ view :: State -> Dispatch Message -> ReactElement
 view state dispatch = H.div "text-end card-body p-4"
   [ SearchBox.view state.departureBox (dispatch <<< DepartureMsg)
   , SearchBox.view state.arrivalBox (dispatch <<< ArrivalMsg)
-  , H.a_ "btn btn-primary mt-2"
-      { href: fromMaybe "" do
-          start <- state.departureBox.station
-          destination <- state.arrivalBox.station
-          pure $ toMotisWebUrl start destination
-      }
-      "Search"
+  , if state.departureBox.station == Nothing || state.arrivalBox.station == Nothing
+    then H.div "text-danger mt-2" [ H.text "Veuillez sélectionner une gare de départ et d'arrivée." ]
+    else
+      H.a_ "btn btn-primary mt-2"
+        { href: fromMaybe "" do
+            start <- state.departureBox.station
+            destination <- state.arrivalBox.station
+            pure $ toMotisWebUrl start destination
+        }
+        "Search"
   ]
 
 main :: Effect Unit


### PR DESCRIPTION
### Motivation
When the user clicks on the “Search” button without selecting the departure and arrival stations, no information is displayed and the query is empty.  
This change adds a red error message to guide the user.

### Details of the change
- Addition of a conditional display in the `view` function of the `website/src/Main.purs` file.
- Message: “Please select a departure and arrival station.”
- Improved user experience on the interface side.

### Screenshots
(Optional: attach a before/after screenshot, if you can)

### Task type
- Refactoring/UI
- Documentation (if you add a comment/describe your change)