### PR TITLE
Add Thailand Public Transport Feed

### DIFF
--- a/feeds/th.json
+++ b/feeds/th.json
@@ -1,0 +1,15 @@
+{
+    "maintainers": [
+        {
+            "name": "Skye Willett",
+            "github": "ExoSkye"
+        }
+    ],
+    "sources": [
+        {
+            "name": "th-namtang",
+            "type": "mobility-database",
+            "mdb-id": "mdb-1831"
+        }
+    ]
+}


### PR DESCRIPTION
This adds a very simple feed description for Thailand Office of Traffic Planning's GTFS feed (ID: namtang).

It's not perfect, but it includes quite a lot of Thailand's public transport (if not all of it), which is very handy. Such as Bangkok's BTS, MRT, buses and boats, the SRT trains, some of the ferries, etc.

I've listed myself as a maintainer, but truthfully I just have family here (and am currently in Thailand as I write this), and they're planning to move back to the UK soon. Thought it'd be good to add nonetheless.