### PR TITLE
Remove Stadtwerke Landshut agency from DELFI feed

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -34,7 +34,8 @@
                 "FlixBus-de",
                 "EUROSTAR",
                 "Bremer Straßenbahn AG",
-                "Verkehrsgemeinschaft Osnabrück"
+                "Verkehrsgemeinschaft Osnabrück",
+                "Stadtwerke Landshut"
             ],
             "http-options": {
                 "fetch-interval-days": 2


### PR DESCRIPTION
Trips in the city of Landshut are currently served by two agencies in DELFI for some reason, which results in some duplicate trips:

See also: https://github.com/mfdz/GTFS-Issues/issues/233

I decided to remove the agency with incomplete data that was added just recently until DELFI figures out what's going on. 

<img width="530" height="914" alt="Image" src="https://github.com/user-attachments/assets/23305ae1-2894-4d58-b470-cb9061ae8a8b" />
