### PR TITLE
Add unofficial GTFS-RT feeds for Ile de France Mobilités

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -356,11 +356,10 @@
             "type": "url",
             "url": "http://gtfsidfm.clarifygdps.com/gtfs-rt-trips-idfm",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-et-interurbain-dile-de-france-mobilites",
+                "url": "https://github.com/Jouca/IDFM_GTFS-RT/blob/main/LICENSE",
                 "spdx-identifier": null
             },
             "spec": "gtfs-rt",
-            "x-data-gov-fr-res-id": 80921,
             "managed-by-script": false
         },
         {
@@ -368,11 +367,10 @@
             "type": "url",
             "url": "http://gtfsidfm.clarifygdps.com/gtfs-rt-alerts-idfm",
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-et-interurbain-dile-de-france-mobilites",
+                "url": "https://github.com/Jouca/IDFM_GTFS-RT/blob/main/LICENSE",
                 "spdx-identifier": null
             },
             "spec": "gtfs-rt",
-            "x-data-gov-fr-res-id": 80921,
             "managed-by-script": false
         },
         {


### PR DESCRIPTION
Add unofficial GTFS-RT feeds for Ile de France Mobilités (greater Paris region), fixing #1786 .