### PR TITLE
Exclude foreign agencies from the swiss feed

### DIFF
--- a/feeds/ch.json
+++ b/feeds/ch.json
@@ -14,7 +14,12 @@
                 "url": "https://opentransportdata.swiss/de/terms-of-use/"
             },
             "drop-agency-names": [
-                "DB Regio AG Baden-Württemberg"
+                "DB Regio AG Baden-Württemberg",
+                "FPLAN VHB SBP",
+                "FPLAN BOD RAB OMP",
+                "Verkehrsverbund Vorarlberg",
+                "DistriBus",
+                "Südbadenbus"
             ],
             "script": "ch-opentransportdataswiss.lua"
         },


### PR DESCRIPTION
The reason for this are duplicated trips from the swiss feed and the other (correct) feeds.