### PR TITLE
jp: GTFS-Realtime for Tokyo railways

### DIFF
--- a/feeds/jp.json
+++ b/feeds/jp.json
@@ -24,6 +24,24 @@
                 "spdx-identifier": "MIT"
             },
             "fix": true
+        },
+        {
+            "name": "tokyo-rail",
+            "spec": "gtfs-rt",
+            "type": "http",
+            "url": "https://mkuran.pl/gtfs/tokyo/rail_alerts.pb",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            }
+        },
+        {
+            "name": "tokyo-rail",
+            "spec": "gtfs-rt",
+            "type": "http",
+            "url": "https://mkuran.pl/gtfs/tokyo/rail_positions.pb",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            }
         }
     ]
 }


### PR DESCRIPTION
This PR adds two GTFS-Realtime feeds for Tokyo railways - one with alerts for almost all routes, and one with trip updates for a couple of the biggest agencies. Both are available under CC-BY-4.0.

I'm guessing cc @altonss as they're the maintainer mentioned in jp.json.