### PR TITLE
Fix #1763: VBN duplicates

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -82,6 +82,9 @@
             "name": "VBN",
             "type": "http",
             "url": "https://www.connect-info.net/opendata/gtfs/connect-nds-lowlevel/eyqasqtsse",
+            "drop-agency-names": [
+                "DB Fernverkehr (Codesharing)"
+            ],
             "http-options": {
                 "fetch-interval-days": 1
             },


### PR DESCRIPTION
The name is "DB Fernverkehr (Codesharing)", and it had SBB Nightjets, and IC by DB Fernfehrkehr that are code-shared with regional trains (Bremen-Emden, Berlin-Prenzlau, Stuttgart-Singen, etc). All of these should be in DELFI or other feeds.

part of the fix of #1763