### PR TITLE
Simplify Matrix channel references

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ routing service that:
 
 ## Contact
 
-For general discussions about data availability: [#opentransport:matrix.org](https://matrix.to/#/#opentransport:matrix.org)
-
-For Transitous-specific technical topics: [#transitous:matrix.spline.de](https://matrix.to/#/#transitous:matrix.spline.de)
+Matrix channel: [#transitous:matrix.spline.de](https://matrix.to/#/#transitous:matrix.spline.de)
 
 Also, follow <a href="https://en.osm.town/@transitous" rel="me">Transitous on Mastodon</a>.
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -30,9 +30,7 @@ routing service that:
 
 ## Contact
 
-For general discussions about data availability: [#opentransport:matrix.org](https://matrix.to/#/#opentransport:matrix.org)
-
-For Transitous-specific technical topics: [#transitous:matrix.spline.de](https://matrix.to/#/#transitous:matrix.spline.de)
+Matrix channel: [#transitous:matrix.spline.de](https://matrix.to/#/#transitous:matrix.spline.de)
 
 ## Used data
 


### PR DESCRIPTION
Only list the Transitous channel, to reduce the risk of Transitous issues ending up in the general open-transport channel.

This is mostly a leftover from the early days, before we had our own channel.