### PR TITLE
nz: reinstate Flamingo Christchurch feed

### DIFF
--- a/feeds/nz.json
+++ b/feeds/nz.json
@@ -28,6 +28,12 @@
             "transitland-atlas-id": "f-flamingo~auckland~gbfs"
         },
         {
+            "name": "Flamingo-Christchurch",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://data.rideflamingo.com/gbfs/3/christchurch/gbfs.json"
+        },
+        {
             "name": "Flamingo-Dunedin",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-flamingo~dunedin~gbfs"


### PR DESCRIPTION
they have relaunched in Christchurch since I removed their feed