### PR TITLE
hu: add funicular GTFS

### DIFF
--- a/feeds/hu.json
+++ b/feeds/hu.json
@@ -32,6 +32,11 @@
             "transitland-atlas-id": "f-u2m-bkk"
         },
         {
+            "name": "bkk-funicular",
+            "type": "http",
+            "url": "https://gy-mate.hu/gtfs/gtfs_hu_funicular.zip"
+        },
+        {
             "name": "bkk",
             "type": "url",
             "spec": "gtfs-rt",


### PR DESCRIPTION
Add a self-created GTFS of the Budapest Castle Hill Funicular. It's a simple line with regular headways.

The feed is automatically built and updated from [gy-mate/gtfs-feeds](https://github.com/gy-mate/gtfs-feeds/tree/751ecb9e6668c6bd9f11c7984071a070b0260dcb/hu_funicular). It's currently valid for the whole year of 2026.