### PR TITLE
th: remove extend-calender-dates from namtang feed

### DIFF
--- a/feeds/th.json
+++ b/feeds/th.json
@@ -13,8 +13,7 @@
             "license": {
                 "spdx-identifier": "CC-BY-4.0"
             },
-            "script": "th-namtang.lua",
-            "extend-calendar": true
+            "script": "th-namtang.lua"
         }
     ]
 }


### PR DESCRIPTION
as mentioned in #1825. may be worth waiting until tomorrow (UTC) to merge this as mobilitydatabase hasn't updated their version of the feed yet. 