### PR TITLE
Add esel.ac GBFS feed

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -228,6 +228,12 @@
             "type": "url",
             "url": "https://gbfs.api.ridedott.com/public/v2/berlin/gbfs.json",
             "spec": "gbfs"
+        },
+        {
+            "name": "esel.ac",
+            "type": "url",
+            "url": "https://di.esel.ac/gbfs/gbfs.json",
+            "spec": "gbfs"
         }
     ]
 }


### PR DESCRIPTION
Community-operated bike sharing network in Aachen.