### PR TITLE
th: fix typo of silom as silon

### DIFF
--- a/scripts/th-namtang.lua
+++ b/scripts/th-namtang.lua
@@ -8,7 +8,7 @@ local route_type_map = {
 
     -- BTS Lines
     ["Sukhumvit"] = SUBURBAN,
-    ["Silon"] = SUBURBAN,
+    ["Silom"] = SUBURBAN,
     ["Gold"] = SUBURBAN,
 
     -- MRT Lines


### PR DESCRIPTION
Accidentally made this typo earlier. Also - there appears to be an updated namtang feed now, should I remove the "extend-calender-dates" option from the feed config?