### PR TITLE
Add licensing information and other options to Namtang feed

### DIFF
--- a/feeds/th.json
+++ b/feeds/th.json
@@ -10,7 +10,6 @@
             "name": "th-namtang",
             "type": "mobility-database",
             "mdb-id": "mdb-1831",
-            "drop-too-fast-trips": false,
             "license": {
                 "spdx-identifier": "CC-BY-4.0"
             }


### PR DESCRIPTION
I should've probably added these in my first PR - but I didn't think it was necessary. However upon further inspection I found that MobilityDatabase sources do need licensing information to be attached. So I've added that here.

I also noticed that the feeds being too fast checking was causing some trips to be removed when they shouldn't be, so I've also told it to not remove trips that are too fast.