### PR TITLE
Switch trains to extended feeds, add new feeds from girlc.at

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -1344,7 +1344,7 @@
             }
         },
         {
-            "name": "Aleksandrów-Łódzki",
+            "name": "Częstochowa",
             "type": "http",
             "spec": "gtfs",
             "url": "https://cdn.zbiorkom.live/gtfs/czestochowa.zip",


### PR DESCRIPTION
- Koleje Śląskie - feed switched to one merging multiple yearly feeds (official one is per train timetable year)
- Koleje Wielkopolskie - feed switched to feed with proper route names and colors, and proper handling of rail replacement bus
- Ciechnice, Goleniów, Aleksandrów-Łódzki, Częstochowa - new feeds from girlc.at and zbiorkom.live