### PR TITLE
hu: replace v-busz feed URL with a direct one

### DIFF
--- a/feeds/hu.json
+++ b/feeds/hu.json
@@ -50,7 +50,7 @@
         {
             "name": "v-busz",
             "type": "http",
-            "url": "https://gtfs.menetbrand.com/download/veszprem",
+            "url": "https://vbusz.hu/gtfs",
             "license": {
                 "spdx-identifier": "CC0-1.0"
             }


### PR DESCRIPTION
…that's updated directly by the operator, therefore is probably more reliable.

Fixes #1771.