### PR TITLE
fr: Switch back to data.gouv.fr redirect urls

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -26,7 +26,7 @@
         {
             "name": "citiz-autopartage-developpement",
             "type": "url",
-            "url": "https://backend.citiz.fr/public/provider/12/gbfs/3.0/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/e64161a2-b7f9-4562-9f13-50a7b758e04a",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/citiz-autopartage-developpement",
@@ -38,7 +38,7 @@
         {
             "name": "gbfs-autopartage-publique-clem",
             "type": "url",
-            "url": "https://gbfs.clem.mobi/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/d21303b7-542d-4642-999a-fcd7f14047fb",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gbfs-autopartage-publique-clem",
@@ -50,7 +50,7 @@
         {
             "name": "flotte-getaround-en-libre-service-france",
             "type": "url",
-            "url": "https://fr.getaround.com/gbfs/manifest?country_code=FR",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/b9a4aeb4-7689-47ea-83a8-992378985381",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/flotte-getaround-en-libre-service-france",
@@ -63,7 +63,6 @@
             "name": "horaires-ave-espagne-france",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/eae0fa46-087a-4018-ada9-d8add124e635",
-            "url-override": "https://ssl.renfe.com/gtransit/Fichero_AV_INT/Renfe_AVE_Int.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-ave-espagne-france",
@@ -77,7 +76,6 @@
             "name": "blablacar-bus-horaires-theoriques-et-temps-reel-du-reseau-europeen",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/fd54f81f-4389-4e73-be75-491133d011c3",
-            "url-override": "https://drive.google.com/uc?export=download&id=1VXd01yQl2Mb67C9bkrx0P8sqNIL532_o",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/blablacar-bus-horaires-theoriques-et-temps-reel-du-reseau-europeen",
@@ -91,7 +89,6 @@
             "name": "eurostar-gtfs-plan-de-transport-et-temps-reel",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/bfd97acd-63f3-4ea4-bfe8-70e4c7fd8d13",
-            "url-override": "https://integration-storage.dm.eurostar.com/gtfs-prod/gtfs_static_commercial_v2.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/eurostar-gtfs-plan-de-transport-et-temps-reel",
@@ -105,7 +102,7 @@
         {
             "name": "eurostar-gtfs-plan-de-transport-et-temps-reel",
             "type": "url",
-            "url": "https://integration-storage.dm.eurostar.com/gtfs-prod/gtfs_rt_v2.bin",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/9c3a3d5c-a52c-451e-89c8-32822af20bee",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/eurostar-gtfs-plan-de-transport-et-temps-reel",
                 "spdx-identifier": "etalab-2.0"
@@ -118,7 +115,6 @@
             "name": "flixbus-horaires-theoriques-du-reseau-europeen-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/30d94e83-48a4-4c44-8a96-c082377f5221",
-            "url-override": "https://gtfs.gis.flix.tech/gtfs_generic_eu.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/flixbus-horaires-theoriques-du-reseau-europeen-1",
@@ -132,7 +128,6 @@
             "name": "horaires-des-trains-trenitalia-france",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/bdecea2c-ebc9-4f22-812d-927e4a2e4bad",
-            "url-override": "https://thello.axelor.com/public/gtfs/gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-des-trains-trenitalia-france",
@@ -158,7 +153,6 @@
             "name": "horaires-sncf--83582",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/9ae758ec-cd7a-40cd-a890-bb3963224942",
-            "url-override": "https://eu.ftp.opendatasoft.com/sncf/plandata/Export_OpenData_SNCF_GTFS_NewTripId.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-sncf",
@@ -173,7 +167,6 @@
             "name": "horaires-sncf",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f7261f25-f76c-4324-97bb-c46c78316d6f",
-            "url-override": "https://eu.ftp.opendatasoft.com/sncf/plandata/export-opendata-sncf-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-sncf",
@@ -210,7 +203,7 @@
         {
             "name": "tier-dott-gbfs-france--82747",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/countries/fr/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/cec0a6f6-676f-4670-afc8-8ee0ce834350",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-france",
@@ -223,7 +216,7 @@
         {
             "name": "tier-dott-gbfs-france--82748",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/bourgoin-jallieu/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/472eb166-6531-4ded-b63a-255f34a23d65",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-france",
@@ -236,7 +229,7 @@
         {
             "name": "tier-dott-gbfs-france--82749",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/gpseo/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/ee6d78be-d7d7-4550-a78e-8e79e7ef5888",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-france",
@@ -249,7 +242,7 @@
         {
             "name": "tier-dott-gbfs-france--82750",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/paris/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/be9ce6cd-ebce-47a6-8f9d-1d6bb7ec8976",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-france",
@@ -262,7 +255,7 @@
         {
             "name": "tier-dott-gbfs-france--82751",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/lyon/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/8c675be6-2280-46cf-8c82-a3446df11f9c",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-france",
@@ -275,7 +268,7 @@
         {
             "name": "tier-dott-gbfs-france--82752",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/saint-quentin-en-yvelines/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a057a711-32cd-45f6-8dd8-6865af20f9cc",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-france",
@@ -288,7 +281,7 @@
         {
             "name": "tier-dott-gbfs-france--82753",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/bordeaux/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/e78ffe2d-c65f-4240-9937-bc860b3d32af",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-france",
@@ -301,7 +294,7 @@
         {
             "name": "tier-dott-gbfs-france--82754",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/ol-vallee/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/226663e8-9434-4190-b67d-06f930145313",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-france",
@@ -314,7 +307,7 @@
         {
             "name": "tier-dott-gbfs-france--82755",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/casgbs/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/73866813-aa8d-4db6-aa7e-2b7f58af2270",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-france",
@@ -327,7 +320,7 @@
         {
             "name": "tier-dott-gbfs-france--82756",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/grenoble/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/c14bfbd4-4199-430d-ad76-d2a544737dbf",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-france",
@@ -341,7 +334,6 @@
             "name": "reseau-urbain-et-interurbain-dile-de-france-mobilites",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/413988ed-d340-467b-8be2-7b999fcd207a",
-            "url-override": "https://eu.ftp.opendatasoft.com/stif/GTFS/IDFM-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-et-interurbain-dile-de-france-mobilites",
@@ -377,7 +369,6 @@
             "name": "horaires-des-lignes-transilien-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/1a1eb5ee-6895-4895-a18e-e87827fff0be",
-            "url-override": "https://eu.ftp.opendatasoft.com/sncf/gtfs/transilien-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-des-lignes-transilien-1",
@@ -390,7 +381,7 @@
         {
             "name": "velib-velos-et-bornes-disponibilite-temps-reel",
             "type": "url",
-            "url": "https://velib-metropole-opendata.smovengo.cloud/opendata/Velib_Metropole/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/9c47d47b-2e09-4c4d-8033-4ef24414afd7",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velib-velos-et-bornes-disponibilite-temps-reel",
@@ -403,7 +394,6 @@
             "name": "agregat-oura",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/231acea2-40cf-4c06-b2eb-646274e0b853",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=OURA&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/agregat-oura",
@@ -416,7 +406,7 @@
         {
             "name": "citiz-autopartage-auvergne-rhone-alpes",
             "type": "url",
-            "url": "https://backend.citiz.fr/public/provider/5/gbfs/3.0/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/4553afe7-fdc4-4f0f-98e5-9d11b5039c57",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/citiz-autopartage-auvergne-rhone-alpes",
@@ -429,7 +419,6 @@
             "name": "reseau-interurbain-cars-region-express",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c379471b-c554-4838-9c00-39d7ced7b53a",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=CARS_REGION_EXPRESS&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-express",
@@ -443,7 +432,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-nva-mobilite-agreges-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/e09ee736-ae5e-48c8-ac13-3839e3f2f74a",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/naq-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-nva-mobilite-agreges-1",
@@ -457,7 +445,6 @@
             "name": "reseau-lio-occitanie",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d747fe79-2915-4cdd-8cc5-51a810baaca5",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/lio?apiKey=2b160d626f783808095373766f18714901325e45&type=gtfs_lio",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-lio-occitanie",
@@ -471,7 +458,6 @@
             "name": "horaires-theoriques-de-loffre-du-reseau-ferre-regional-de-transport",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/83620/download",
-            "url-override": "https://geocatalogue.hautsdefrance.fr/gtfs/HDF_TER_GTFS_J___90_jours.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-de-loffre-du-reseau-ferre-regional-de-transport",
@@ -485,7 +471,6 @@
             "name": "agregat-des-reseaux-urbains-et-interurbains-en-region-grand-est",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/83634/download",
-            "url-override": "http://tsi.grandest2.cityway.fr/ftp/opendata/REGION_GRANDEST.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/agregat-des-reseaux-urbains-et-interurbains-en-region-grand-est",
@@ -499,7 +484,6 @@
             "name": "offre-du-reseau-de-transport-interurbain-fluo-grand-est",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/83635/download",
-            "url-override": "https://tsi.grandest2.cityway.fr/ftp/opendata/FLUO.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-du-reseau-de-transport-interurbain-fluo-grand-est",
@@ -512,7 +496,7 @@
         {
             "name": "vls-velo-fluo-grand-est",
             "type": "url",
-            "url": "https://gbfs.partners.fifteen.eu/gbfs/velo-fluo/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/f13fd58e-faa4-4534-9ec3-1e67b2f65b58",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/vls-velo-fluo-grand-est",
@@ -525,7 +509,6 @@
             "name": "lignes-des-reseaux-transport-zou-provence-alpes-cote-d-azur-proximite-3-3",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/9c8116cb-2f1a-4045-b149-c5bf6cae6bef",
-            "url-override": "https://www.datasud.fr/fr/dataset/datasets/3745/resource/5016/download/",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/lignes-des-reseaux-transport-zou-provence-alpes-cote-d-azur-proximite-3-3",
@@ -551,7 +534,6 @@
             "name": "lignes-des-reseaux-transport-zou-provence-alpes-cote-d-azur-express-3-3",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/1164d75b-4a9f-4c5a-b765-31d861b34fda",
-            "url-override": "https://www.datasud.fr/fr/dataset/datasets/3743/resource/5153/download/",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/lignes-des-reseaux-transport-zou-provence-alpes-cote-d-azur-express-3-3",
@@ -577,7 +559,6 @@
             "name": "lignes-des-reseaux-transport-zou-provence-alpes-cote-d-azur-scolaire-1-3",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/6471d334-17df-4308-bae0-5736c24a2e6a",
-            "url-override": "https://www.datasud.fr/fr/dataset/datasets/3746/resource/5015/download/",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/lignes-des-reseaux-transport-zou-provence-alpes-cote-d-azur-scolaire-1-3",
@@ -591,7 +572,6 @@
             "name": "horaires-theoriques-des-trains-regionaux-zou-en-provence-alpes-cote-d-azur",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/07cedea1-d25e-45fc-882a-0299e211d549",
-            "url-override": "https://www.datasud.fr/fr/dataset/datasets/4561/resource/6371/download/",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-des-trains-regionaux-zou-en-provence-alpes-cote-d-azur",
@@ -605,7 +585,6 @@
             "name": "zou",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/764d6d5b-d04e-4aa7-94b7-f8b2274d2964",
-            "url-override": "https://www.data.gouv.fr/fr/datasets/r/30782be6-90aa-40bb-940a-cb881a95ad26",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/zou",
@@ -618,7 +597,7 @@
         {
             "name": "zou",
             "type": "url",
-            "url": "https://qommutef8e7.blob.core.windows.net/out-gtfs-rt-trip-update/gtfs-rt-trip-updates.pb?sp=r&st=2025-06-23T14%3A10%3A00Z&se=2125-06-24T21%3A59%3A00Z&spr=https&sv=2024-11-04&sr=b&sig=tSjVPNeqolsiRwU%2FxmeF6mlzgxVHfieggx%2FWYnwqSoM%3D",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/74db080b-3d7c-4f30-8811-b344e79f4092",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/zou",
                 "spdx-identifier": "etalab-2.0"
@@ -631,7 +610,6 @@
             "name": "arrets-horaires-et-circuits-des-lignes-de-transports-en-commun-en-pays-de-la-loire-gtfs-destineo-reseaux-aom-aleop-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c0bd9ff1-97f9-43f8-aca4-8e80d7728324",
-            "url-override": "https://mobi-iti-pdl.okina.fr/static/mobiiti_technique/gtfs_global.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-circuits-des-lignes-de-transports-en-commun-en-pays-de-la-loire-gtfs-destineo-reseaux-aom-aleop-1",
@@ -648,7 +626,6 @@
             "name": "arrets-horaires-et-circuits-des-lignes-de-transports-aleop-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/916752e4-5daa-48bd-8bc1-4dd8d64f1d4a",
-            "url-override": "https://donnees.paysdelaloire.fr/data/pdl.zip",
             "fix": true,
             "http-options": {
                 "ignore-tls-errors": true
@@ -689,7 +666,6 @@
             "name": "base-de-donnees-multimodale-transports-publics-en-bretagne-korrigo-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/8c7b32d0-6481-4bb8-b903-c50a04c72fec",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/KORRIGOBRET.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/base-de-donnees-multimodale-transports-publics-en-bretagne-korrigo-gtfs",
@@ -703,7 +679,6 @@
             "name": "breizhgo-car--81461",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d09facf8-2bc9-4d8c-ad43-d5cb05f39406",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_22.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
@@ -717,7 +692,6 @@
             "name": "breizhgo-car--81462",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c407501a-ee0d-425d-b954-42927c0eaffa",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_29.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
@@ -731,7 +705,6 @@
             "name": "breizhgo-car--81463",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/69948a62-0bac-4081-8ae0-d71c4d5b751d",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_35.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
@@ -745,7 +718,6 @@
             "name": "breizhgo-car--81464",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/1b9a895a-1843-4620-bcd4-3bbd08c396c0",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_56.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
@@ -759,7 +731,6 @@
             "name": "breizhgo-car--83728",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/3d50ba51-117b-4b13-80ca-0da5e9526042",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_NS.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
@@ -773,7 +744,6 @@
             "name": "breizhgo-car--83729",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2935244d-b140-470a-8dfb-fb9efe3e0ec9",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_RLP.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
@@ -786,7 +756,7 @@
         {
             "name": "breizhgo-car--81463",
             "type": "url",
-            "url": "https://www.korrigo.bzh/ftp/OPENDATA/gtfsrt/BREIZHGO_CAR_35.GtfsRt.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/54be7908-75c5-43b5-92d1-4b4fe80519b7",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
                 "spdx-identifier": "ODbL-1.0"
@@ -798,7 +768,7 @@
         {
             "name": "breizhgo-car",
             "type": "url",
-            "url": "https://www.korrigo.bzh/ftp/OPENDATA/gtfsrt/TIBUS.GtfsRt.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/fada8938-5689-42a3-b58d-5188690a2d70",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
                 "spdx-identifier": "ODbL-1.0"
@@ -813,7 +783,6 @@
             "name": "breizhgo-ter",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b7a835d4-7a93-4d8b-87bd-c657800fc29f",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_TER.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-ter",
@@ -827,7 +796,6 @@
             "name": "base-de-donnees-multimodale-des-reseaux-de-transport-public-normands",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/81942/download",
-            "url-override": "https://static.data.gouv.fr/resources/base-de-donnees-multimodale-des-reseaux-de-transport-public-normands/20260116-145329/pt-th-offer-atoumod-gtfs-20260115-657-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/base-de-donnees-multimodale-des-reseaux-de-transport-public-normands",
@@ -853,7 +821,6 @@
             "name": "nomad-car-region-normandie",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/82317/download",
-            "url-override": "https://static.data.gouv.fr/resources/nomad-car-region-normandie/20251224-093724/pt-th-offer-nomad-gtfs-20251215-920-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/nomad-car-region-normandie",
@@ -867,7 +834,6 @@
             "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11081",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/05cabcf8-c4bb-4dab-b8f3-ddb826790511",
-            "url-override": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT21",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte",
@@ -881,7 +847,6 @@
             "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11082",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b9bef242-2af5-4945-a38a-c37b7e459e9e",
-            "url-override": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT25",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte",
@@ -895,7 +860,6 @@
             "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11083",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/fda806ca-8624-469d-9609-0279c91e914d",
-            "url-override": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT39",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte",
@@ -909,7 +873,6 @@
             "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11084",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/6c4ac6eb-d6b0-496d-a52a-3e67666997c6",
-            "url-override": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT58",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte",
@@ -923,7 +886,6 @@
             "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11085",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/e42ce1e1-81c5-4ace-9fa8-e6091a89378c",
-            "url-override": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT70",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte",
@@ -937,7 +899,6 @@
             "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11086",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/e2d405ba-8b1c-4398-9623-45c8324da0bf",
-            "url-override": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT71",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte",
@@ -951,7 +912,6 @@
             "name": "reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte--11087",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/639db1dc-8b31-481e-a42f-46b27e3605f3",
-            "url-override": "https://exs.mobigo.cityway.fr/gtfs.aspx?key=OPENDATA&operatorCode=UT89",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-interurbain-mobigo-en-bourgogne-franche-comte",
@@ -965,7 +925,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord--81828",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/293d12e7-7db8-42d8-bbb4-543aad13fc7e",
-            "url-override": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_59_P1.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord",
@@ -979,7 +938,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord--81829",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/58babea3-fc7a-4e2d-be16-69936f10e81c",
-            "url-override": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_59_P2.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord",
@@ -993,7 +951,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord--81830",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/bb4ce18c-af05-4a8c-b7ae-f9c53bdb3fae",
-            "url-override": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_59_P3A.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord",
@@ -1007,7 +964,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord--81832",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/1e2937e3-d495-44bc-aec0-bd5da085e3a4",
-            "url-override": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_59_P4.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-59-nord",
@@ -1021,7 +977,6 @@
             "name": "arrets-itineraires-et-horaires-theoriques-des-reseaux-de-transport-des-membres-de-jvmalin",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/a193c142-366b-4a7b-8afb-c0bdf23ca7ea",
-            "url-override": "https://fr.ftp.opendatasoft.com/centrevaldeloire/OKINAGTFS/GTFS_AGREGE/JVMALIN.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-itineraires-et-horaires-theoriques-des-reseaux-de-transport-des-membres-de-jvmalin",
@@ -1035,7 +990,6 @@
             "name": "remi-offre-theorique-mobilite-reseau-interurbain-regional",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/6c52238c-1c1e-4c5a-922b-8b66c0415a9e",
-            "url-override": "https://fr.ftp.opendatasoft.com/centrevaldeloire/OKINAGTFS/GTFS_AO/REMI.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/remi-offre-theorique-mobilite-reseau-interurbain-regional",
@@ -1048,7 +1002,7 @@
         {
             "name": "voi-velos-paris",
             "type": "url",
-            "url": "https://api.voiapp.io/gbfs/fr/6bb6b5dc-1cda-4da7-9216-d3023a0bc54a/v2/352/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/f6a217b2-1b7b-4cb3-b4f0-88725e648ded",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/voi-velos-paris",
@@ -1060,7 +1014,7 @@
         {
             "name": "tier-dott-gbfs-paris",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/paris/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/7e3a67a0-8226-46e2-9a25-7b4238511ebe",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-paris",
@@ -1072,7 +1026,7 @@
         {
             "name": "gbfs-paris",
             "type": "url",
-            "url": "https://data.lime.bike/api/partners/v2/gbfs/paris/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/2581b170-5686-49a6-a227-6ab4c41334dc",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gbfs-paris",
@@ -1085,7 +1039,6 @@
             "name": "reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone--39589",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/7eef6ec9-9ebb-44f2-becb-2efc522522d6",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp-rtm?apiKey=16421b08630a7d065c6d250051780f484b673659",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
@@ -1099,7 +1052,6 @@
             "name": "reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone--39591",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/e8a86701-6359-45de-bee5-95e648ec04e3",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp-uly?apiKey=0940631b6473164b4a1c136a2828324e6f3f3c08",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
@@ -1113,7 +1065,6 @@
             "name": "reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone--39592",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/3fc0ab9d-e7a3-4728-ac2b-be55d927e757",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp-lib?apiKey=14276f6a093c2c53370b48001f75646f2b2c3969",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
@@ -1127,7 +1078,6 @@
             "name": "reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone--39593",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/42b6ba26-f817-455b-8ba2-fa30c100fff4",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp-col?apiKey=776d384907333d300f1b0077344506394e09501d",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
@@ -1141,7 +1091,6 @@
             "name": "reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone--39594",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d61403a1-7694-4a04-a229-044a43aff5c7",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp-cig?apiKey=0262073f524e2f1e1a2f4f254c6b01790b2b2b39",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
@@ -1155,7 +1104,6 @@
             "name": "reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone--39595",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2bbfc260-c908-4242-9796-c30cb36511ea",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp-mrc?apiKey=70560f77767d05157479657b597a6544026b4b75",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
@@ -1169,7 +1117,6 @@
             "name": "reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone--39596",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/05c200aa-798d-4660-bae7-3bf77e551c4c",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp-ctb?apiKey=686525656f2c3228054e6a7c3e38330037076207",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
@@ -1183,7 +1130,6 @@
             "name": "reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone--39597",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c671fcc9-fe50-4bee-bed0-78e6443c1010",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp-bde?apiKey=2b7a3b3b084c750566663c2e09726b19171f275c",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
@@ -1197,7 +1143,6 @@
             "name": "reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone--39598",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/cde22673-d7e4-4cbd-837f-3c8bd9fb2f9b",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp-aub?apiKey=5d154e7479302217113b0146044950783f2e7f72",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
@@ -1211,7 +1156,6 @@
             "name": "reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone--39599",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2316529b-3075-4013-8b85-46777fefd56e",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp-fri?apiKey=0d5075674700466047752b2c591d300a1452601d",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
@@ -1225,7 +1169,6 @@
             "name": "reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone--39601",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ab931edc-0bc1-4c66-960a-dc546b46df03",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp-pam?apiKey=596e694f3330142c525b7d6b123a5b055f744058",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
@@ -1239,7 +1182,6 @@
             "name": "reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone--39602",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/10e025a1-9048-4c19-925a-466b2a79232f",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp-c13?apiKey=3675433c4f196f4d3c6b62316e130536196f0336",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
@@ -1253,7 +1195,6 @@
             "name": "reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone--39603",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/9b44cd04-63b5-46e7-a1f8-d5c1c9151d5a",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp-aix?apiKey=020c7c326b6c5e750b168064336e344c61213521",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
@@ -1267,7 +1208,6 @@
             "name": "reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone--80736",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/304e9bce-2f14-417f-a02e-3b3827de8d5f",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp-cio?apiKey=2b37114236244f1e115f6542331d243617772448",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
@@ -1281,7 +1221,6 @@
             "name": "reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone--81969",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/0d9a808a-9a9b-4fa1-b04f-339bbf2cfeb1",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/mamp?apiKey=60327e505a214c77303f52206f11483069257343",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseaux-de-transports-en-commun-de-la-metropole-daix-marseille-provence-et-des-bouches-du-rhone",
@@ -1294,7 +1233,7 @@
         {
             "name": "velos-a-assistance-electrique-en-libre-service-levelo-sur-marseille",
             "type": "url",
-            "url": "https://api.omega.fifteen.eu/gbfs/2.2/marseille/en/gbfs.json?&key=MjE0ZDNmMGEtNGFkZS00M2FlLWFmMWItZGNhOTZhMWQyYzM2",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/66916530-2b3f-4443-abf2-135edd6e5fe3",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-levelo-sur-marseille",
@@ -1307,7 +1246,6 @@
             "name": "horaires-theoriques-du-reseau-transports-en-commun-lyonnais",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2f1e1bfc-d378-4e3d-a175-e26f14abc3e6",
-            "url-override": "https://download.data.grandlyon.com/files/rdata/tcl_sytral.tcltheorique/GTFS_TCL.ZIP",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-transports-en-commun-lyonnais",
@@ -1322,7 +1260,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-gir-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ba4be162-cc7f-4c7c-9d96-376a225e9045",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/gironde-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-gir-nva-m-1",
@@ -1336,7 +1273,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-bac-nva-m",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c3f86058-0be8-41f2-aa98-82d3a5625f22",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/bac_gironde-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-bac-nva-m",
@@ -1350,7 +1286,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-interurbain-62-pas-de-calais-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/3e744287-1221-47fd-96e0-fa154e79c4f8",
-            "url-override": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_62.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-interurbain-62-pas-de-calais-1",
@@ -1364,7 +1299,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-62-pas-de-calais",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/deb2e6c8-fc48-4a11-b7d0-180f961fd4dc",
-            "url-override": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_SCO_62.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-62-pas-de-calais",
@@ -1378,7 +1312,6 @@
             "name": "horaires-des-bacs-de-loire-en-loire-atlantique-gtfs--83674",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b04f2bcc-a99c-4d45-a22a-b61f491c30ad",
-            "url-override": "https://data.loire-atlantique.fr/api/v2/catalog/datasets/224400028_horaires-bacs-loire-en-loire-atlantique-gtfs/alternative_exports/bacs_loire_gtfs_2025_maj_nov_zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-des-bacs-de-loire-en-loire-atlantique-gtfs",
@@ -1393,7 +1326,6 @@
             "name": "horaires-des-bacs-de-loire-en-loire-atlantique-gtfs--83727",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/daebfad5-7273-4637-b897-88308b2d96d7",
-            "url-override": "https://data.loire-atlantique.fr/api/v2/catalog/datasets/224400028_horaires-bacs-loire-en-loire-atlantique-gtfs/alternative_exports/bacs_loire_gtfs_2025_maj_dec_zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-des-bacs-de-loire-en-loire-atlantique-gtfs",
@@ -1406,7 +1338,7 @@
         {
             "name": "offre-et-disponibilite-temps-reel-du-service-citiz-en-autopartage-metropole-de-lyon",
             "type": "url",
-            "url": "https://data.grandlyon.com/files/rdata/lpa_mobilite.donnees/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/5ca23de0-8f2d-442b-addb-f423f5da11cc",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-et-disponibilite-temps-reel-du-service-citiz-en-autopartage-metropole-de-lyon",
@@ -1418,7 +1350,7 @@
         {
             "name": "vehicules-en-autopartage-leoandgo-dans-la-metropole-de-lyon-disponibilites-temps-reel",
             "type": "url",
-            "url": "https://download.data.grandlyon.com/files/rdata/lag_leoandgo.disponibilite/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/1269341b-cb9d-465c-85b5-771ee1086846",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/vehicules-en-autopartage-leoandgo-dans-la-metropole-de-lyon-disponibilites-temps-reel",
@@ -1430,7 +1362,7 @@
         {
             "name": "tier-dott-gbfs-lyon",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/lyon/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/77de0492-9fb9-46f0-a87a-c1173f63ff44",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-lyon",
@@ -1442,7 +1374,7 @@
         {
             "name": "stations-velov-de-la-metropole-de-lyon-disponibilites-temps-reel",
             "type": "url",
-            "url": "https://download.data.grandlyon.com/files/rdata/jcd_jcdecaux.jcdvelov/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/4cf2b946-9c2c-44a9-bbc7-4b5cb9e2c2fe",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/stations-velov-de-la-metropole-de-lyon-disponibilites-temps-reel",
@@ -1455,7 +1387,6 @@
             "name": "desserte-des-stations-de-ski-iseroises-transaltitude-38",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/932fb155-53d5-4717-87e0-b42fe3aa538b",
-            "url-override": "https://www.itinisere.fr/fr/donnees-open-data/169/OpenData/Download?fileName=TRANSAL.GTFS.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/desserte-des-stations-de-ski-iseroises-transaltitude-38",
@@ -1469,7 +1400,6 @@
             "name": "reseau-cars-region-isere-38",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/40ee9d6c-3bb9-409e-b670-986212de63f2",
-            "url-override": "https://www.itinisere.fr/fr/donnees-open-data/169/OpenData/Download?fileName=CG38.GTFS.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-cars-region-isere-38",
@@ -1482,7 +1412,7 @@
         {
             "name": "reseau-cars-region-isere-38",
             "type": "url",
-            "url": "https://www.itinisere.fr/ftp/GtfsRT/GtfsRT.CG38.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/2ded65d2-0a8a-4f8b-95e7-71adbce8e939",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-cars-region-isere-38",
                 "spdx-identifier": "ODbL-1.0"
@@ -1494,7 +1424,7 @@
         {
             "name": "reseau-cars-region-isere-38",
             "type": "url",
-            "url": "https://www.itinisere.fr/ftp/gtfsrt/GtfsRT.Disruptions.CG38.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/9cb65b0d-3221-44c7-a843-58760ea9b581",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-cars-region-isere-38",
                 "spdx-identifier": "ODbL-1.0"
@@ -1507,7 +1437,6 @@
             "name": "bacs-de-seine-departement-seine-maritime",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/82308/download",
-            "url-override": "https://static.data.gouv.fr/resources/bacs-de-seine-departement-seine-maritime/20251230-075024/pt-th-offer-seinemaritime76-gtfs-20251230-303-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/bacs-de-seine-departement-seine-maritime",
@@ -1521,7 +1450,6 @@
             "name": "flibco-lille-airport-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f389ca22-d36e-46f3-9e00-5be700c7139b",
-            "url-override": "https://static.data.gouv.fr/resources/flibco-lille-airport-gtfs/20260115-124306/lille-v4.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/flibco-lille-airport-gtfs",
@@ -1536,7 +1464,6 @@
             "name": "ilevia-localisation-des-arrets-bus-metro-et-tram-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c9e5dd3f-8eed-4ad7-aec2-915240599cf6",
-            "url-override": "https://media.ilevia.fr/opendata/gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/ilevia-localisation-des-arrets-bus-metro-et-tram-gtfs",
@@ -1561,7 +1488,7 @@
         {
             "name": "vlille-disponibilite-en-temps-reel-3",
             "type": "url",
-            "url": "https://media.ilevia.fr/opendata/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/36459a88-73c3-47e6-acef-d1a00378c140",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/vlille-disponibilite-en-temps-reel-3",
@@ -1574,7 +1501,6 @@
             "name": "offre-de-transport-du-reseau-fluo-grand-est-bas-rhin-67",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80417/download",
-            "url-override": "https://api.grandest2.cityway.fr/exs/GTFS?Key=OPENDATA&OperatorCode=CG67",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-bas-rhin-67",
@@ -1588,7 +1514,6 @@
             "name": "tisseo-reseau-transport-urbain-toulousain",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/64318177-f5b5-4144-a6be-2d0f22d26c77",
-            "url-override": "https://data.toulouse-metropole.fr/explore/dataset/tisseo-gtfs/files/fc1dda89077cf37e4f7521760e0ef4e9/download/",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tisseo-reseau-transport-urbain-toulousain",
@@ -1601,7 +1526,7 @@
         {
             "name": "tisseo-reseau-transport-urbain-toulousain",
             "type": "url",
-            "url": "https://api.tisseo.fr/opendata/gtfsrt/GtfsRt.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/b2343456-4e73-4e5e-bf0f-e8cab63357a8",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tisseo-reseau-transport-urbain-toulousain",
                 "spdx-identifier": "ODbL-1.0"
@@ -1614,7 +1539,6 @@
             "name": "breizhgo-35-experimentation",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/7a438a9a-517b-492c-89b0-2e4d3b72ac00",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_CAR_35.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-35-experimentation",
@@ -1628,7 +1552,6 @@
             "name": "offre-de-transport-du-reseau-fluo-grand-est-moselle-57",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80427/download",
-            "url-override": "https://api.grandest2.cityway.fr/exs/GTFS?Key=OPENDATA&OperatorCode=TIM",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-moselle-57",
@@ -1641,7 +1564,7 @@
         {
             "name": "citiz-autopartage-provence",
             "type": "url",
-            "url": "https://backend.citiz.fr/public/provider/6/gbfs/v3.0/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/4d37b9c9-1014-4981-9810-6601e558198c",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/citiz-autopartage-provence",
@@ -1654,7 +1577,6 @@
             "name": "finistair-region-bretagne",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/073a6dbc-2bef-4088-afe4-68a29dd4e796",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/FINISTAIR.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/finistair-region-bretagne",
@@ -1667,7 +1589,7 @@
         {
             "name": "citiz-autopartage-occitanie",
             "type": "url",
-            "url": "https://backend.citiz.fr/public/provider/8/gbfs/3.0/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a73a8d89-a43e-4d9b-883d-854b5864a4bf",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/citiz-autopartage-occitanie",
@@ -1679,7 +1601,7 @@
         {
             "name": "voi-gbfs-et-netex-marseille",
             "type": "url",
-            "url": "https://api.voiapp.io/gbfs/fr/6bb6b5dc-1cda-4da7-9216-d3023a0bc54a/v2/66/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/0b8496f5-bf13-4c08-b07c-6d85bcc62b1f",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/voi-gbfs-et-netex-marseille",
@@ -1692,7 +1614,6 @@
             "name": "horaires-theoriques-au-format-gtfs-et-horaires-temps-reel-au-format-gtfs-rt-du-reseau-car-jaune-a-la-reunion",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80934/download",
-            "url-override": "https://pysae.com/api/v2/groups/car-jaune/gtfs/pub",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-au-format-gtfs-et-horaires-temps-reel-au-format-gtfs-rt-du-reseau-car-jaune-a-la-reunion",
@@ -1705,7 +1626,7 @@
         {
             "name": "horaires-theoriques-au-format-gtfs-et-horaires-temps-reel-au-format-gtfs-rt-du-reseau-car-jaune-a-la-reunion",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/car-jaune/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/c0a17be1-e89a-48a3-aca1-d8eb8e89a55e",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-au-format-gtfs-et-horaires-temps-reel-au-format-gtfs-rt-du-reseau-car-jaune-a-la-reunion",
                 "spdx-identifier": "etalab-2.0"
@@ -1718,7 +1639,6 @@
             "name": "offres-de-services-bus-tram-et-scolaire-au-format-gtfs-netex-gtfs-rt-siri-lite",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/10b87ffe-e6bb-494d-93df-bb6019e223d9",
-            "url-override": "https://bdx.mecatran.com/utw/ws/gtfsfeed/static/bordeaux?apiKey=opendata-bordeaux-metropole-flux-gtfs-rt",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offres-de-services-bus-tram-et-scolaire-au-format-gtfs-netex-gtfs-rt-siri-lite",
@@ -1731,7 +1651,7 @@
         {
             "name": "offres-de-services-bus-tram-et-scolaire-au-format-gtfs-netex-gtfs-rt-siri-lite",
             "type": "url",
-            "url": "https://bdx.mecatran.com/utw/ws/gtfsfeed/realtime/bordeaux?apiKey=opendata-bordeaux-metropole-flux-gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/bd01907f-4756-43f4-8eb3-6a9650d6e4b5",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offres-de-services-bus-tram-et-scolaire-au-format-gtfs-netex-gtfs-rt-siri-lite",
                 "spdx-identifier": "etalab-2.0"
@@ -1743,7 +1663,7 @@
         {
             "name": "offres-de-services-bus-tram-et-scolaire-au-format-gtfs-netex-gtfs-rt-siri-lite",
             "type": "url",
-            "url": "https://bdx.mecatran.com/utw/ws/gtfsfeed/alerts/bordeaux?apiKey=opendata-bordeaux-metropole-flux-gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a635ff4f-7515-4e4c-a755-7523bbdbe7c9",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offres-de-services-bus-tram-et-scolaire-au-format-gtfs-netex-gtfs-rt-siri-lite",
                 "spdx-identifier": "etalab-2.0"
@@ -1755,7 +1675,7 @@
         {
             "name": "tier-dott-gbfs-bordeaux",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/bordeaux/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/84b1ed77-efe4-4819-b6a4-6443435ac939",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-bordeaux",
@@ -1767,7 +1687,7 @@
         {
             "name": "station-le-velo-en-temps-reel-1",
             "type": "url",
-            "url": "https://bdx.mecatran.com/utw/ws/gbfs/bordeaux/v3/gbfs.json?apiKey=opendata-bordeaux-metropole-flux-gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/51af208b-121d-48ae-b8ee-d45864e450ae",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/station-le-velo-en-temps-reel-1",
@@ -1780,7 +1700,6 @@
             "name": "reseau-interurbain-cars-region-haute-savoie-74",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/71926816-92f8-4620-8b8f-e1804f645e26",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=HAUTE_SAVOIE&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-haute-savoie-74",
@@ -1793,7 +1712,7 @@
         {
             "name": "velotoulouse-velo-en-libre-service-au-standard-gbfs",
             "type": "url",
-            "url": "https://api.cyclocity.fr/contracts/toulouse/gbfs/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/ca5c6590-57a5-418a-83e6-e8343bfe2be7",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velotoulouse-velo-en-libre-service-au-standard-gbfs",
@@ -1806,7 +1725,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise-1--81820",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ae3f2c20-ddf9-4469-a953-ebb56e273d3f",
-            "url-override": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_60_P1.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise-1",
@@ -1820,7 +1738,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise-1--81821",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/67129a71-49d0-467d-b388-4672ab1d5593",
-            "url-override": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_60_P2.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise-1",
@@ -1834,7 +1751,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise-1--81822",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c50a9ec8-98dc-40ee-a842-555738197957",
-            "url-override": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_60_P3.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise-1",
@@ -1848,7 +1764,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise-1--81823",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/5338146c-d7d5-44fe-aa17-df21e170b7d5",
-            "url-override": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_SCO_60_P4.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-du-reseau-routier-regional-de-transport-scolaire-et-interurbain-60-oise-1",
@@ -1861,7 +1776,7 @@
         {
             "name": "citiz-autopartage-hauts-de-france",
             "type": "url",
-            "url": "https://backend.citiz.fr/public/provider/16/gbfs/v3.0/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/ea739e26-e3b8-4e93-84d3-31b12c12a10d",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/citiz-autopartage-hauts-de-france",
@@ -1874,7 +1789,6 @@
             "name": "reseau-interurbain-cars-region-loire-42",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d22ab458-e6b4-4334-96dc-18590a3d9e5d",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=CARS_REGION_LOIRE&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-loire-42",
@@ -1888,7 +1802,6 @@
             "name": "offre-de-transport-du-reseau-fluo-grand-est-haut-rhin-68",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80419/download",
-            "url-override": "https://api.grandest2.cityway.fr/exs/GTFS?Key=OPENDATA&OperatorCode=CG68",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-haut-rhin-68",
@@ -1926,7 +1839,6 @@
             "name": "offre-de-transport-du-reseau-fluo-grand-est-meurthe-et-moselle-54",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80423/download",
-            "url-override": "https://api.grandest2.cityway.fr/exs/GTFS?Key=OPENDATA&OperatorCode=TED",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-meurthe-et-moselle-54",
@@ -1940,7 +1852,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-pat-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/44806d1e-0798-40e6-8e7e-21d0ddfe81d2",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/pyrenees_atlantiques-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-pat-nva-m-1",
@@ -1953,7 +1864,7 @@
         {
             "name": "citiz-autopartage-nantes",
             "type": "url",
-            "url": "https://backend.citiz.fr/public/provider/15/gbfs/v3.0/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/644cc960-79a3-41ae-bdfe-4efbcb81f04e",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/citiz-autopartage-nantes",
@@ -1966,7 +1877,6 @@
             "name": "reseau-de-transports-collectifs-naolib",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/a18d5977-ca80-4712-a9cf-1a555feb2621",
-            "url-override": "https://data.nantesmetropole.fr/explore/dataset/244400404_tan-arrets-horaires-circuits/files/16a1a0af5946619af621baa4ad9ee662/download/",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transports-collectifs-naolib",
@@ -1979,7 +1889,7 @@
         {
             "name": "offre-et-temps-reel-du-service-velos-en-libre-service-naolib-de-nantes-metropole-au-format-gbfs",
             "type": "url",
-            "url": "https://api.cyclocity.fr/contracts/nantes/gbfs/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/87b23567-8fa1-4a58-9000-5f13b6014641",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-et-temps-reel-du-service-velos-en-libre-service-naolib-de-nantes-metropole-au-format-gbfs",
@@ -1992,7 +1902,6 @@
             "name": "reseau-interurbain-cars-region-ain-01",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/723f0cc2-476a-464c-a40e-bf8686f7bd8d",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=CARS_REGION_AIN&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-ain-01",
@@ -2006,7 +1915,6 @@
             "name": "reseau-interurbain-cars-region-puy-de-dome-63",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/fff9c08f-6172-4c94-b46e-c0144ae0bd10",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=PUY_DE_DOME&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-puy-de-dome-63",
@@ -2020,7 +1928,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cma-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/161ac8dd-bdd4-40dd-bce7-d9edef4af632",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/charente_maritime-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cma-nva-m-1",
@@ -2034,7 +1941,6 @@
             "name": "horaires-theoriques-des-lignes-m-covoit-ligne-plus",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/91dbf9cb-4ab2-42a3-9f40-0791a53d58d2",
-            "url-override": "https://data.mobilites-m.fr/api/gtfs/MCO",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-des-lignes-m-covoit-ligne-plus",
@@ -2048,7 +1954,6 @@
             "name": "transports-a-la-demande-en-pays-de-la-loire-gtfs-flex-aleop",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/7bc6edfa-d68c-4cc7-a1a5-a8b05fcae444",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/pdlFlex?apiKey=19496e1c0c0e42607d54444b2a191b61533b3634",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transports-a-la-demande-en-pays-de-la-loire-gtfs-flex-aleop",
@@ -2062,7 +1967,7 @@
         {
             "name": "vehicules-en-autopartage-1",
             "type": "url",
-            "url": "https://backend.citiz.fr/public/provider/4/gbfs/v3.0/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/4a69aee4-05ea-45e9-81b7-f9dbdfc7a344",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/vehicules-en-autopartage-1",
@@ -2075,7 +1980,6 @@
             "name": "donnees-statiques-et-dynamiques-du-reseau-de-transport-lignes-dazur",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f5678ab2-c863-4b48-ba1f-9021c7d97634",
-            "url-override": "https://chouette.enroute.mobi/api/v1/datas/OpendataRLA/gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-dynamiques-du-reseau-de-transport-lignes-dazur",
@@ -2088,7 +1992,7 @@
         {
             "name": "donnees-statiques-et-dynamiques-du-reseau-de-transport-lignes-dazur",
             "type": "url",
-            "url": "https://ara-api.enroute.mobi/rla/gtfs/trip-updates",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/af3f0734-ef07-468e-b8c9-aed97e4c8a32",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-dynamiques-du-reseau-de-transport-lignes-dazur",
                 "spdx-identifier": "etalab-2.0"
@@ -2101,7 +2005,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-interurbain-80-somme",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/429d30fb-ba6e-4e90-ad82-6d589a98cbfd",
-            "url-override": "https://sig.hautsdefrance.fr/ext/opendata/Transport/GTFS/80/RHDF_GTFS_COM_80.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-interurbain-80-somme",
@@ -2115,7 +2018,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-80-somme",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/34cc46fd-56f8-450c-802c-f5ad3a4914af",
-            "url-override": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_SCO_80.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-80-somme",
@@ -2129,7 +2031,6 @@
             "name": "offre-de-transport-du-reseau-fluo-grand-est-marne-51",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80421/download",
-            "url-override": "https://api.grandest2.cityway.fr/exs/GTFS?Key=OPENDATA&OperatorCode=C51",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-marne-51",
@@ -2143,7 +2044,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-interurbain-02-aisne",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/4258bcab-8da4-42fe-a811-0135d7476e85",
-            "url-override": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_COM_02.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-interurbain-02-aisne",
@@ -2157,7 +2057,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-02-aisne",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/46fa1d25-72a8-40e2-849d-c08c096a44c7",
-            "url-override": "https://geocatalogue.hautsdefrance.fr/gtfs/RHDF_GTFS_SCO_02.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-scolaire-02-aisne",
@@ -2171,7 +2070,6 @@
             "name": "reseau-interurbain-et-scolaire-cars-region-drome-26",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/fda59af2-0eb3-4a8a-8e59-593f768f836a",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=DROME&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-et-scolaire-cars-region-drome-26",
@@ -2185,7 +2083,6 @@
             "name": "donnees-theoriques-gtfs-et-temps-reel-siri-lite-du-reseau-cts",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/eeea9e52-4f8a-459e-aef5-a093a3b05356",
-            "url-override": "https://opendata.cts-strasbourg.eu/google_transit.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-gtfs-et-temps-reel-siri-lite-du-reseau-cts",
@@ -2198,7 +2095,7 @@
         {
             "name": "stations-en-libre-service-velhop-flux-gbfs",
             "type": "url",
-            "url": "https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ae/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/2ef45ff5-f5ed-4588-9c1e-9e96b724fcef",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/stations-en-libre-service-velhop-flux-gbfs",
@@ -2211,7 +2108,6 @@
             "name": "offre-de-transport-de-montpellier-mediterranee-metropole-tam-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2ef043c8-3b10-4d87-af5f-65fead127407",
-            "url-override": "https://data.montpellier3m.fr/sites/default/files/ressources/TAM_MMM_GTFS.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-de-montpellier-mediterranee-metropole-tam-gtfs",
@@ -2225,7 +2121,6 @@
             "name": "offre-de-transport-tam-en-temps-reel-gtfs-rt-urbain-et-suburbain--81754",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/350c3f75-226e-4570-960a-dec2144926b6",
-            "url-override": "https://data.montpellier3m.fr/GTFS/Urbain/GTFS.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-tam-en-temps-reel-gtfs-rt-urbain-et-suburbain",
@@ -2239,7 +2134,6 @@
             "name": "offre-de-transport-tam-en-temps-reel-gtfs-rt-urbain-et-suburbain--83773",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c9d1350c-8f13-4761-b603-ecb12ad10b5b",
-            "url-override": "https://data.montpellier3m.fr/GTFS/Suburbain/GTFS.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-tam-en-temps-reel-gtfs-rt-urbain-et-suburbain",
@@ -2252,7 +2146,7 @@
         {
             "name": "disponibilite-en-temps-reel-des-velos-en-libre-service-velomagg-de-montpellier",
             "type": "url",
-            "url": "https://gbfs.theta.fifteen.eu/gbfs/2.2/montpellier/en/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/732c582d-8815-4892-98fd-4446b7ba13d5",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/disponibilite-en-temps-reel-des-velos-en-libre-service-velomagg-de-montpellier",
@@ -2265,7 +2159,6 @@
             "name": "donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c0ebcf01-954a-4d24-b2d8-a00333ffe937",
-            "url-override": "https://api.mrn.cityway.fr/dataflow/offre-tc/download?provider=ASTUCE&dataFormat=gtfs&dataProfil=ASTUCE",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
@@ -2278,7 +2171,7 @@
         {
             "name": "donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
             "type": "url",
-            "url": "https://api.mrn.cityway.fr/dataflow/horaire-tc-tr/download?provider=TCAR&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/b6f39c29-87a8-42c5-be52-cd439050b5d1",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
                 "spdx-identifier": "etalab-2.0"
@@ -2290,7 +2183,7 @@
         {
             "name": "donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
             "type": "url",
-            "url": "https://gtfs.bus-tracker.fr/gtfs-rt/tcar/trip-updates",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/178700bf-570a-4a5e-95a2-59ac5857c622",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
                 "spdx-identifier": "etalab-2.0"
@@ -2302,7 +2195,7 @@
         {
             "name": "donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
             "type": "url",
-            "url": "https://api.mrn.cityway.fr/dataflow/horaire-tc-tr/download?provider=TNI&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/544afe29-c195-40b1-a52d-c5d654b98f75",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
                 "spdx-identifier": "etalab-2.0"
@@ -2314,7 +2207,7 @@
         {
             "name": "donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
             "type": "url",
-            "url": "https://api.mrn.cityway.fr/dataflow/horaire-tc-tr/download?provider=TAE&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/04647b22-2acc-46b2-b06b-67025acb823c",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
                 "spdx-identifier": "etalab-2.0"
@@ -2326,7 +2219,7 @@
         {
             "name": "donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
             "type": "url",
-            "url": "https://api.mrn.cityway.fr/dataflow/info-transport/download?provider=ASTUCE&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/773f526c-2e8a-4202-9f21-9fe98b04eda5",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
                 "spdx-identifier": "etalab-2.0"
@@ -2338,7 +2231,7 @@
         {
             "name": "donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
             "type": "url",
-            "url": "https://gtfs.flocaseih.me/service_alerts.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/93b93483-e475-498c-908d-ddbc10287d26",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
                 "spdx-identifier": "etalab-2.0"
@@ -2350,7 +2243,7 @@
         {
             "name": "donnees-statiques-et-temps-reel-du-service-de-vls-lovelo-metropole-rouen-normandie",
             "type": "url",
-            "url": "https://gbfs.urbansharing.com/lovelolibreservice.fr/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/4905ea74-6480-42d9-9978-5d81c0a62383",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reel-du-service-de-vls-lovelo-metropole-rouen-normandie",
@@ -2362,7 +2255,7 @@
         {
             "name": "citiz-autopartage-rennes-metropole",
             "type": "url",
-            "url": "https://backend.citiz.fr/public/provider/19/gbfs/v3.0/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/9d526d49-1db5-48f8-baa0-a5b83991a222",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/citiz-autopartage-rennes-metropole",
@@ -2375,7 +2268,6 @@
             "name": "versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs--83281",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/0644f537-575e-4cce-9570-06165d6f3b27",
-            "url-override": "https://eu.ftp.opendatasoft.com/star/gtfs/GTFS_STAR_BUS_METRO_EN_COURS.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs",
@@ -2389,7 +2281,6 @@
             "name": "versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs--83282",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ef4779c4-d066-40d8-b8d9-fb8c7eea8820",
-            "url-override": "https://eu.ftp.opendatasoft.com/star/gtfs/GTFS_STAR_BUS_METRO_A_VENIR.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/versions-des-horaires-theoriques-des-lignes-de-bus-et-de-metro-du-reseau-star-au-format-gtfs",
@@ -2431,7 +2322,6 @@
             "name": "reseau-de-transport-urbain-de-la-metropole-toulon-provence-mediterranee",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b0789d9e-5077-4124-b6b2-773353ada8cf",
-            "url-override": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/rd-toulon/exports/gtfs-complet.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-urbain-de-la-metropole-toulon-provence-mediterranee",
@@ -2444,7 +2334,7 @@
         {
             "name": "reseau-de-transport-urbain-de-la-metropole-toulon-provence-mediterranee",
             "type": "url",
-            "url": "https://notify.ratpdev.com/api/networks/RD%20TPM/alerts/gtfsrt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/f30614b3-a35b-4c9f-98c9-7450585d3941",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-urbain-de-la-metropole-toulon-provence-mediterranee",
                 "spdx-identifier": "etalab-2.0"
@@ -2456,7 +2346,7 @@
         {
             "name": "reseau-de-transport-urbain-de-la-metropole-toulon-provence-mediterranee",
             "type": "url",
-            "url": "https://feed-rdtpm-toulon.ratpdev.com/TripUpdate/GTFS-RT",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/10f2e5d4-6a1b-45e2-897a-5b9044ebb6b3",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-urbain-de-la-metropole-toulon-provence-mediterranee",
                 "spdx-identifier": "etalab-2.0"
@@ -2469,7 +2359,6 @@
             "name": "horaires-theoriques-du-reseau-tag",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b6ec7ba4-09bc-46df-b9a1-79a2c2668cf2",
-            "url-override": "https://data.mobilites-m.fr/api/gtfs/SEM",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-tag",
@@ -2483,7 +2372,6 @@
             "name": "reseau-interurbain-cars-region-savoie-73",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/4b74f1b9-fcc0-4e59-bf48-7ed4102e5222",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=SAVOIE&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-savoie-73",
@@ -2497,7 +2385,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-vie-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/a70fab11-9ac9-481e-91c8-925e805741ba",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/vienne-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-vie-nva-m-1",
@@ -2510,7 +2397,7 @@
         {
             "name": "tier-dott-gbfs-gpseo",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/gpseo/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/43546974-406b-4bf7-bb2b-dbe8661d7e1c",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-gpseo",
@@ -2523,7 +2410,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lan-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/476fec18-c51f-41e6-9d15-0030174389c3",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/landes-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lan-nva-m-1",
@@ -2537,7 +2423,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-dor-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f7590323-d782-40ed-a6b2-67e37930f6cd",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/dordogne-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-dor-nva-m-1",
@@ -2551,7 +2436,6 @@
             "name": "horaires-des-traversees-brittany-ferries",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/83427/download",
-            "url-override": "https://static.data.gouv.fr/resources/horaires-des-traversees-brittany-ferries/20260114-223119/gtfs-brittanyferries.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-des-traversees-brittany-ferries",
@@ -2565,7 +2449,6 @@
             "name": "horaires-du-reseau-stas",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/fc66b270-658c-4678-9794-229a1a8a4938",
-            "url-override": "https://api.saint-etienne-metropole.fr/stas/api/horraires_tc/GTFS.aspx",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-du-reseau-stas",
@@ -2578,7 +2461,7 @@
         {
             "name": "horaires-du-reseau-stas",
             "type": "url",
-            "url": "https://api.saint-etienne-metropole.fr/stas/api/horraires_tc/GTFS-RT.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a414cd50-a9ea-4891-99ce-88e0fedd4411",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-du-reseau-stas",
                 "spdx-identifier": "etalab-2.0"
@@ -2590,7 +2473,7 @@
         {
             "name": "flux-temps-reel-velivert",
             "type": "url",
-            "url": "https://api.saint-etienne-metropole.fr/velivert/api/gbfs/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/68b1883a-5e22-4824-8211-dd7f4f027514",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/flux-temps-reel-velivert",
@@ -2602,7 +2485,7 @@
         {
             "name": "paris-sud-velos-a-assistance-electrique-en-libre-service--63612",
             "type": "url",
-            "url": "https://gateway.prod.zoov.io/gbfs/2.2/saclay/en/station_information.json?key=NGFlMjU3MDUtNDk5My00MTM4LTk1ZjctNmNlNDM1MWQ0NjE1",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/0dbd100e-d824-4c21-a2f3-2af8b7612b6d",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/paris-sud-velos-a-assistance-electrique-en-libre-service",
@@ -2614,7 +2497,7 @@
         {
             "name": "paris-sud-velos-a-assistance-electrique-en-libre-service--63613",
             "type": "url",
-            "url": "https://gateway.prod.zoov.io/gbfs/2.2/saclay/en/station_status.json?key=NGFlMjU3MDUtNDk5My00MTM4LTk1ZjctNmNlNDM1MWQ0NjE1",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/b12c7ba9-51ac-496d-a205-fc98cbd5dea9",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/paris-sud-velos-a-assistance-electrique-en-libre-service",
@@ -2626,7 +2509,7 @@
         {
             "name": "paris-sud-velos-a-assistance-electrique-en-libre-service--63614",
             "type": "url",
-            "url": "https://gateway.prod.zoov.io/gbfs/2.2/saclay/en/free_bike_status.json?key=NGFlMjU3MDUtNDk5My00MTM4LTk1ZjctNmNlNDM1MWQ0NjE1",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/8f49a928-e1e2-43aa-828f-c4088bf53a90",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/paris-sud-velos-a-assistance-electrique-en-libre-service",
@@ -2638,7 +2521,7 @@
         {
             "name": "paris-sud-velos-a-assistance-electrique-en-libre-service--63615",
             "type": "url",
-            "url": "https://gateway.prod.zoov.io/gbfs/2.2/saclay/en/gbfs.json?key=NGFlMjU3MDUtNDk5My00MTM4LTk1ZjctNmNlNDM1MWQ0NjE1",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/4646ba01-4fe0-4cd8-91d3-09e204bbaf86",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/paris-sud-velos-a-assistance-electrique-en-libre-service",
@@ -2651,7 +2534,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-dse-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/73b1b1ee-2b81-445f-8930-b95a2b28a81b",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/deux_sevres-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-dse-nva-m-1",
@@ -2665,7 +2547,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-hvi-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/8d1cc7f8-2b29-4844-b98c-4a5b35075d57",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/haute_vienne-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-hvi-nva-m-1",
@@ -2679,7 +2560,6 @@
             "name": "gtfs-du-reseau-maritime-de-martinique",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/39fc07d6-65b5-49f0-a5f2-d56757a8dd42",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-du-reseau-maritime-de-martinique/20251218-214039/gtfs-maritime-bluelines.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-maritime-de-martinique",
@@ -2693,7 +2573,6 @@
             "name": "gtfs-du-transport-scolaire-en-martinique",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c14a1893-58a1-4e7b-830e-bd1f9daa863d",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-du-transport-scolaire-en-martinique/20250905-181503/gtfs-scolaire-mt.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-du-transport-scolaire-en-martinique",
@@ -2707,7 +2586,6 @@
             "name": "offre-de-transport-du-reseau-fluo-grand-est-vosges-88",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80429/download",
-            "url-override": "https://api.grandest2.cityway.fr/exs/GTFS?Key=OPENDATA&OperatorCode=LIVO",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-vosges-88",
@@ -2721,7 +2599,6 @@
             "name": "fr-200052264-t0039-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80431/download",
-            "url-override": "https://exs.grandest2.cityway.fr/GTFS.aspx?Key=OPENDATA&OperatorCode=LESUB",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0039-0000-1",
@@ -2735,7 +2612,6 @@
             "name": "offre-transport-du-reseau-txik-txak",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/a6c39f5b-9e05-4dc6-be13-f2620ff73216",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/txiktxak?apiKey=0f64273f070b7d4621002040646e180d374e5373",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-transport-du-reseau-txik-txak",
@@ -2748,7 +2624,7 @@
         {
             "name": "offre-transport-du-reseau-txik-txak",
             "type": "url",
-            "url": "https://app.mecatran.com/utw/ws/gtfsfeed/alerts/txiktxak?apiKey=0f64273f070b7d4621002040646e180d374e5373",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/29c3470e-5846-42d2-a9d6-e1168287143e",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-transport-du-reseau-txik-txak",
                 "spdx-identifier": "ODbL-1.0"
@@ -2760,7 +2636,7 @@
         {
             "name": "offre-transport-du-reseau-txik-txak",
             "type": "url",
-            "url": "https://app.mecatran.com/utw/ws/gtfsfeed/realtime/txiktxak?apiKey=0f64273f070b7d4621002040646e180d374e5373",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a228fac6-b0ab-44f5-b2e8-a6e47b9c1b98",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-transport-du-reseau-txik-txak",
                 "spdx-identifier": "ODbL-1.0"
@@ -2773,7 +2649,6 @@
             "name": "horaires-du-reseau-transvilles-au-format-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/15438966-8d3c-4dd9-8905-189379ea4c7d",
-            "url-override": "https://static.data.gouv.fr/resources/horaires-du-reseau-transvilles-au-format-gtfs/20251229-152016/google-transit.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-du-reseau-transvilles-au-format-gtfs",
@@ -2787,7 +2662,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cha-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/7eb95c82-711e-455c-86b1-ecf138697ebe",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/charente-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cha-nva-m-1",
@@ -2801,7 +2675,6 @@
             "name": "gtfs-transport-horaires-chemins-de-fer-corse-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/eff447a1-b61c-4573-8aae-c778bd8e07d0",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-transport-horaires-chemins-de-fer-corse-1/20251106-084201/cfc.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-chemins-de-fer-corse-1",
@@ -2816,7 +2689,6 @@
             "name": "programme-des-rotations-corsica-ferries",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b95d6838-1143-4653-840f-eebc33c16fa7",
-            "url-override": "https://static.data.gouv.fr/resources/programme-des-rotations-corsica-ferries/20251226-152616/gtfs-updated.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/programme-des-rotations-corsica-ferries",
@@ -2830,7 +2702,6 @@
             "name": "programme-des-rotations-corsica-linea",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/13977931-86ae-4b7a-9598-d222333a5fbd",
-            "url-override": "https://static.data.gouv.fr/resources/programme-des-rotations-corsica-linea/20251015-070956/zip.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/programme-des-rotations-corsica-linea",
@@ -2845,7 +2716,6 @@
             "name": "horaires-theoriques-et-temps-reel-du-reseau-bordeaux-navettes-aeroport-30-direct-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/4cb2f0a9-d3d8-402b-b0bb-afafb741e5f1",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=bordeaux-navettes-aeroport",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-bordeaux-navettes-aeroport-30-direct-gtfs-gtfs-rt",
@@ -2858,7 +2728,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-du-reseau-bordeaux-navettes-aeroport-30-direct-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=bordeaux-navettes-aeroport",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/372463bd-d7b4-4668-a9b5-bd71a28f389d",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-bordeaux-navettes-aeroport-30-direct-gtfs-gtfs-rt",
                 "spdx-identifier": "ODbL-1.0"
@@ -2870,7 +2740,7 @@
         {
             "name": "tier-dott-gbfs-casgbs",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/casgbs/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/2b493e3c-4085-45d7-8b6e-137ad68076be",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-casgbs",
@@ -2883,7 +2753,6 @@
             "name": "reseau-interurbain-cars-region-allier-03",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/edf15063-dbbb-4543-a39d-60a39a418ee3",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=ALLIER&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-allier-03",
@@ -2897,7 +2766,6 @@
             "name": "reseau-interurbain-cars-region-ardeche-07",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/4e69fff6-6ae5-4ac0-9fa4-9c24ac92f291",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=ARDECHE&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-ardeche-07",
@@ -2911,7 +2779,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lga-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/bbf7ffef-9706-42e8-a3c8-7113168621d7",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/lot_et_garonne-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lga-nva-m-1",
@@ -2924,7 +2791,7 @@
         {
             "name": "citiz-autopartage-pays-basque-aupa",
             "type": "url",
-            "url": "https://backend.citiz.fr/public/provider/20/gbfs/3.0/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/3c8fc225-a3e0-42fb-86e6-e696c629415f",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/citiz-autopartage-pays-basque-aupa",
@@ -2937,7 +2804,6 @@
             "name": "horaires-theoriques-et-temps-reel-des-navettes-paris-saclay-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/206530ec-6a48-44a4-8042-75d76be59636",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=caee",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-paris-saclay-gtfs-gtfs-rt",
@@ -2950,7 +2816,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-des-navettes-paris-saclay-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=caee",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/c0cf09df-9248-4828-8435-336dacbbbbc6",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-paris-saclay-gtfs-gtfs-rt",
                 "spdx-identifier": "ODbL-1.0"
@@ -2963,7 +2829,6 @@
             "name": "horaires-theoriques-et-temps-reel-du-reseau-gpso-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/bb187aa1-d027-4a9e-bfa8-67fec4be3c71",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=gpso-rt",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-gpso-gtfs-gtfs-rt",
@@ -2976,7 +2841,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-du-reseau-gpso-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=gpso-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/57138f8c-3034-4489-93e8-ea61212cc218",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-gpso-gtfs-gtfs-rt",
                 "spdx-identifier": "ODbL-1.0"
@@ -2988,7 +2853,7 @@
         {
             "name": "citiz-autopartage-bourgogne-franche-comte",
             "type": "url",
-            "url": "https://backend.citiz.fr/public/provider/2/gbfs/3.0/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/9713ac07-d86f-4e04-9368-9c78af612c67",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/citiz-autopartage-bourgogne-franche-comte",
@@ -3001,7 +2866,6 @@
             "name": "offre-de-transport-du-reseau-fluo-grand-est-aube-10",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80415/download",
-            "url-override": "https://api.grandest2.cityway.fr/exs/GTFS?Key=OPENDATA&OperatorCode=AUBE",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-aube-10",
@@ -3014,7 +2878,7 @@
         {
             "name": "vehicules-en-libre-service-autopartage-citiz",
             "type": "url",
-            "url": "https://backend.citiz.fr/public/provider/7/gbfs/v3.0/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/03bae304-927d-4e0e-80fd-2238bd582d4c",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/vehicules-en-libre-service-autopartage-citiz",
@@ -3027,7 +2891,6 @@
             "name": "angers-loire-metropole-reseau-irigo-gtfs-gtfs-rt-siri",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/32f30b64-33f7-43bb-9b6f-34c21c2f83a3",
-            "url-override": "https://chouette.enroute.mobi/api/v1/datas/Irigo/gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/angers-loire-metropole-reseau-irigo-gtfs-gtfs-rt-siri",
@@ -3040,7 +2903,7 @@
         {
             "name": "angers-loire-metropole-reseau-irigo-gtfs-gtfs-rt-siri",
             "type": "url",
-            "url": "https://notify.ratpdev.com/api/networks/RD%20ANGERS/alerts/gtfsrt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/3349a69a-bc9a-4de4-a2c2-9f9d32e4923c",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/angers-loire-metropole-reseau-irigo-gtfs-gtfs-rt-siri",
                 "spdx-identifier": "ODbL-1.0"
@@ -3052,7 +2915,7 @@
         {
             "name": "angers-loire-metropole-reseau-irigo-gtfs-gtfs-rt-siri",
             "type": "url",
-            "url": "https://ara-api.enroute.mobi/irigo/gtfs/trip-updates",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/0a6d20c5-19b4-4e72-80bf-3875c2555a45",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/angers-loire-metropole-reseau-irigo-gtfs-gtfs-rt-siri",
                 "spdx-identifier": "ODbL-1.0"
@@ -3065,7 +2928,6 @@
             "name": "offre-de-transport-du-reseau-temob-syndicat-mixte-des-transports-urbains-thionville-fensch",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80459/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0040-0000/fluo-grand-est-citeline-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-temob-syndicat-mixte-des-transports-urbains-thionville-fensch",
@@ -3091,7 +2953,6 @@
             "name": "fil-bleu-syndicat-des-mobilites-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f48ed7c9-5ce0-4874-93dd-c95272530510",
-            "url-override": "https://data.tours-metropole.fr/api/v2/catalog/datasets/horaires-temps-reel-gtfsrt-reseau-filbleu-tmvl/alternative_exports/filbleu_gtfszip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fil-bleu-syndicat-des-mobilites-gtfs-gtfs-rt",
@@ -3104,7 +2965,7 @@
         {
             "name": "fil-bleu-syndicat-des-mobilites-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://data.filbleu.fr/ws-tr/gtfs-rt/opendata/trip-updates",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/c3351c35-b2ab-441b-9829-0c0bb8b77f30",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fil-bleu-syndicat-des-mobilites-gtfs-gtfs-rt",
                 "spdx-identifier": "etalab-2.0"
@@ -3116,7 +2977,7 @@
         {
             "name": "fil-bleu-syndicat-des-mobilites-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://data.filbleu.fr/ws-tr/gtfs-rt/opendata/service-alerts",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/32646037-a138-4c45-86a0-4e44fbbcfd1c",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fil-bleu-syndicat-des-mobilites-gtfs-gtfs-rt",
                 "spdx-identifier": "etalab-2.0"
@@ -3129,7 +2990,6 @@
             "name": "offre-de-transport-du-reseau-grand-reims-mobilites-communaute-urbaine-du-grand-reims",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80594/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0031-0000/fluo-grand-est-rei-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-grand-reims-mobilites-communaute-urbaine-du-grand-reims",
@@ -3154,7 +3014,7 @@
         {
             "name": "zebullo-stations-de-velos-en-libre-service-a-reims-2",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/zebullo/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/f8b375ae-355e-4715-a593-47d6052f194d",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/zebullo-stations-de-velos-en-libre-service-a-reims-2",
@@ -3167,7 +3027,6 @@
             "name": "syndicat-mixte-des-transports-en-commun-de-lagglomeration-clermontoise-smtc-ac-reseau-t2c-gtfs-gtfs-rt--83465",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/4e237a58-cd14-4746-b729-1337a40a8a7b",
-            "url-override": "https://opendata.clermontmetropole.eu/api/v2/catalog/datasets/gtfs-smtc/alternative_exports/gtfs",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/syndicat-mixte-des-transports-en-commun-de-lagglomeration-clermontoise-smtc-ac-reseau-t2c-gtfs-gtfs-rt",
@@ -3180,7 +3039,7 @@
         {
             "name": "etat-des-stations-de-velos-en-libre-service-c-velo-gbfs-du-syndicat-mixte-des-transports-en-commun-de-lagglomeration-clermontoise-smtc-ac-1",
             "type": "url",
-            "url": "https://clermontferrand.publicbikesystem.net/customer/gbfs/v2/",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/6f67638b-a628-4365-adac-6fe9be8dddc2",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/etat-des-stations-de-velos-en-libre-service-c-velo-gbfs-du-syndicat-mixte-des-transports-en-commun-de-lagglomeration-clermontoise-smtc-ac-1",
@@ -3193,7 +3052,6 @@
             "name": "gtfs-netex-et-gtfs-rt-reseau-tao-orleans-metropole",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b2dfbaa3-47e9-4749-b6a4-750bebd760e7",
-            "url-override": "https://chouette.enroute.mobi/api/v1/datas/keolis_orleans/gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-netex-et-gtfs-rt-reseau-tao-orleans-metropole",
@@ -3206,7 +3064,7 @@
         {
             "name": "gtfs-netex-et-gtfs-rt-reseau-tao-orleans-metropole",
             "type": "url",
-            "url": "https://ara-api.enroute.mobi/tao/gtfs/trip-updates",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/671f5967-4bb9-4eca-bba6-db47dc970c31",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-netex-et-gtfs-rt-reseau-tao-orleans-metropole",
                 "spdx-identifier": "etalab-2.0"
@@ -3219,7 +3077,6 @@
             "name": "description-de-loffre-tad-tao-gtfs-flex-orleans-metropole",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b85b743c-448c-411f-8fe6-e09bec2700a5",
-            "url-override": "https://data.orleans-metropole.fr/api/explore/v2.1/catalog/datasets/om-mobilite-tao-tad-gtfsflex/alternative_exports/gtfs_flex_tao_012026_062026_zip/",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/description-de-loffre-tad-tao-gtfs-flex-orleans-metropole",
@@ -3234,7 +3091,6 @@
             "name": "gtfs-sankeo",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/3047f942-98f0-4d4c-92cf-7c5de1fe233c",
-            "url-override": "https://eur.mecatran.com/utw/ws/gtfsfeed/static/perpignan?apiKey=612f606b5e3b0a3e6e1f441a2c4a050f6a345b55",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-sankeo",
@@ -3248,7 +3104,6 @@
             "name": "gtfs-sankeo--83734",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/6e9de060-61f6-49aa-a7ae-f0e5f509415a",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-sankeo/20251223-101020/gtfs-sankeo-ls.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-sankeo",
@@ -3262,7 +3117,6 @@
             "name": "gtfs-sankeo--83735",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2afffa1f-aa4a-4fe4-9802-4b5f82bb96c6",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-sankeo/20251223-100921/gtfs-sankeo.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-sankeo",
@@ -3275,7 +3129,7 @@
         {
             "name": "gtfs-sankeo",
             "type": "url",
-            "url": "https://eur.mecatran.com/utw/ws/gtfsfeed/realtime/perpignan?apiKey=612f606b5e3b0a3e6e1f441a2c4a050f6a345b55",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/19990c8d-e56f-4a13-afbb-795cddd1a6da",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-sankeo",
                 "spdx-identifier": "etalab-2.0"
@@ -3288,7 +3142,6 @@
             "name": "caen-la-mer-reseau-twisto-gtfs-siri-2",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/71728bd6-b9a4-48e3-93ee-ac566e42fe99",
-            "url-override": "https://data.twisto.fr/api/v2/catalog/datasets/fichier-gtfs-du-reseau-twisto/alternative_exports/gtfs_twisto_zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/caen-la-mer-reseau-twisto-gtfs-siri-2",
@@ -3302,7 +3155,6 @@
             "name": "fr-200052264-t0014-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80787/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0014-0000/fluo-grand-est-sitram-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0014-0000-1",
@@ -3340,7 +3192,6 @@
             "name": "offre-de-transport-solea-et-tram-train-en-format-gtfs-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/7db50c2d-3fe4-4d3d-9942-57ac37c93a8d",
-            "url-override": "https://eu.ftp.opendatasoft.com/mulhouse/TRANSPORT_GTFS/SOLEA.GTFS_current.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-solea-et-tram-train-en-format-gtfs-1",
@@ -3353,7 +3204,7 @@
         {
             "name": "stations-de-velo-en-libre-service-velocite-sur-mulhouse-flux-gbfs",
             "type": "url",
-            "url": "https://data.mulhouse-alsace.fr/api/explore/v2.1/catalog/datasets/m2a_stationsvelocite_gbfs/exports/json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/9b88545b-135d-457d-af83-51f81af08348",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/stations-de-velo-en-libre-service-velocite-sur-mulhouse-flux-gbfs",
@@ -3366,7 +3217,6 @@
             "name": "offre-de-transport-du-reseau-fluo-grand-est-ardennes-08",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80413/download",
-            "url-override": "https://api.grandest2.cityway.fr/exs/GTFS?Key=OPENDATA&OperatorCode=ARDENNES",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-ardennes-08",
@@ -3380,7 +3230,6 @@
             "name": "reseau-de-transport-en-commun-lia-gtfs-siri",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/1e666e24-58ee-46b9-8952-ea2755ba88f2",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-de-transport-en-commun-lia-gtfs-siri/20260112-123407/lia-20260112.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-en-commun-lia-gtfs-siri",
@@ -3393,7 +3242,7 @@
         {
             "name": "reseau-de-transport-en-commun-lia-gtfs-siri",
             "type": "url",
-            "url": "https://gtfs.bus-tracker.fr/gtfs-rt/lia/trip-updates",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/80da0245-2ec7-4afb-bc7e-5b74f33e3f94",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-en-commun-lia-gtfs-siri",
                 "spdx-identifier": "ODbL-1.0"
@@ -3418,7 +3267,6 @@
             "name": "offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/15aeb8a5-1cca-4bb9-ae5f-b6e67e4ff2ab",
-            "url-override": "https://static.data.gouv.fr/resources/offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt/20260115-061108/gtfs-production.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt",
@@ -3431,7 +3279,7 @@
         {
             "name": "offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt",
             "type": "url",
-            "url": "http://185.220.72.38:8085/ProfilGtfsRt2_0RSProducer-TANGO/Alert.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/43ab2a14-f9b2-4238-b92e-f71875156acc",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt",
                 "spdx-identifier": "etalab-2.0"
@@ -3443,7 +3291,7 @@
         {
             "name": "offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt",
             "type": "url",
-            "url": "http://185.220.72.38:8085/ProfilGtfsRt2_0RSProducer-TANGO/TripUpdate.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/dba43a34-366d-4bef-aed1-b48c0e31c863",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt",
                 "spdx-identifier": "etalab-2.0"
@@ -3455,7 +3303,7 @@
         {
             "name": "offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://gtfs.bus-tracker.fr/gtfs-rt/tango/trip-updates",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/9be4a7ae-6436-4aab-bdb7-a81e09fa3233",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-tango-de-nimes-metropole-gtfs-gtfs-rt",
                 "spdx-identifier": "etalab-2.0"
@@ -3467,7 +3315,7 @@
         {
             "name": "velos-a-assistance-electrique-en-libre-service-nimes-metropole-nemovelo",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/nemovelo/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/73d25741-ffc4-4914-8816-3d973caaaa6d",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-nimes-metropole-nemovelo",
@@ -3480,7 +3328,6 @@
             "name": "gtfs-diviamobilites",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/e0dbd217-15cd-4e28-9459-211a27511a34",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-diviamobilites/20260105-153609/gtfs-diviamobilites-current.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-diviamobilites",
@@ -3506,7 +3353,6 @@
             "name": "fr-200052264-t0034-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/83710/download",
-            "url-override": "https://api.grandest2.cityway.fr/exs/GTFS?Key=OPENDATA&OperatorCode=STAN",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0034-0000-1",
@@ -3531,7 +3377,7 @@
         {
             "name": "stations-velostanlib",
             "type": "url",
-            "url": "https://api.cyclocity.fr/contracts/nancy/gbfs/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/67a10089-1ffe-4de7-9b12-d5b8a3526d5c",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/stations-velostanlib",
@@ -3544,7 +3390,6 @@
             "name": "gtfs-tadao",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/47a5e290-7883-4a40-bdcf-b693f64087b0",
-            "url-override": "https://chouette.enroute.mobi/api/v1/datas/opendata/gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-tadao",
@@ -3558,7 +3403,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cor-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2b76718b-2ab0-4f95-8528-cce4bb6af4fe",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/correze-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cor-nva-m-1",
@@ -3571,7 +3415,7 @@
         {
             "name": "tier-dott-gbfs-saint-quentin-en-yvelines",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/saint-quentin-en-yvelines/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/1731d548-3554-4b84-875e-adebefd5ef71",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-saint-quentin-en-yvelines",
@@ -3584,7 +3428,7 @@
         {
             "name": "voi-gbfs-saint-quentin-en-yvelines",
             "type": "url",
-            "url": "https://api.voiapp.io/gbfs/fr/6bb6b5dc-1cda-4da7-9216-d3023a0bc54a/v2/355/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/e01c988a-87d2-4f3e-a6d7-c5db7f49e91c",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/voi-gbfs-saint-quentin-en-yvelines",
@@ -3596,7 +3440,7 @@
         {
             "name": "tier-dott-gbfs-siemu",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/siemu/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/8da09bcd-458f-4e3a-afbc-44bee5e481c6",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-siemu",
@@ -3609,7 +3453,6 @@
             "name": "fichiers-gtfs-eurometropole-de-metz",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/92af6161-1b1a-4e0b-8f60-d97f213d993a",
-            "url-override": "https://data.lemet.fr/documents/LEMET-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fichiers-gtfs-eurometropole-de-metz",
@@ -3646,7 +3489,7 @@
         {
             "name": "fichier-gbfs-eurometropole-de-metz-1",
             "type": "url",
-            "url": "https://gbfs.partners.fifteen.eu/gbfs/2.2/metz/en/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/f340a7f3-467a-4b55-bbf7-baed4ac27e16",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fichier-gbfs-eurometropole-de-metz-1",
@@ -3658,7 +3501,7 @@
         {
             "name": "velo-en-libre-service-du-star-au-standard-gbfs",
             "type": "url",
-            "url": "https://eu.ftp.opendatasoft.com/star/gbfs/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/ed5d8c45-4768-4e78-97f8-e0cd6c20e0a9",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velo-en-libre-service-du-star-au-standard-gbfs",
@@ -3671,7 +3514,6 @@
             "name": "reseau-interurbain-cars-region-haute-loire-43",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/6dc48e22-edc4-478d-896d-7fdd02bbcda9",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=HAUTE_LOIRE&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-haute-loire-43",
@@ -3685,7 +3527,6 @@
             "name": "ce-jeu-de-donnees-contient-la-liste-des-arrets-des-horaires-et-des-parcours-theoriques-du-reseau-de-transport-urbain-et-interurbain-de-vrm",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/46bf6b5c-68c1-4198-a982-caeee88540a3",
-            "url-override": "https://static.data.gouv.fr/resources/ce-jeu-de-donnees-contient-la-liste-des-arrets-des-horaires-et-des-parcours-theoriques-du-reseau-de-transport-urbain-et-interurbain-de-vrm/20251203-092355/gtfs-citea-20251203-20260628.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/ce-jeu-de-donnees-contient-la-liste-des-arrets-des-horaires-et-des-parcours-theoriques-du-reseau-de-transport-urbain-et-interurbain-de-vrm",
@@ -3722,7 +3563,7 @@
         {
             "name": "ce-jeu-de-donnees-contient-la-liste-et-lemplacement-des-velostations-en-libres-service-du-service-libelo-appartenant-a-valence-romans-mobilites",
             "type": "url",
-            "url": "https://valence.publicbikesystem.net/customer/gbfs/v2/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/6ffc56fd-93a0-48ef-af13-17a16c676ca7",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/ce-jeu-de-donnees-contient-la-liste-et-lemplacement-des-velostations-en-libres-service-du-service-libelo-appartenant-a-valence-romans-mobilites",
@@ -3735,7 +3576,6 @@
             "name": "reseau-karouest",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c9c2f609-d0cd-4233-ad1b-cf86b9bf2dc8",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-karouest/20251226-081443/urbain20252026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-karouest",
@@ -3749,7 +3589,6 @@
             "name": "horaire-du-reseau-citalis",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/fc065c47-8644-4941-a8ca-4d8322a45749",
-            "url-override": "https://static.data.gouv.fr/resources/horaire-du-reseau-citalis/20251231-070829/pan-30122025-25012026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaire-du-reseau-citalis",
@@ -3763,7 +3602,6 @@
             "name": "citalis-telepherique-papang",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/fa444b8c-c1c6-4015-ac50-f748c12764d3",
-            "url-override": "https://static.data.gouv.fr/resources/citalis-telepherique-papang/20251229-113508/pap1-gtfs-2025-12-02-2028-03-01.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/citalis-telepherique-papang",
@@ -3777,7 +3615,6 @@
             "name": "horaires-theoriques-et-temps-reel-des-bus-et-tramways-circulant-sur-le-territoire-de-brest-metropole",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/583d1419-058b-481b-b378-449cab744c82",
-            "url-override": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/bibus/exports/medias.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-bus-et-tramways-circulant-sur-le-territoire-de-brest-metropole",
@@ -3814,7 +3651,7 @@
         {
             "name": "velo-a-assistance-electrique-en-libre-service-velozef-en-temps-reel",
             "type": "url",
-            "url": "https://gbfs.partners.fifteen.eu/gbfs/2.2/brest/en/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/651d9d3f-2ce9-4f57-a873-36f7bf946bda",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velo-a-assistance-electrique-en-libre-service-velozef-en-temps-reel",
@@ -3827,7 +3664,6 @@
             "name": "offre-de-transports-sibra-a-annecy-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/8b12f6db-9aa7-43dc-a179-013998a1c4c0",
-            "url-override": "https://static.data.gouv.fr/resources/offre-de-transports-sibra-a-annecy-gtfs/20251223-131236/gtfs-sibra.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-sibra-a-annecy-gtfs",
@@ -3840,7 +3676,7 @@
         {
             "name": "stations-velonecy-60-min-gbfs",
             "type": "url",
-            "url": "https://gbfs.partners.fifteen.eu/gbfs/2.2/annecy/en/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a0a5cccf-70a1-4fe9-9490-de8f7a5cae43",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/stations-velonecy-60-min-gbfs",
@@ -3853,7 +3689,6 @@
             "name": "gtfs-du-reseau-des-transports-bus-et-tramway-setram-circulant-sur-le-territoire-le-mans-metropole",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/5339d96c-6d20-4a01-939a-40f7b56d6cc1",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-du-reseau-des-transports-bus-et-tramway-setram-circulant-sur-le-territoire-le-mans-metropole/20260112-165503/gtfs-setram-lmm.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-des-transports-bus-et-tramway-setram-circulant-sur-le-territoire-le-mans-metropole",
@@ -3891,7 +3726,6 @@
             "name": "horaires-theoriques-du-reseau-izilo-format-gtfs-de-lorient-agglomeration",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c32dc40b-3538-4796-a6c6-fd239d6c1364",
-            "url-override": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/rdla-lorient/exports/medias.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-izilo-format-gtfs-de-lorient-agglomeration",
@@ -3916,7 +3750,7 @@
         {
             "name": "horaires-theoriques-du-reseau-izilo-format-gtfs-de-lorient-agglomeration",
             "type": "url",
-            "url": "https://feed-rdla-lorient.ratpdev.com/GTFS-RT",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/4f4169e8-6bc6-4492-aa9a-7543e74c6280",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-izilo-format-gtfs-de-lorient-agglomeration",
                 "spdx-identifier": "etalab-2.0"
@@ -3929,7 +3763,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lim-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/99e0887d-4855-47f7-a03b-a8235dfc86b7",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_limoges_metropole-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lim-nva-m-1",
@@ -3943,7 +3776,6 @@
             "name": "gtfs-et-siri-du-reseau-ginko-besancon-lignes-urbaines-et-periurbaines",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/e18e0aeb-8805-47fd-bcdb-c226d21c96fe",
-            "url-override": "https://api.ginko.voyage/gtfs-ginko.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-et-siri-du-reseau-ginko-besancon-lignes-urbaines-et-periurbaines",
@@ -3957,7 +3789,6 @@
             "name": "reseau-orizo-grand-avignon--83330",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/68eddc46-b2f5-4396-a298-214c415f6984",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-orizo-grand-avignon/20251208-142709/gtfs-mri-08decembre-au15fevrier.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-orizo-grand-avignon",
@@ -3971,7 +3802,6 @@
             "name": "reseau-orizo-grand-avignon--9279",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/556b9c3d-ec50-406b-9c22-7d37e0f6a15b",
-            "url-override": "https://exs.tcra2.cityway.fr/gtfs.aspx?key=UID&operatorCode=TCRA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-orizo-grand-avignon",
@@ -3985,7 +3815,7 @@
         {
             "name": "donnees-velopop-temps-reel-sur-lagglomeration-du-grand-avignon-velos-electriques-en-libre-service",
             "type": "url",
-            "url": "https://gbfs.partners.fifteen.eu/gbfs/avignon/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/e506dfcb-3cbb-4a3a-8dd0-7391aad5d430",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-velopop-temps-reel-sur-lagglomeration-du-grand-avignon-velos-electriques-en-libre-service",
@@ -3997,7 +3827,7 @@
         {
             "name": "citiz-autopartage-grand-poitiers",
             "type": "url",
-            "url": "https://backend.citiz.fr/public/provider/9/gbfs/3.0/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/3d6ff3dc-f3c5-4e23-a508-0420be4c46c4",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/citiz-autopartage-grand-poitiers",
@@ -4010,7 +3840,6 @@
             "name": "mobilite-offre-de-transport-du-reseau-bus-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/82146378-f019-4048-aa16-7328081b0369",
-            "url-override": "https://data.grandpoitiers.fr/data-fair/api/v1/datasets/offre-de-transport-du-reseau-vitalis/metadata-attachments/gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/mobilite-offre-de-transport-du-reseau-bus-gtfs-gtfs-rt",
@@ -4023,7 +3852,7 @@
         {
             "name": "mobilite-offre-de-transport-du-reseau-bus-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://data.grandpoitiers.fr/data-fair/api/v1/datasets/offre-de-transport-du-reseau-vitalis/metadata-attachments/poitiers.pbf",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/bc0b47d2-38fa-461c-8916-18e05779370a",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/mobilite-offre-de-transport-du-reseau-bus-gtfs-gtfs-rt",
                 "spdx-identifier": "etalab-2.0"
@@ -4036,7 +3865,6 @@
             "name": "offre-de-transports-reseau-dk-bus-de-la-communaute-urbaine-de-dunkerque-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f51fabfb-9d7a-44b7-bd03-d1032337fb80",
-            "url-override": "https://static.data.gouv.fr/resources/offre-de-transports-reseau-dk-bus-de-la-communaute-urbaine-de-dunkerque-gtfs/20251229-091801/gtfs-20251218-102857-dkbus.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-reseau-dk-bus-de-la-communaute-urbaine-de-dunkerque-gtfs",
@@ -4049,7 +3877,7 @@
         {
             "name": "velos-en-libre-service-du-reseau-transvilles-au-format-gbfs",
             "type": "url",
-            "url": "https://stables.donkey.bike/api/public/gbfs/2/donkey_valenciennes/gbfs",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/2acb1849-0dde-4079-bea7-f51d64d7202c",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-en-libre-service-du-reseau-transvilles-au-format-gbfs",
@@ -4062,7 +3890,6 @@
             "name": "gtfs-transport-lignes-privees-corse",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/aabc13db-58bd-41d4-8c06-ea3a10e604a6",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-transport-horaires-cars-de-haute-corse/20250421-151214/lignes-privees-corse-lignes-privees-corse-v1-gtfs-2025-04-17-09-56-13.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-lignes-privees-corse",
@@ -4076,7 +3903,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-bus-du-reseau-des-transports-publics-envibus",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/344e5a88-e993-4952-a8bf-503048020116",
-            "url-override": "https://open-share.agglo-casa.fr/s/34FS2SWg36NEZk4/download",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-bus-du-reseau-des-transports-publics-envibus",
@@ -4090,7 +3916,6 @@
             "name": "donnees-du-reseau-alterneo",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80676/download",
-            "url-override": "https://static.data.gouv.fr/resources/donnees-du-reseau-alterneo/20251110-123957/gtfs-cineo-20251110-20261031.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-du-reseau-alterneo",
@@ -4128,7 +3953,6 @@
             "name": "ametis--80223",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/571e3014-066d-4bd6-9f73-fb8065c928c6",
-            "url-override": "https://static.data.gouv.fr/resources/ametis/20251201-143438/open-data-du-30-11-2025-au-30-05-2026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/ametis",
@@ -4142,7 +3966,6 @@
             "name": "ametis--80705",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/5bc8b7dc-0d4e-48e7-b2ec-eccfe3702c19",
-            "url-override": "https://static.data.gouv.fr/resources/ametis/20251006-100451/sae-du-06-10-2025-au-03-07-2026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/ametis",
@@ -4155,7 +3978,7 @@
         {
             "name": "velo-en-libre-service-de-la-ville-damiens",
             "type": "url",
-            "url": "https://api.cyclocity.fr/contracts/amiens/gbfs/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/54d6c34c-4981-4382-a653-254c7ff15778",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velo-en-libre-service-de-la-ville-damiens",
@@ -4168,7 +3991,6 @@
             "name": "reseau-taneo-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/696cd51a-1d94-4d3f-9001-8e719c25fe03",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-taneo-1/20260104-210542/gtfs-lot1-20260105-20261231.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-taneo-1",
@@ -4182,7 +4004,6 @@
             "name": "offre-de-transport-du-reseau-fluo-grand-est-meuse-55",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80425/download",
-            "url-override": "https://api.grandest2.cityway.fr/exs/GTFS?Key=OPENDATA&OperatorCode=RITM",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-meuse-55",
@@ -4195,7 +4016,7 @@
         {
             "name": "citiz-autopartage-la-rochelle",
             "type": "url",
-            "url": "https://backend.citiz.fr/public/provider/18/gbfs/v3.0/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a2158a72-466a-4a3f-b7cd-4267538f44b2",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/citiz-autopartage-la-rochelle",
@@ -4208,7 +4029,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lro-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/030b9c31-4237-4355-a4d5-842861d225be",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_la_rochelle-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lro-nva-m-1",
@@ -4221,7 +4041,7 @@
         {
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lro-nva-m-1",
             "type": "url",
-            "url": "https://gtfs.bus-tracker.fr/gtfs-rt/yelo",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/b34de2a7-6268-4f4d-8a38-fce8bd888569",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lro-nva-m-1",
                 "spdx-identifier": "ODbL-1.0"
@@ -4234,7 +4054,6 @@
             "name": "telepherique-du-mont-faron",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/9bba0b17-2863-4ee1-a38a-c7a445f820d1",
-            "url-override": "https://static.data.gouv.fr/resources/telepherique-du-mont-faron/20251204-171032/gtfs-telfermeture.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/telepherique-du-mont-faron",
@@ -4248,7 +4067,6 @@
             "name": "horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2e97c9b3-a59f-42dd-9b9e-a232fa771f21",
-            "url-override": "https://static.data.gouv.fr/resources/horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin/20250902-083641/gtfs-capcotentin-20082025-au-28062026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin",
@@ -4261,7 +4079,7 @@
         {
             "name": "horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin",
             "type": "url",
-            "url": "https://app.pysae.com/api/v2/groups/transdev-cotentin/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/c94af528-293f-406f-a96f-bf847bcb252a",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-en-temps-reel-des-bus-et-autocars-circulant-sur-le-reseau-cap-cotentin",
                 "spdx-identifier": "etalab-2.0"
@@ -4273,7 +4091,7 @@
         {
             "name": "velos-a-assistance-electrique-en-libre-service-cap-cotentin",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/capcotentin/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/6f2d9c03-815b-4c7a-a876-7fe0ed9f10d4",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-cap-cotentin",
@@ -4286,7 +4104,6 @@
             "name": "reseau-urbain-kiceo",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/565533c0-64ae-44d6-9dfa-169be5b805c6",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-kiceo/20260108-144059/gtfs-20260108-153608-kiceo.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-kiceo",
@@ -4312,7 +4129,6 @@
             "name": "donnees-tcat-troyes-champagne-metropole-1--79747",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/79747/download",
-            "url-override": "https://static.data.gouv.fr/resources/donnees-tcat-troyes-champagne-metropole-1/20251229-080439/gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-tcat-troyes-champagne-metropole-1",
@@ -4326,7 +4142,6 @@
             "name": "donnees-tcat-troyes-champagne-metropole-1--79847",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/79847/download",
-            "url-override": "https://static.data.gouv.fr/resources/donnees-tcat-troyes-champagne-metropole-1/20251223-141509/gtfs-navineo.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-tcat-troyes-champagne-metropole-1",
@@ -4339,7 +4154,7 @@
         {
             "name": "voi-gbfs-et-netex-le-havre-et-octeville-sur-mer",
             "type": "url",
-            "url": "https://api.voiapp.io/gbfs/fr/6bb6b5dc-1cda-4da7-9216-d3023a0bc54a/v2/336/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/79a75130-596a-4906-a5a2-14e54aa9a79a",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/voi-gbfs-et-netex-le-havre-et-octeville-sur-mer",
@@ -4352,7 +4167,6 @@
             "name": "offre-de-transport-du-reseau-fluo-grand-est-haute-marne-52",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/81989/download",
-            "url-override": "https://api.grandest2.cityway.fr/exs/GTFS?Key=OPENDATA&OperatorCode=C52",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-fluo-grand-est-haute-marne-52",
@@ -4366,7 +4180,6 @@
             "name": "fichier-des-donnees-theoriques-du-reseau-scolaris-au-format-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/cf2d4693-a21d-41af-9c92-a5f8847e38cb",
-            "url-override": "https://opendata.idelis.fr/?file=GTFS_Scolaris/Data.GTFS.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fichier-des-donnees-theoriques-du-reseau-scolaris-au-format-gtfs",
@@ -4380,7 +4193,6 @@
             "name": "fichier-des-donnees-theoriques-du-reseau-idelis-au-format-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/25c5caff-fb19-4358-bb83-7f18d320bea8",
-            "url-override": "https://opendata.idelis.fr/?file=GTFS_MultiRoutes/Data.GTFS.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fichier-des-donnees-theoriques-du-reseau-idelis-au-format-gtfs",
@@ -4393,7 +4205,7 @@
         {
             "name": "idecycle-velos-en-libre-service-au-standard-gbfs",
             "type": "url",
-            "url": "https://gbfs.partners.fifteen.eu/gbfs/pau/gbfs",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/61d69bf4-cadc-4fb2-aedf-f008654b17fa",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/idecycle-velos-en-libre-service-au-standard-gbfs",
@@ -4406,7 +4218,6 @@
             "name": "syndicat-mixte-des-transports-du-petit-cul-de-sac-marin",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ac89688b-252b-4b23-9e97-39226402cf2b",
-            "url-override": "https://static.data.gouv.fr/resources/syndicat-mixte-des-transports-du-petit-cul-de-sac-marin/20260102-170300/karulis-2026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/syndicat-mixte-des-transports-du-petit-cul-de-sac-marin",
@@ -4420,7 +4231,6 @@
             "name": "gtfs-transport-via-strada-les-cars-corse-du-sud",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/fe20cb23-34b8-4965-acf7-1b28bf966891",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-transport-via-strada-les-cars-corse-du-sud/20250619-080806/via-strada-via-strada-2025.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-via-strada-les-cars-corse-du-sud",
@@ -4433,7 +4243,7 @@
         {
             "name": "gtfs-transport-via-strada-les-cars-corse-du-sud",
             "type": "url",
-            "url": "https://ctc.plateforme-2cloud.com/api/gtfsrt/2.0/tripupdates/CTC-2298-2048-0876/bin",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/33a9eabf-86c1-4980-84b8-529026f0a84c",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-via-strada-les-cars-corse-du-sud",
                 "spdx-identifier": "etalab-2.0"
@@ -4446,7 +4256,6 @@
             "name": "lignes-maritimes-de-corse-du-sud-de-la-collectivite-de-corse",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/edabe706-150e-4320-a0cc-b68eed217495",
-            "url-override": "https://static.data.gouv.fr/resources/lignes-maritimes-de-corse-du-sud-de-la-collectivite-de-corse/20241001-080142/lignes-maritimes-de-corse-du-sud-de-la-collectivite-de-corse.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/lignes-maritimes-de-corse-du-sud-de-la-collectivite-de-corse",
@@ -4460,7 +4269,6 @@
             "name": "gtfs-transport-horaires-des-lignes-de-la-communaute-de-communes-corse-du-sud-a-berlina",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/a84de823-7cb2-4d87-917e-e2dda306d280",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-transport-horaires-des-lignes-de-la-communaute-de-communes-corse-du-sud-a-berlina/20250702-113144/a-berlina.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-des-lignes-de-la-communaute-de-communes-corse-du-sud-a-berlina",
@@ -4486,7 +4294,6 @@
             "name": "horaires-theoriques-du-telepherique-de-la-bastille",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/3ec51aee-ce59-4608-b721-faae118ea1d0",
-            "url-override": "https://data.mobilites-m.fr/api/gtfs/BUL",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-telepherique-de-la-bastille",
@@ -4499,7 +4306,7 @@
         {
             "name": "voi-trottinettes-et-velos-aire-grenobloise",
             "type": "url",
-            "url": "https://api.voiapp.io/gbfs/fr/6bb6b5dc-1cda-4da7-9216-d3023a0bc54a/v2/358/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/53797344-9ab7-4f52-b000-a1136a89f632",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/voi-trottinettes-et-velos-aire-grenobloise",
@@ -4512,7 +4319,6 @@
             "name": "horaires-theoriques-et-temps-reel-gtfs-gtfs-rt-du-reseau-palmbus-cannes-pays-de-lerins",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/47bc8088-6c72-43ad-a959-a5bbdd1aa14f",
-            "url-override": "https://static.data.gouv.fr/resources/horaires-theoriques-et-temps-reel-gtfs-gtfs-rt-du-reseau-palmbus-cannes-pays-de-lerins/20260109-141802/palmbus-cannes-fr.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-gtfs-gtfs-rt-du-reseau-palmbus-cannes-pays-de-lerins",
@@ -4550,7 +4356,6 @@
             "name": "gtfs-du-reseau-de-transports-publics-de-saint-brieuc-armor-agglomeration",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/9bccfc79-5d35-4fc3-8296-526b791fc950",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-du-reseau-de-transports-publics-de-saint-brieuc-armor-agglomeration/20251103-092328/gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-de-transports-publics-de-saint-brieuc-armor-agglomeration",
@@ -4563,7 +4368,7 @@
         {
             "name": "location-de-velos-velobaie--80484",
             "type": "url",
-            "url": "https://gateway.prod.partners-fs37hd8.zoov.site/gbfs/2.2/saintbrieuc/en/station_status.json?key=YmE1ZDVlNDYtMGIwNy00MGEyLWIxZWYtNGEwOGQ4NTYxNTYz",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/407ae361-d196-45e1-ba9a-0b34997dad25",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/location-de-velos-velobaie",
@@ -4575,7 +4380,7 @@
         {
             "name": "location-de-velos-velobaie--80485",
             "type": "url",
-            "url": "https://gateway.prod.partners-fs37hd8.zoov.site/gbfs/2.2/saintbrieuc/en/station_information.json?key=YmE1ZDVlNDYtMGIwNy00MGEyLWIxZWYtNGEwOGQ4NTYxNTYz",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/6aba2959-4200-4404-a707-b4954df29fb4",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/location-de-velos-velobaie",
@@ -4587,7 +4392,7 @@
         {
             "name": "location-de-velos-velobaie--80486",
             "type": "url",
-            "url": "https://gateway.prod.partners-fs37hd8.zoov.site/gbfs/2.2/saintbrieuc/en/gbfs.json?key=YmE1ZDVlNDYtMGIwNy00MGEyLWIxZWYtNGEwOGQ4NTYxNTYz",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/c5759f74-d558-4095-b122-e041439b2d0e",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/location-de-velos-velobaie",
@@ -4600,7 +4405,6 @@
             "name": "agence-agglobus--81705",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/9e9cea88-cdf9-4f3d-ae17-f30c9512d276",
-            "url-override": "https://static.data.gouv.fr/resources/agence-agglobus/20250806-142142/agglobus-peri-urbain-25-agglo-bus-inter-gtfs-2025-07-23-07-58-11-2-.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/agence-agglobus",
@@ -4614,7 +4418,6 @@
             "name": "agence-agglobus--83304",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/12c4aed4-a268-4cb3-8fb5-7625a747cf56",
-            "url-override": "https://static.data.gouv.fr/resources/agence-agglobus/20250806-161732/cacl-l7-10-ligne-n-7-et-n-10-v2-gtfs-2025-08-06-13-12-18.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/agence-agglobus",
@@ -4628,7 +4431,6 @@
             "name": "gtfs-urbain-de-la-zone-centre",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/6e599077-0719-44b4-82ad-0da90a282846",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-urbain-de-la-zone-centre/20251226-145011/gtfs-centre-rtm.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-urbain-de-la-zone-centre",
@@ -4642,7 +4444,6 @@
             "name": "horaires-theoriques-des-lignes-urbaines-et-interurbaines-sur-le-reseau-alesy-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b9a0f32e-4386-454c-8759-b82653fa861e",
-            "url-override": "https://static.data.gouv.fr/resources/horaires-theoriques-des-lignes-urbaines-et-interurbaines-sur-le-reseau-alesy-gtfs/20260116-092222/gtfs-is-20260119.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-des-lignes-urbaines-et-interurbaines-sur-le-reseau-alesy-gtfs",
@@ -4655,7 +4456,7 @@
         {
             "name": "horaires-theoriques-des-lignes-urbaines-et-interurbaines-sur-le-reseau-alesy-gtfs",
             "type": "url",
-            "url": "https://alesy.plateforme-2cloud.com/api/gtfsrt/2.0/tripupdates/ALESY-6574-4401-7572/bin",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/68e3fd78-f72a-45cc-a43a-e02290550c7b",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-des-lignes-urbaines-et-interurbaines-sur-le-reseau-alesy-gtfs",
                 "spdx-identifier": "ODbL-1.0"
@@ -4668,7 +4469,6 @@
             "name": "eveole-douai-reseau-bus-du-syndicat-mixte-des-transports-du-douaisis-smtd",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/99cf5e2f-87c2-4ff1-bc0d-32f04cc213ab",
-            "url-override": "https://static.data.gouv.fr/resources/eveole-douai-reseau-bus-du-syndicat-mixte-des-transports-du-douaisis-smtd/20251212-155914/gtfs-08122025-03072026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/eveole-douai-reseau-bus-du-syndicat-mixte-des-transports-du-douaisis-smtd",
@@ -4682,7 +4482,6 @@
             "name": "reseau-interurbain-cars-region-cantal-15",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2053f06d-439c-43fe-87fb-528179a8502e",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=CAR_REGION_CANTAL&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-interurbain-cars-region-cantal-15",
@@ -4696,7 +4495,6 @@
             "name": "horaires-theoriques-et-temps-reel-reseau-mobius",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/021fd4a3-ba9a-4d78-aa65-71d4d289f389",
-            "url-override": "https://static.data.gouv.fr/resources/horaires-theoriques-et-temps-reel-reseau-mobius/20251008-085244/gtfs-mobius-saison25-26-20250930-tad.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-reseau-mobius",
@@ -4722,7 +4520,6 @@
             "name": "arrets-et-horaires-theoriques-bus-temps-reel",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/a81cdf4b-5a70-43c9-8803-cef0430ed170",
-            "url-override": "https://mwe.mecatran.com/utw/ws/gtfsfeed/static/chambery?apiKey=223f2f102c1242570d3f0231326a271940774f72&type=gtfs_urbain",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-et-horaires-theoriques-bus-temps-reel",
@@ -4735,7 +4532,7 @@
         {
             "name": "arrets-et-horaires-theoriques-bus-temps-reel",
             "type": "url",
-            "url": "https://mwe.mecatran.com/utw/ws/gtfsfeed/alerts/chambery?apiKey=223f2f102c1242570d3f0231326a271940774f72",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/fca16c60-b6f9-49ab-98c0-0c5985ba799e",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-et-horaires-theoriques-bus-temps-reel",
                 "spdx-identifier": "ODbL-1.0"
@@ -4747,7 +4544,7 @@
         {
             "name": "arrets-et-horaires-theoriques-bus-temps-reel",
             "type": "url",
-            "url": "https://mwe.mecatran.com/utw/ws/gtfsfeed/realtime/chambery?apiKey=223f2f102c1242570d3f0231326a271940774f72",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/fbd5179e-fb3c-4361-853e-6d868f9a42b5",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-et-horaires-theoriques-bus-temps-reel",
                 "spdx-identifier": "ODbL-1.0"
@@ -4760,7 +4557,6 @@
             "name": "evolity-horaires-theoriques-de-transport-public",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b45aa8d8-4bd4-4528-99c7-acfc980fdb09",
-            "url-override": "https://static.data.gouv.fr/resources/evolity-horaires-theoriques-de-transport-public/20251224-131758/gtfs-du-01-01-2026-au-12-07-2026-vdef-rs-ok.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/evolity-horaires-theoriques-de-transport-public",
@@ -4774,7 +4570,6 @@
             "name": "filibus-urbain",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/8d4c3e5c-1702-4649-b47a-b16c6016dcc6",
-            "url-override": "https://static.data.gouv.fr/resources/filibus-urbain/20251229-173429/gtfs-filibus-20260105-20260215.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/filibus-urbain",
@@ -4788,7 +4583,6 @@
             "name": "rubis-horaires-theoriques-du-reseau-de-transport-urbain-de-grand-bourg-agglomeration",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/cd0ec3c7-431b-48df-bab5-269e5d5c05bb",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=RUBIS&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/rubis-horaires-theoriques-du-reseau-de-transport-urbain-de-grand-bourg-agglomeration",
@@ -4802,7 +4596,6 @@
             "name": "reseau-urbain-illygo",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/024123a0-8665-4983-90bd-134ef7d70383",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-illygo/20251212-113806/gtfs-20251209-horsbord-illygo.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-illygo",
@@ -4815,7 +4608,7 @@
         {
             "name": "reseau-urbain-illygo",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/illygo/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/476d53cd-374b-41b7-b11a-a158cc9abfaa",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-illygo",
                 "spdx-identifier": "ODbL-1.0"
@@ -4828,7 +4621,6 @@
             "name": "referentiel-topologique-reseau-carsud",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/8f3642e3-9fc3-45ed-af46-8c532966ace3",
-            "url-override": "https://static.data.gouv.fr/resources/referentiel-topologique-reseau-carsud/20251221-164735/gtfs-carsud-17122025v1.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/referentiel-topologique-reseau-carsud",
@@ -4841,7 +4633,7 @@
         {
             "name": "referentiel-topologique-reseau-carsud",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?src=true&dataset=carsud-reunion",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/146fe36f-16c5-44bc-ac1a-06c0fedcc4dd",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/referentiel-topologique-reseau-carsud",
                 "spdx-identifier": "etalab-2.0"
@@ -4854,7 +4646,6 @@
             "name": "offre-de-transport-communaute-dagglomeration-le-grand-narbonne",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/21ca2b77-505b-4c4c-9154-a044e61b8560",
-            "url-override": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/narbonne/exports/scolaires-sans-tad.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-communaute-dagglomeration-le-grand-narbonne",
@@ -4867,7 +4658,7 @@
         {
             "name": "offre-de-transport-communaute-dagglomeration-le-grand-narbonne",
             "type": "url",
-            "url": "https://notifytest.ratpdev.com/api/networks/RD%20GRAND%20NARBONNE/alerts/gtfsrt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/b0e4dade-42ce-4a36-b93d-1137a2c34094",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-communaute-dagglomeration-le-grand-narbonne",
                 "spdx-identifier": "etalab-2.0"
@@ -4879,7 +4670,7 @@
         {
             "name": "offre-de-transport-communaute-dagglomeration-le-grand-narbonne",
             "type": "url",
-            "url": "https://feed-citibus-narbonne.ratpdev.com/GTFS-RT/gtfs-rt.bin",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/1fc16ad0-4aef-402d-9faa-da04ddd61fd2",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-communaute-dagglomeration-le-grand-narbonne",
                 "spdx-identifier": "etalab-2.0"
@@ -4892,7 +4683,6 @@
             "name": "horaires-theoriques-et-temps-reel-du-reseau-de-transports-beemob-beziers-mediterranee",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c1581a3a-0b78-4944-905c-a8530206648a",
-            "url-override": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/rdbm/exports/medias.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-de-transports-beemob-beziers-mediterranee",
@@ -4918,7 +4708,6 @@
             "name": "yceo-arrets-horaires-et-lignes-urbaines-et-scolaires-gtfs-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/e7f40c40-b39d-4583-bc03-05e5bce06949",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/stran-merge?apiKey=2e6071036d276153761f0c090b4a45420e047612&type=gtfs_stran",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/yceo-arrets-horaires-et-lignes-urbaines-et-scolaires-gtfs-1",
@@ -4931,7 +4720,7 @@
         {
             "name": "liste-api-ecovelo-pour-stations-velyceo-electriques-sur-saint-nazaire-agglo",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/velyceo/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/ddb3806b-ceb6-4feb-8332-cba546a313bd",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/liste-api-ecovelo-pour-stations-velyceo-electriques-sur-saint-nazaire-agglo",
@@ -4944,7 +4733,6 @@
             "name": "reseau-bus-sete-agglopole-mobilite",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/9402f130-ac11-4615-8494-a5c84fcdb78c",
-            "url-override": "https://drive.google.com/uc?export=download&id=1PUISUlg0tpVFTdr7NOzJ2w9KthNXpQNn",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-bus-sete-agglopole-mobilite",
@@ -4957,7 +4745,7 @@
         {
             "name": "reseau-bus-sete-agglopole-mobilite",
             "type": "url",
-            "url": "https://sete.ceccli.com/gtfs/TripUpdates.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/c417d4b1-323d-48f1-814a-b299bf4adfba",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-bus-sete-agglopole-mobilite",
                 "spdx-identifier": "etalab-2.0"
@@ -4969,7 +4757,7 @@
         {
             "name": "reseau-bus-sete-agglopole-mobilite",
             "type": "url",
-            "url": "https://sete.ceccli.com/gtfs/Alerts.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a41c8985-4f03-4a20-9eed-8466a76eacb3",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-bus-sete-agglopole-mobilite",
                 "spdx-identifier": "etalab-2.0"
@@ -4982,7 +4770,6 @@
             "name": "gtfs-3",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/84f7501c-de7b-46d9-8e0c-14c30d9fa58b",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-3/20251231-101225/gtfs-zenbus-kolibri-20251231-110016.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-3",
@@ -4995,7 +4782,7 @@
         {
             "name": "gtfs-3",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=tlp-mobilites",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/38611abb-fb76-4072-8be9-514fdbc4b13a",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-3",
                 "spdx-identifier": "etalab-2.0"
@@ -5007,7 +4794,7 @@
         {
             "name": "vls-tlp-mobilites",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/tlpmobilites/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/080f2fa8-b04a-4e62-899a-e9fc0bf18349",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/vls-tlp-mobilites",
@@ -5020,7 +4807,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-nio-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d724a6df-7dc4-4b2d-be15-fc8b1d52c8ea",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_du_niortais-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-nio-nva-m-1",
@@ -5033,7 +4819,7 @@
         {
             "name": "stations-velos-en-libre-service-tanlib-flux-en-temps-reel",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/tanlib/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/981a94bb-8c80-45a1-93bc-dbef0a02fc70",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/stations-velos-en-libre-service-tanlib-flux-en-temps-reel",
@@ -5046,7 +4832,6 @@
             "name": "reseau-transport-urbain-le-bus",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/11e73e58-edb0-4fab-a220-61a659cf6423",
-            "url-override": "https://www.datasud.fr/fr/dataset/datasets/1224/resource/4791/download/",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-transport-urbain-le-bus",
@@ -5060,7 +4845,6 @@
             "name": "fr-200052264-t0002-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80451/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0002-0000/fluo-grand-est-chm-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0002-0000-1",
@@ -5085,7 +4869,7 @@
         {
             "name": "besancon-velos-en-libre-service-ginko-velo",
             "type": "url",
-            "url": "https://api.cyclocity.fr/contracts/besancon/gbfs/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/94963d3a-e623-4c1e-9475-95cae3b1b720",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/besancon-velos-en-libre-service-ginko-velo",
@@ -5098,7 +4882,6 @@
             "name": "dreux-offre-theorique-mobilite-reseau-urbain",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c654db3d-a710-4ed5-a327-417f812bf9a0",
-            "url-override": "https://fr.ftp.opendatasoft.com/centrevaldeloire/OKINAGTFS/GTFS_AO/DREUX.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/dreux-offre-theorique-mobilite-reseau-urbain",
@@ -5112,7 +4895,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cre-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b3f2f823-fe55-4265-9efe-605d8156dea2",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/creuse-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cre-nva-m-1",
@@ -5126,7 +4908,6 @@
             "name": "gtfs-urbain-de-la-zone-sud",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d910480b-c9a5-4f48-a257-4e1aa799c5c8",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-urbain-de-la-zone-sud/20251221-154625/gtfs-sud-sudlib.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-urbain-de-la-zone-sud",
@@ -5140,7 +4921,6 @@
             "name": "offre-de-transport-du-reseau-de-laval-agglomeration-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/bd780aef-b3c5-405a-8450-8365a7a0c315",
-            "url-override": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/rd-laval/exports/medias.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-de-laval-agglomeration-gtfs",
@@ -5154,7 +4934,6 @@
             "name": "reseau-rtca",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/941123b0-004e-4f48-81e7-8c62fb4f07aa",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-rtca/20260105-153046/gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-rtca",
@@ -5167,7 +4946,7 @@
         {
             "name": "cyclolibre-les-velos-electriques-en-libre-service-par-carcassonne",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/cyclolibre/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/161c040f-eb71-4a52-ae5f-a6c50337a935",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/cyclolibre-les-velos-electriques-en-libre-service-par-carcassonne",
@@ -5180,7 +4959,6 @@
             "name": "fr-200052264-t0004-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80479/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0004-0000/fluo-grand-est-cac-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0004-0000-1",
@@ -5194,7 +4972,6 @@
             "name": "tedbus-horaires-des-lignes-reseau",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/a1d56fb0-e264-45f2-8822-c08746847a97",
-            "url-override": "https://www.datasud.fr/fr/dataset/datasets/1760/resource/2210/download/",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tedbus-horaires-des-lignes-reseau",
@@ -5207,7 +4984,7 @@
         {
             "name": "tedbus-horaires-des-lignes-reseau",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/draguignan/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/f32c61d5-30b7-4e06-a05e-a2fc934ba7d9",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tedbus-horaires-des-lignes-reseau",
                 "spdx-identifier": "etalab-2.0"
@@ -5220,7 +4997,6 @@
             "name": "reseauzoom-horaires-theoriques",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f11a3766-1fe3-40ff-8d5a-27eacda3d9a7",
-            "url-override": "https://static.data.gouv.fr/resources/reseauzoom-horaires-theoriques/20251229-092806/gtfs-20251217-143039-stac-gc.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseauzoom-horaires-theoriques",
@@ -5234,7 +5010,6 @@
             "name": "horaires-theoriques-et-temps-reel-du-reseau-de-transport-marineo",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/579e4f5e-2916-4b95-90b8-f675943d0136",
-            "url-override": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/boulogne/exports/medias.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-de-transport-marineo",
@@ -5260,7 +5035,6 @@
             "name": "transurbain-evreux-portes-de-normandie",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80613/download",
-            "url-override": "https://static.data.gouv.fr/resources/transurbain-evreux-portes-de-normandie/20260105-210614/pt-th-offer-transurbain-gtfs-20260105-334-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transurbain-evreux-portes-de-normandie",
@@ -5298,7 +5072,6 @@
             "name": "agglobus-offre-theorique-mobilite-reseau-urbain-de-bourges",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ef2f826c-c1c6-4eb4-9da3-4c2f37b3afaf",
-            "url-override": "https://fr.ftp.opendatasoft.com/centrevaldeloire/OKINAGTFS/GTFS_AO/BOURGES-GTFS.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/agglobus-offre-theorique-mobilite-reseau-urbain-de-bourges",
@@ -5336,7 +5109,6 @@
             "name": "reseau-ruban",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/34d2cc17-3eb5-4581-917b-a8c06a112e61",
-            "url-override": "https://api.pysae.com/api/v4/groups/keolis-9cc4/gtfs/695be455bd8fba1fded7d497",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-ruban",
@@ -5349,7 +5121,7 @@
         {
             "name": "reseau-ruban",
             "type": "url",
-            "url": "https://app.pysae.com/api/v2/groups/keolis-9cc4/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/120182b0-e338-4917-b2bb-ee37b60de1ba",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-ruban",
                 "spdx-identifier": "ODbL-1.0"
@@ -5362,7 +5134,6 @@
             "name": "fr-200052264-t0009-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80461/download",
-            "url-override": "https://exs.grandest2.cityway.fr/GTFS.aspx?Key=OPENDATA&OperatorCode=IMAGINE",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0009-0000-1",
@@ -5387,7 +5158,7 @@
         {
             "name": "vls-vilvolt-agglomeration-depinal",
             "type": "url",
-            "url": "https://gbfs.partners.fifteen.eu/gbfs/epinal/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/697795d0-761c-410d-80c5-4f1b5eede6df",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/vls-vilvolt-agglomeration-depinal",
@@ -5400,7 +5171,6 @@
             "name": "reseau-de-transport-artis",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/4ded8fb3-a38d-45c5-b4a7-a2f6ac17ba4f",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-de-transport-artis/20250829-085009/gtfs-20250828-151217.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-artis",
@@ -5414,7 +5184,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-bri-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/87a0b98b-8a5a-4ba7-ad93-5a1fb9924844",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_bassin_de_brive-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-bri-nva-m-1",
@@ -5427,7 +5196,7 @@
         {
             "name": "vls-ca-bassin-de-brive-velibeo",
             "type": "url",
-            "url": "https://mobi-iti-nam.okina.fr/api-proxy/api/gbfs/1.0/gbfs/velibeo_ecovelo/gbfs",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a6f25e43-e1f5-4c4f-ab7b-12999527c41f",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/vls-ca-bassin-de-brive-velibeo",
@@ -5440,7 +5209,6 @@
             "name": "agglopolys-offre-theorique-mobilite-reseau-urbain-azalys-de-blois",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/e6e0228d-9916-4216-bb5f-7d3edf57866c",
-            "url-override": "https://fr.ftp.opendatasoft.com/centrevaldeloire/OKINAGTFS/GTFS_AO/BLOIS.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/agglopolys-offre-theorique-mobilite-reseau-urbain-azalys-de-blois",
@@ -5453,7 +5221,7 @@
         {
             "name": "agglopolys-offre-theorique-mobilite-reseau-urbain-azalys-de-blois",
             "type": "url",
-            "url": "https://app.mecatran.com/utw/ws/gtfsfeed/realtime/blois?apiKey=7a0d1031460836674e76041e7a78011813347f04",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/61d5a03f-311d-4fb1-9c14-dd0c8856af32",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/agglopolys-offre-theorique-mobilite-reseau-urbain-azalys-de-blois",
                 "spdx-identifier": "ODbL-1.0"
@@ -5466,7 +5234,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-per-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/907e15b8-9a0c-4b00-b1b3-325ab1ac7d4c",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_grand_perigueux-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-per-nva-m-1",
@@ -5479,7 +5246,7 @@
         {
             "name": "vls-ca-grand-perigueux-perivelo",
             "type": "url",
-            "url": "https://mobi-iti-nam.okina.fr/api-proxy/api/gbfs/1.0/gbfs/perivelo_ecovelo/gbfs",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/0e2fce22-9da3-4376-8b04-831eb47de8e2",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/vls-ca-grand-perigueux-perivelo",
@@ -5492,7 +5259,6 @@
             "name": "transports-publics-urbains-sur-le-territoire-de-la-ca-du-pays-de-gex-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/95c73b12-d117-4faf-bb6f-abfe3c95eee1",
-            "url-override": "https://static.data.gouv.fr/resources/transports-publics-urbains-sur-le-territoire-de-la-ca-du-pays-de-gex-1/20250115-151914/gtfs-2025.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transports-publics-urbains-sur-le-territoire-de-la-ca-du-pays-de-gex-1",
@@ -5507,7 +5273,6 @@
             "name": "horaires-theoriques-reseau-choletbus",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/71e8ee8e-0b55-40a1-a297-21ef89aba4dc",
-            "url-override": "https://static.data.gouv.fr/resources/horaires-theoriques-reseau-choletbus/20260115-130633/gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-reseau-choletbus",
@@ -5520,7 +5285,7 @@
         {
             "name": "horaires-theoriques-reseau-choletbus",
             "type": "url",
-            "url": "https://app.mecatran.com/utw/ws/gtfsfeed/alerts/choletbus?apiKey=0b0f0b6035007b7f1243311973401c294e6a0143",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/0787f55a-c16f-40bb-88d5-554f2b394658",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-reseau-choletbus",
                 "spdx-identifier": "etalab-2.0"
@@ -5532,7 +5297,7 @@
         {
             "name": "horaires-theoriques-reseau-choletbus",
             "type": "url",
-            "url": "https://app.mecatran.com/utw/ws/gtfsfeed/realtime/choletbus?apiKey=0b0f0b6035007b7f1243311973401c294e6a0143",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a905e627-3467-4da0-9327-a433054c904e",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-reseau-choletbus",
                 "spdx-identifier": "etalab-2.0"
@@ -5544,7 +5309,7 @@
         {
             "name": "choletbus-2-roues-vaels",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/choletbus/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/af29544e-b171-46de-8e02-0746a68b172b",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/choletbus-2-roues-vaels",
@@ -5557,7 +5322,6 @@
             "name": "transports-en-commun-audomarois-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/584491f9-0ace-4ee2-a49e-23caedb6f3f1",
-            "url-override": "https://static.data.gouv.fr/resources/transports-en-commun-audomarois-1/20260115-142314/05-01-2026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transports-en-commun-audomarois-1",
@@ -5571,7 +5335,6 @@
             "name": "reseau-urbain-dinamo",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/7ec415c9-a963-40fc-8350-7ca77cb824c8",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-dinamo/20251204-132959/gtfs-20251204-142134-dinamo.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-dinamo",
@@ -5585,7 +5348,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-corolis-interurbain-communaute-dagglomeration-du-beauvaisis--81138",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/191ae476-2ce8-48d7-bed2-b9cb93f63364",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=COROLIS_INT&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-corolis-interurbain-communaute-dagglomeration-du-beauvaisis",
@@ -5599,7 +5361,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-corolis-interurbain-communaute-dagglomeration-du-beauvaisis--81650",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/61277099-cde9-457c-919d-a1b7b20fe992",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/tad/download?provider=COROLIS_INT&dataFormat=gtfs",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-corolis-interurbain-communaute-dagglomeration-du-beauvaisis",
@@ -5614,7 +5375,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-corolis-urbain-communaute-dagglomeration-du-beauvaisis",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2b8e53ce-a26c-4986-8d33-505e1b680bb4",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=COROLIS_URB&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-corolis-urbain-communaute-dagglomeration-du-beauvaisis",
@@ -5627,7 +5387,7 @@
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-corolis-urbain-communaute-dagglomeration-du-beauvaisis",
             "type": "url",
-            "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=COROLIS_URB&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/aedbd2be-1ffb-45c4-88c2-7639712612aa",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-corolis-urbain-communaute-dagglomeration-du-beauvaisis",
                 "spdx-identifier": "etalab-2.0"
@@ -5640,7 +5400,6 @@
             "name": "reseau-transport-mouv-enbus-agglomeration-provence-verte",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/9e2f1dd8-cbf4-4e56-b022-b350561a1cb9",
-            "url-override": "https://www.datasud.fr/fr/dataset/datasets/1311/resource/5230/download/",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-transport-mouv-enbus-agglomeration-provence-verte",
@@ -5654,7 +5413,6 @@
             "name": "horaires-theoriques-du-reseau-tougo",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c1067233-c35e-4c53-93b3-050f707bf6a2",
-            "url-override": "https://data.mobilites-m.fr/api/gtfs/GSV",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-tougo",
@@ -5668,7 +5426,6 @@
             "name": "semo-val-de-reuil-louviers-seine-eure-agglo",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/81338/download",
-            "url-override": "https://static.data.gouv.fr/resources/semo-val-de-reuil-louviers-seine-eure-agglo/20251218-104416/pt-th-offer-semo-gtfs-20251216-761-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/semo-val-de-reuil-louviers-seine-eure-agglo",
@@ -5706,7 +5463,6 @@
             "name": "horaires-theoriques-et-du-reseau-de-transports-qub-transports-urbains-de-quimper-bretagne-occidentale",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/95530333-7002-401d-9d64-2829496d1c36",
-            "url-override": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/qbo/exports/medias.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-du-reseau-de-transports-qub-transports-urbains-de-quimper-bretagne-occidentale",
@@ -5719,7 +5475,7 @@
         {
             "name": "horaires-theoriques-et-du-reseau-de-transports-qub-transports-urbains-de-quimper-bretagne-occidentale",
             "type": "url",
-            "url": "https://notify.ratpdev.com/api/networks/RD%20QUIMPER/alerts/gtfsrt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/c7d65730-5726-4003-af58-9080017287dc",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-du-reseau-de-transports-qub-transports-urbains-de-quimper-bretagne-occidentale",
                 "spdx-identifier": "ODbL-1.0"
@@ -5731,7 +5487,7 @@
         {
             "name": "horaires-theoriques-et-du-reseau-de-transports-qub-transports-urbains-de-quimper-bretagne-occidentale",
             "type": "url",
-            "url": "https://feed-qub-quimper.ratpdev.com/GTFS-RT_tripUpdate/gtfs-rt.bin",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/d3b095ca-4c32-43b4-bc34-c339c91a7b24",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-du-reseau-de-transports-qub-transports-urbains-de-quimper-bretagne-occidentale",
                 "spdx-identifier": "ODbL-1.0"
@@ -5744,7 +5500,6 @@
             "name": "hop-bus-le-reseau-100-gratuit-du-coeur-de-flandre",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d10fb9b2-1a5a-498c-ba55-e89cf0136ef1",
-            "url-override": "https://gtfs-rt.infra-hubup.fr/hopbus/current/revision/gtfs",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/hop-bus-le-reseau-100-gratuit-du-coeur-de-flandre",
@@ -5757,7 +5512,7 @@
         {
             "name": "hop-bus-le-reseau-100-gratuit-du-coeur-de-flandre",
             "type": "url",
-            "url": "https://gtfs-rt.infra-hubup.fr/hopbus/realtime",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/131da43c-d324-4f98-8481-0c7b20327df1",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/hop-bus-le-reseau-100-gratuit-du-coeur-de-flandre",
                 "spdx-identifier": "etalab-2.0"
@@ -5770,7 +5525,6 @@
             "name": "lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire--79821",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/1580b34b-8ebe-42b1-b75c-a4ae41d579b7",
-            "url-override": "https://static.data.gouv.fr/resources/lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire/20251119-082709/gtfs-scolaire-sillages-20251119.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire",
@@ -5784,7 +5538,6 @@
             "name": "lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire--79822",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/851decd7-714f-45ad-9579-d60c06fad9dd",
-            "url-override": "https://static.data.gouv.fr/resources/lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire/20251119-082733/gtfs-urbain-sillages-20251119.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/lignes-regulieres-de-transports-sillages-en-pays-de-grasse-urbain-et-scolaire",
@@ -5798,7 +5551,6 @@
             "name": "star-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-roannais-agglomeration",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ff0dffab-3cf5-4c6b-b576-05bd462a1e33",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=STAR&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/star-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-roannais-agglomeration",
@@ -5811,7 +5563,7 @@
         {
             "name": "star-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-roannais-agglomeration",
             "type": "url",
-            "url": "https://api.oura3.cityway.fr/dataflow/horaire-tr/download?provider=STAR&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/46b88327-a75e-44b4-b369-c6f2943145cf",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/star-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-roannais-agglomeration",
                 "spdx-identifier": "ODbL-1.0"
@@ -5824,7 +5576,6 @@
             "name": "agen-gtfs-scolaire",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/3fd582f2-e2ef-4ad7-894c-6f057b53b006",
-            "url-override": "https://static.data.gouv.fr/resources/agen-gtfs-scolaire/20250912-142632/agen-gtfs-scolaire-rentree-2025-v9.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/agen-gtfs-scolaire",
@@ -5837,7 +5588,7 @@
         {
             "name": "agen-gtfs-scolaire",
             "type": "url",
-            "url": "https://urldefense.com/v3/__https://zenbus.net/gtfs/rt/poll.proto?src=true&dataset=agen-scolaire__;!!GXVuaUlRqA!aP1rnhWBNoKP6uStLU2TfthgAipcY9qdn_A_68IeuGnuVnTxm-jRYTvXwJGm5Dbawfr9VBhW7Gx6bfpuE8Bd4PP5VhDwhtE$",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/503a31c5-a574-44b2-afd5-700a0887de47",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/agen-gtfs-scolaire",
                 "spdx-identifier": "etalab-2.0"
@@ -5850,7 +5601,6 @@
             "name": "agen-gtfs-urbain",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c1415ff3-7457-4b51-aead-aacbf03a474e",
-            "url-override": "https://static.data.gouv.fr/resources/agen-gtfs-urbain/20250831-152838/agen-gtfs-urbain-rentree-septembre-2025.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/agen-gtfs-urbain",
@@ -5863,7 +5613,7 @@
         {
             "name": "agen-gtfs-urbain",
             "type": "url",
-            "url": "https://urldefense.com/v3/__https://zenbus.net/gtfs/rt/poll.proto?src=true&dataset=agen-urbain__;!!GXVuaUlRqA!aP1rnhWBNoKP6uStLU2TfthgAipcY9qdn_A_68IeuGnuVnTxm-jRYTvXwJGm5Dbawfr9VBhW7Gx6bfpuE8Bd4PP5glcwziM$",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/37b144db-2013-49ff-9a24-b8396f19655d",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/agen-gtfs-urbain",
                 "spdx-identifier": "etalab-2.0"
@@ -5876,7 +5626,6 @@
             "name": "agen-gtfs-tad",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/a17ab630-01bf-44ad-b99c-1e48db8eb78e",
-            "url-override": "https://static.data.gouv.fr/resources/agen-gtfs-tad/20250831-152726/agen-gtfs-tad-rentree-septembre-2025-ok-.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/agen-gtfs-tad",
@@ -5889,7 +5638,7 @@
         {
             "name": "gbfs-tempo-velo",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/tempovelo/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/42e8bdf8-86c0-4750-bb31-bce63d237738",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gbfs-tempo-velo",
@@ -5901,7 +5650,7 @@
         {
             "name": "optymo-auto-en-libre-service",
             "type": "url",
-            "url": "https://data.optymo.fr/als/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/c3d88db1-d380-4e77-a4af-49cc4696ad45",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/optymo-auto-en-libre-service",
@@ -5914,7 +5663,6 @@
             "name": "arrets-circuits-et-horaires-du-reseau-optymo-de-belfort",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/797c424e-7d28-4e65-84f6-6677e47d8a6e",
-            "url-override": "https://static.data.gouv.fr/resources/arrets-circuits-et-horaires-du-reseau-optymo-de-belfort/20251217-113541/gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-circuits-et-horaires-du-reseau-optymo-de-belfort",
@@ -5928,7 +5676,6 @@
             "name": "tilt-lannion-tregor-communaute",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/905a57b4-eb87-4c31-86cc-9a86deff09e0",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/TILT.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tilt-lannion-tregor-communaute",
@@ -5941,7 +5688,7 @@
         {
             "name": "tilt-lannion-tregor-communaute",
             "type": "url",
-            "url": "https://www.korrigo.bzh/ftp/OPENDATA/gtfsrt/TILT.GtfsRt.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/efbce591-9baa-430d-a60b-6066d6d891cb",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tilt-lannion-tregor-communaute",
                 "spdx-identifier": "ODbL-1.0"
@@ -5954,7 +5701,6 @@
             "name": "fr-200052264-t0008-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80449/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0008-0000/fluo-grand-est-haguenau-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0008-0000-1",
@@ -5968,7 +5714,6 @@
             "name": "horaires-theoriques-et-temps-reel-du-reseau-ritmo-haguenau-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/8df46b2d-1be4-4a84-a227-bc2c61af97ca",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=haguenau",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-ritmo-haguenau-gtfs-gtfs-rt",
@@ -5981,7 +5726,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-du-reseau-ritmo-haguenau-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=haguenau",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/ae8b5fd2-283a-462c-aa34-27e02f6fc4a5",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-ritmo-haguenau-gtfs-gtfs-rt",
                 "spdx-identifier": "ODbL-1.0"
@@ -5993,7 +5738,7 @@
         {
             "name": "disponibilite-en-temps-reel-des-velin",
             "type": "url",
-            "url": "https://stce.transdev-hdf.fr/gbfs/",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/9c2ee44c-baed-41a8-860d-959c20ee9723",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/disponibilite-en-temps-reel-des-velin",
@@ -6006,7 +5751,6 @@
             "name": "reseau-de-transport-impulsyon-a-la-roche-sur-yon",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/735f1b54-94ee-4a21-b378-05c2b44ad70f",
-            "url-override": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/impulsyon/exports/medias.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-impulsyon-a-la-roche-sur-yon",
@@ -6031,7 +5775,7 @@
         {
             "name": "stations-trottinette-en-libre-service-de-la-roche-sur-yon",
             "type": "url",
-            "url": "https://gbfs.getapony.com/v1/la_roche_sur_yon/fr/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/b8ac4e2d-770e-40cf-9415-f5f78f8c7374",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/stations-trottinette-en-libre-service-de-la-roche-sur-yon",
@@ -6043,7 +5787,7 @@
         {
             "name": "stations-velo-en-libre-service-vls-de-la-roche-sur-yon",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/impulsyon/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/9db56b13-60a0-487e-aa06-0b20a4a18b99",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/stations-velo-en-libre-service-vls-de-la-roche-sur-yon",
@@ -6056,7 +5800,6 @@
             "name": "lignes-arrets-et-horaires-theorique-du-reseau-de-transport-gtfs-netex-saumur-val-de-loire-agglomeration",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/4c73f3c1-7f5a-4e38-b97d-75471bd47048",
-            "url-override": "https://mobi-iti-pdl.okina.fr/static/mobiiti_saumur_val_de_loire/gtfs_imported-id_saumur.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/lignes-arrets-et-horaires-theorique-du-reseau-de-transport-gtfs-netex-saumur-val-de-loire-agglomeration",
@@ -6070,7 +5813,6 @@
             "name": "horaires-theoriques-du-reseau-transport-du-pays-voironnais",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2ee1e02f-da22-4b86-8451-5ef67ae32cdd",
-            "url-override": "https://data.mobilites-m.fr/api/gtfs/TPV",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-transport-du-pays-voironnais",
@@ -6084,7 +5826,6 @@
             "name": "gtfs-urbain-de-la-zone-nord-cap-nord",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/82481c27-2e52-40ef-a563-b011ba487ead",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-urbain-de-la-zone-nord-cap-nord/20251226-144246/gtfs-nord-rtm.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-urbain-de-la-zone-nord-cap-nord",
@@ -6098,7 +5839,6 @@
             "name": "offre-de-transports-reseau-tac-annemasse-agglo",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/373e19e2-af0a-4939-9f33-3f1268d1e0bb",
-            "url-override": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/tp2a/exports/medias.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-reseau-tac-annemasse-agglo",
@@ -6136,7 +5876,6 @@
             "name": "thonon-agglomeration-donnees-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/7cbb883b-d0cb-4bc7-b2e0-7537afdbc86e",
-            "url-override": "https://static.data.gouv.fr/resources/thonon-agglomeration-donnees-gtfs/20260102-071718/2025.12.15-2026.02.08-gtfs-start.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/thonon-agglomeration-donnees-gtfs",
@@ -6150,7 +5889,6 @@
             "name": "reseau-lva",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/e0831d78-5577-4cae-aa00-de5eeaf3ecb6",
-            "url-override": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/vienne-mobi/exports/medias.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-lva",
@@ -6163,7 +5901,7 @@
         {
             "name": "reseau-lva",
             "type": "url",
-            "url": "https://feed-vienne-mobi.ratpdev.com/GTFS-RT/gtfs-rt.bin",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/4e87a135-b46e-46b3-8aaa-0233ec3c242a",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-lva",
                 "spdx-identifier": "ODbL-1.0"
@@ -6175,7 +5913,7 @@
         {
             "name": "reseau-lva",
             "type": "url",
-            "url": "https://notify.ratpdev.com/api/networks/VIENNE%20MOBI/alerts/gtfsrt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/1d919c39-41d4-4453-998c-9417c45b2f28",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-lva",
                 "spdx-identifier": "ODbL-1.0"
@@ -6188,7 +5926,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lib-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c521df03-4d5c-4b38-afee-ef6c0f43a491",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_du_libournais-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-lib-nva-m-1",
@@ -6201,7 +5938,7 @@
         {
             "name": "vls-ca-du-libournais-calivelo--82694",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/calivelo/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/badc250f-3b11-44d2-9275-d3a3f498a5d0",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/vls-ca-du-libournais-calivelo",
@@ -6213,7 +5950,7 @@
         {
             "name": "vls-ca-du-libournais-calivelo--82695",
             "type": "url",
-            "url": "https://mobi-iti-nam.okina.fr/api-proxy/api/gbfs/1.0/gbfs/calivelo_ecovelo/gbfs",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/345d5add-5ab1-431f-931b-bca18d3e80a0",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/vls-ca-du-libournais-calivelo",
@@ -6226,7 +5963,6 @@
             "name": "andemu-gtfs-2025",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/7213015d-a5b6-429d-84e8-c8c01e4cb84e",
-            "url-override": "https://static.data.gouv.fr/resources/andemu-gtfs-2025/20250529-153656/andemu-gtfs-2025.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/andemu-gtfs-2025",
@@ -6241,7 +5977,6 @@
             "name": "information-sur-les-transports-en-commun",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/3f08460c-8ec7-4b9e-a244-8855292b9e24",
-            "url-override": "https://static.data.gouv.fr/resources/information-sur-les-transports-en-commun/20250117-074102/gtfs-capa.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/information-sur-les-transports-en-commun",
@@ -6256,7 +5991,6 @@
             "name": "reseau-urbain-glazgo",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/4dc52cb9-909e-40dd-80e5-a90073bc80fc",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-glazgo/20260109-080828/gtfs-20260109-090528-glazgo.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-glazgo",
@@ -6281,7 +6015,7 @@
         {
             "name": "vls-aqta-auray-quiberon-terre-atlantique",
             "type": "url",
-            "url": "https://gbfs.partners.fifteen.eu/gbfs/auray-quiberon/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/5979a419-b655-4273-b63b-3015ce09adf8",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/vls-aqta-auray-quiberon-terre-atlantique",
@@ -6294,7 +6028,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-du-reseau-monrezo-cucm-gtfs-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/128b06bc-f263-4530-8e03-395402f87256",
-            "url-override": "https://static.data.gouv.fr/resources/arrets-horaires-et-parcours-theoriques-du-reseau-monrezo-cucm-gtfs-1/20250703-084245/gtfs-20250506-172037-cmt.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-du-reseau-monrezo-cucm-gtfs-1",
@@ -6308,7 +6041,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-axo-communaute-dagglomeration-creil-sud-oise--81072",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/0676f78f-66f9-4d37-a67e-0944ac5164e3",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=AXO&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-axo-communaute-dagglomeration-creil-sud-oise",
@@ -6322,7 +6054,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-axo-communaute-dagglomeration-creil-sud-oise--81645",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/23f2f5ed-c21c-4e87-840b-22512fe7c5d7",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/tad/download?provider=AXO&dataFormat=gtfs",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-axo-communaute-dagglomeration-creil-sud-oise",
@@ -6337,7 +6068,6 @@
             "name": "reseau-urbain-mat",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/3bd31fbe-93f4-432d-ade7-ee8d69897880",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-mat/20251202-131408/gtfs-02122025-au-05042026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-mat",
@@ -6351,7 +6081,6 @@
             "name": "donnees-gtfs-du-reseau-de-transport-public-cara-bus",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d4915904-ebd0-43cf-9b35-fbfc04ce91fd",
-            "url-override": "https://data.agglo-royan.fr/dataset/9b761974-a195-4e33-91b7-ecee3b368016/resource/d4915904-ebd0-43cf-9b35-fbfc04ce91fd/download/gtfs_20251204_151204_tdra.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-gtfs-du-reseau-de-transport-public-cara-bus",
@@ -6365,7 +6094,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-car-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/3af621da-a600-4da9-92c4-dfd994b22c31",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_royan_atlantique-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-car-nva-m-1",
@@ -6378,7 +6106,7 @@
         {
             "name": "velos-a-assistance-electrique-en-libre-service-saint-pierre-la-reunion-civis-altervelo",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/altervelo/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/2d36fc16-22c2-4aea-9e52-9aab45a8ec85",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-saint-pierre-la-reunion-civis-altervelo",
@@ -6391,7 +6119,6 @@
             "name": "donnees-statiques-et-temps-reels-reseau-envia",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/52216d2f-072e-4b7d-af0c-15d8d4e98b09",
-            "url-override": "https://static.data.gouv.fr/resources/donnees-statiques-et-temps-reels-reseau-envia/20260105-075346/gtfs-envia-20260105.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reels-reseau-envia",
@@ -6404,7 +6131,7 @@
         {
             "name": "donnees-statiques-et-temps-reels-reseau-envia",
             "type": "url",
-            "url": "https://accm.2cloud.app/api/gtfsrt/2.0/tripupdates/LUMIPLAN-2021-4815-1108/bin",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/9e97f7df-891f-4ae4-8d90-0e37dc822837",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reels-reseau-envia",
                 "spdx-identifier": "etalab-2.0"
@@ -6416,7 +6143,7 @@
         {
             "name": "donnees-statiques-et-temps-reels-reseau-envia",
             "type": "url",
-            "url": "https://accm.plateforme-2cloud.com/api/gtfsrt/2.0/tripupdates/ACCM-RSUD-4552-8552-5459/bin",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/af998ded-046f-458c-abb6-34eb110cad14",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-statiques-et-temps-reels-reseau-envia",
                 "spdx-identifier": "etalab-2.0"
@@ -6429,7 +6156,6 @@
             "name": "mobivie-reseau-urbain-vichy-communaute",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/4653683f-48a6-4f84-b313-058687fc5d04",
-            "url-override": "https://static.data.gouv.fr/resources/mobivie-reseau-urbain-vichy-communaute/20250813-081437/gtfs-01092025-31072026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/mobivie-reseau-urbain-vichy-communaute",
@@ -6442,7 +6168,7 @@
         {
             "name": "mobivie-reseau-urbain-vichy-communaute",
             "type": "url",
-            "url": "https://gtfs.bus-tracker.fr/gtfs-rt/vichy/trip-updates",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a58ae5d5-5415-4d45-b7a6-f07c2e6843aa",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/mobivie-reseau-urbain-vichy-communaute",
                 "spdx-identifier": "etalab-2.0"
@@ -6454,7 +6180,7 @@
         {
             "name": "velos-en-libre-service-vivelo",
             "type": "url",
-            "url": "https://gbfs.partners.fifteen.eu/gbfs/vichy/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/cde3a02c-8e59-410c-83a6-fa2858cb8a96",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-en-libre-service-vivelo",
@@ -6467,7 +6193,6 @@
             "name": "offre-de-transports-du-grand-albigeois-gtfs--79687",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/eff42667-b36b-4334-bc44-6cf620f90cbf",
-            "url-override": "https://static.data.gouv.fr/resources/offre-de-transports-du-grand-albigeois-gtfs/20251020-144525/gtfs-urbain.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-du-grand-albigeois-gtfs",
@@ -6481,7 +6206,6 @@
             "name": "offre-de-transports-du-grand-albigeois-gtfs--79728",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/15878ceb-7c8f-4546-bb0f-c540a15f2188",
-            "url-override": "https://static.data.gouv.fr/resources/offre-de-transports-du-grand-albigeois-gtfs/20260105-131900/libea-navettes.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-du-grand-albigeois-gtfs",
@@ -6495,7 +6219,6 @@
             "name": "offre-de-transports-du-grand-albigeois-gtfs--81522",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/79bc8313-3499-4bb3-a809-a8d80b44000a",
-            "url-override": "https://static.data.gouv.fr/resources/offre-de-transports-du-grand-albigeois-gtfs/20260116-151326/libea-reseau-periurbain.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-du-grand-albigeois-gtfs",
@@ -6509,7 +6232,6 @@
             "name": "fr-200052264-t0017-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80437/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0017-0000/fluo-grand-est-cc3f-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0017-0000-1",
@@ -6535,7 +6257,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-tic-interurbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d9ea4b4a-0717-4a7d-bd14-054afa192457",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=TIC_INT&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tic-interurbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
@@ -6548,7 +6269,7 @@
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-tic-interurbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
             "type": "url",
-            "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=TIC_INT&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/cc142542-5ceb-4685-a5d8-0f9a690a24c0",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tic-interurbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
                 "spdx-identifier": "etalab-2.0"
@@ -6561,7 +6282,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-tic-urbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/3a98dcdb-ca6e-40fc-8da9-09ab7f5661c9",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=TIC_URB&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tic-urbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
@@ -6574,7 +6294,7 @@
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-tic-urbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
             "type": "url",
-            "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=TIC_URB&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/cb580163-d9f8-4ba3-9abe-7d10a1a03691",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tic-urbain-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
                 "spdx-identifier": "etalab-2.0"
@@ -6587,7 +6307,6 @@
             "name": "donnees-theoriques-du-reseau-de-transport-a-la-demande-allotic-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2c64085e-8c3d-4bb6-b935-a4b6c0a2e550",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=ALLOTIC&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-de-transport-a-la-demande-allotic-communaute-dagglomeration-de-la-region-de-compiegne-et-de-la-basse-automne",
@@ -6601,7 +6320,6 @@
             "name": "sngo-vernon-les-andelys-seine-normandie-agglo",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80655/download",
-            "url-override": "https://static.data.gouv.fr/resources/sngo-vernon-les-andelys-seine-normandie-agglo/20260105-142455/pt-th-offer-sngo-gtfs-20260105-334-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/sngo-vernon-les-andelys-seine-normandie-agglo",
@@ -6627,7 +6345,6 @@
             "name": "donnees-tac-reseau-de-transport-de-grand-chatellerault-2025",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/1711bfbe-1b9d-4a10-85d9-dcf604213f66",
-            "url-override": "https://static.data.gouv.fr/resources/donnees-tac-reseau-de-transport-de-grand-chatellerault-2025/20251020-100448/gtfs-tac-20102025-05072026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-tac-reseau-de-transport-de-grand-chatellerault-2025",
@@ -6640,7 +6357,7 @@
         {
             "name": "donnees-tac-reseau-de-transport-de-grand-chatellerault-2025",
             "type": "url",
-            "url": "https://grand-chatellerault.plateforme-2cloud.com/api/gtfsrt/2.0/tripupdates/GCH-0910-7677-1418/bin",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/07a7288d-e549-47d0-af02-425f874a2fdf",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-tac-reseau-de-transport-de-grand-chatellerault-2025",
                 "spdx-identifier": "etalab-2.0"
@@ -6652,7 +6369,7 @@
         {
             "name": "grand-chatellerault",
             "type": "url",
-            "url": "https://www.mobility-parc.net/gbfs/v3/CHATELLERAULT/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/cc0b027f-d5d4-4c48-8541-cd15dc646bea",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/grand-chatellerault",
@@ -6665,7 +6382,6 @@
             "name": "reseau-urbain-ville-de-vitre--83019",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c7b620bf-e0c5-4f81-a34b-9c8d02c6e3a4",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-ville-de-vitre/20250425-133101/20-gtfs-urbain-vitre-ete-2025.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-ville-de-vitre",
@@ -6680,7 +6396,6 @@
             "name": "reseau-urbain-ville-de-vitre--83276",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/282974b2-bf13-41f2-a0bf-feb0682e594e",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-ville-de-vitre/20250724-070907/05-gtfs-urbain-vitre-chateaubourg-sept25-v05.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-ville-de-vitre",
@@ -6694,7 +6409,6 @@
             "name": "reseau-urbain-ville-de-vitre--83280",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/bf176d3d-c487-40f9-a823-68279395f2ab",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-ville-de-vitre/20250716-121402/planning.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-ville-de-vitre",
@@ -6708,7 +6422,6 @@
             "name": "tam-horaires-theoriques-du-reseau-de-transport-urbain-sur-la-ville-damberieu-en-bugey",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/317b003c-dca6-4908-8829-6d2842a5f47c",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=TAM&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tam-horaires-theoriques-du-reseau-de-transport-urbain-sur-la-ville-damberieu-en-bugey",
@@ -6722,7 +6435,6 @@
             "name": "gtfs-capbus",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/8ce8ad14-836e-427d-bb43-a6ce0ab5ecda",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=agdecapbus68429531",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-capbus",
@@ -6736,7 +6448,7 @@
         {
             "name": "gtfs-capbus",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=agdecapbus68429531",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/7dab24f0-3114-49b9-827d-376d10a4b193",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-capbus",
                 "spdx-identifier": "etalab-2.0"
@@ -6751,7 +6463,6 @@
             "name": "gtfs-de-la-societe-de-transport-urbain-du-grand-montauban-semtm",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/969c7483-e3d3-4ec2-b11d-db20105e9600",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-de-la-societe-de-transport-urbain-du-grand-montauban-semtm/20251215-085859/gtfs-dec25-v3.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-de-la-societe-de-transport-urbain-du-grand-montauban-semtm",
@@ -6765,7 +6476,6 @@
             "name": "transports-urbains-soissonnais-tus",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b66f3a43-2ba1-4b61-8459-439104582a92",
-            "url-override": "https://static.data.gouv.fr/resources/transports-urbains-soissonnais-tus/20251217-151951/transports-urbains-soissonnais-tus-v01-2025-gtfs-2025-12-17-09-31-08.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transports-urbains-soissonnais-tus",
@@ -6779,7 +6489,6 @@
             "name": "donnees-gtfs-reseau-tuc-communaute-dagglomeration-de-cambrai",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d00d1684-6980-4f84-ac38-363b6f058a68",
-            "url-override": "https://static.data.gouv.fr/resources/donnees-gtfs-reseau-tuc-communaute-dagglomeration-de-cambrai/20251114-082013/rhdf-gtfs-cac-tuc-14-11-2025.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-gtfs-reseau-tuc-communaute-dagglomeration-de-cambrai",
@@ -6793,7 +6502,6 @@
             "name": "ctlb-donnees-theoriques-et-rt-aix-les-bains-lac-du-bourget",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b4e8d98c-e17a-4fb0-857f-8cb618039b2a",
-            "url-override": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/ctlb-aix-les-bains/exports/medias.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/ctlb-donnees-theoriques-et-rt-aix-les-bains-lac-du-bourget",
@@ -6831,7 +6539,6 @@
             "name": "offre-de-transport-du-reseau-trema-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2c2b58d3-e93b-47af-be7b-655520671cbc",
-            "url-override": "https://static.data.gouv.fr/resources/offre-de-transport-du-reseau-trema-gtfs/20251015-151314/trema-gtfs-2025-10-15.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-trema-gtfs",
@@ -6845,7 +6552,6 @@
             "name": "bus-pastel-saint-quentin",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/42e3ea9d-251e-47c1-988d-f7227f0e2d0f",
-            "url-override": "https://static.data.gouv.fr/resources/bus-pastel-saint-quentin/20251230-130818/gtfs-20251204-171737-sqm.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/bus-pastel-saint-quentin",
@@ -6859,7 +6565,6 @@
             "name": "offre-de-transport-du-reseau-libellus-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/70c9f936-129e-41f4-940a-8e6f272535d1",
-            "url-override": "https://static.data.gouv.fr/resources/offre-de-transport-du-reseau-libellus-gtfs/20260108-095309/08012026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-libellus-gtfs",
@@ -6873,7 +6578,6 @@
             "name": "fr-200052264-t0005-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80457/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0005-0000/fluo-grand-est-cec-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0005-0000-1",
@@ -6899,7 +6603,6 @@
             "name": "reseau-urbain-scolaire-lila-presquile",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/83762/download",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-scolaire-lila-presquile/20260115-125839/gtfs-20260114-144057-capatlantique.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-scolaire-lila-presquile",
@@ -6961,7 +6664,6 @@
             "name": "reseau-urbain-le-passe-pont-communes-de-couffouleux-et-de-rabastens",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/6f4deabd-1cad-435c-8915-235132d74291",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-le-passe-pont-communes-de-couffouleux-et-de-rabastens/20250904-131713/gtfs-passe-pont.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-le-passe-pont-communes-de-couffouleux-et-de-rabastens",
@@ -6975,7 +6677,6 @@
             "name": "fr-200052264-t0038-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80445/download",
-            "url-override": "https://exs.grandest2.cityway.fr/GTFS.aspx?Key=OPENDATA&OperatorCode=LEFIL",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0038-0000-1",
@@ -7015,7 +6716,6 @@
             "name": "fr-200052264-t0007-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80467/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0007-0000/fluo-grand-est-forbus-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0007-0000-1",
@@ -7040,7 +6740,7 @@
         {
             "name": "bird-trottinettes-en-libre-service-a-ajaccio-gbfs",
             "type": "url",
-            "url": "https://mds.bird.co/gbfs/v2/public/provider/bird/ajaccio/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/eb9956df-76f1-4011-81c0-221e41dfb9dc",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/bird-trottinettes-en-libre-service-a-ajaccio-gbfs",
@@ -7053,7 +6753,6 @@
             "name": "donnee-statistiques-transport",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/cc0e964e-2021-4b2d-8bde-05c8b493a248",
-            "url-override": "https://static.data.gouv.fr/resources/donnee-statistiques-transport/20251014-151130/tsud-gtfs-10-10-2025-032912.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnee-statistiques-transport",
@@ -7067,7 +6766,6 @@
             "name": "offre-de-transport-ca-du-bocage-bressuirais-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/414c049b-323a-4a5c-b484-e3917a62f485",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_bocage_bressuirais-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-ca-du-bocage-bressuirais-1",
@@ -7081,7 +6779,6 @@
             "name": "reseau-urbain-scolaire-guingamp-paimpol-mobilite",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/52057eec-3786-444c-8696-8473c4c6888e",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-scolaire-guingamp-paimpol-mobilite/20250827-210113/gtfs-20250827-225938-gpmobi.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-scolaire-guingamp-paimpol-mobilite",
@@ -7110,7 +6807,6 @@
             "name": "fr-200052264-t0016-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80453/download",
-            "url-override": "https://exs.grandest2.cityway.fr/GTFS.aspx?Key=OPENDATA&OperatorCode=DEOBUS",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0016-0000-1",
@@ -7148,7 +6844,6 @@
             "name": "offre-de-transport-coban",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/88be32ef-3b1a-493f-b73f-660a1f1b24f7",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/coban-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-coban",
@@ -7162,7 +6857,6 @@
             "name": "astrobus-lisieux-normandie",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/82140/download",
-            "url-override": "https://static.data.gouv.fr/resources/astrobus-lisieux-normandie/20260105-143252/pt-th-offer-astrobus-gtfs-20260102-871-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/astrobus-lisieux-normandie",
@@ -7188,7 +6882,6 @@
             "name": "horaires-reseau-zest",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/72609821-2459-47fb-a63b-3dbbc0d96c92",
-            "url-override": "https://static.data.gouv.fr/resources/horaires-reseau-zest/20251023-153623/gtfs-23-10-2025-08-03.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-reseau-zest",
@@ -7217,7 +6910,6 @@
             "name": "reseau-yego-macs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c5c0943e-0830-46ac-ba18-0d95a7227a4a",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-yego-macs/20250921-050658/gtfs-yego.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-yego-macs",
@@ -7231,7 +6923,6 @@
             "name": "le-37-horaires-theoriques-du-reseau-de-transport-urbain-de-la-communaute-de-communes-entre-bievre-et-rhone",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/83725/download",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=PEAGE_ROUSSILLON&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/le-37-horaires-theoriques-du-reseau-de-transport-urbain-de-la-communaute-de-communes-entre-bievre-et-rhone",
@@ -7245,7 +6936,6 @@
             "name": "offre-de-transport-cobas",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/9564e981-7d13-481d-a29f-452025af7432",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/cobas-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-cobas",
@@ -7259,7 +6949,6 @@
             "name": "reseau-urbain-distribus",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/148bf3a3-792f-44e2-9757-e0cc0d83afae",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-distribus/20251204-105701/gtfs-20251204-115142-distribus.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-distribus",
@@ -7272,7 +6961,7 @@
         {
             "name": "reseau-urbain-distribus",
             "type": "url",
-            "url": "http://h21.hanoverdisplays.com:52320/api-1.0/gtfs-rt/trip-updates",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/9c744022-049a-4bb9-a97f-acfe6425d60a",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-distribus",
                 "spdx-identifier": "ODbL-1.0"
@@ -7285,7 +6974,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cog-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/7a0c4ec1-628d-4b72-b180-f0c2e750112f",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_grand_cognac-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-cog-nva-m-1",
@@ -7299,7 +6987,6 @@
             "name": "horaires-montelibus-2025-2026",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/974cede8-3a14-4c7b-b94d-b2655c31932e",
-            "url-override": "https://static.data.gouv.fr/resources/horaires-montelibus-2025-2026/20260102-150553/gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-montelibus-2025-2026",
@@ -7325,7 +7012,6 @@
             "name": "horaires-rlv-mobilites",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/90846819-b970-48db-967b-8eb7d2da3e2c",
-            "url-override": "https://static.data.gouv.fr/resources/horaires-rlv-mobilites/20251210-131134/gtfs-25-12-15-au-26-08-30-avec-lignes-rlv-smtc.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-rlv-mobilites",
@@ -7351,7 +7037,6 @@
             "name": "reseau-de-transports-en-commun-de-la-communaute-dagglomeration-de-lauxerrois",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/78934/download",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-de-transports-en-commun-de-la-communaute-dagglomeration-de-lauxerrois/20251222-213043/2025.12.21-gtfs-mdma.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transports-en-commun-de-la-communaute-dagglomeration-de-lauxerrois",
@@ -7376,7 +7061,7 @@
         {
             "name": "reseau-de-transports-en-commun-de-la-communaute-dagglomeration-de-lauxerrois",
             "type": "url",
-            "url": "https://leo.plateforme-2cloud.com/api/gtfsrt/2.0/tripUpdates/LEO-6547-2543-6895?&format=bin&network=AURMLEBUS",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/8ce98543-0431-419e-811b-b1afa129a6c9",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transports-en-commun-de-la-communaute-dagglomeration-de-lauxerrois",
                 "spdx-identifier": "etalab-2.0"
@@ -7389,7 +7074,6 @@
             "name": "versions-des-horaires-theoriques-des-lignes-du-reseau-de-bus-au-format-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/0b65dda9-51d3-4d84-811b-8a11629a5e55",
-            "url-override": "https://static.data.gouv.fr/resources/versions-des-horaires-theoriques-des-lignes-du-reseau-de-bus-au-format-gtfs/20251103-131706/gtfs-v2-201025-030726.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/versions-des-horaires-theoriques-des-lignes-du-reseau-de-bus-au-format-gtfs",
@@ -7403,7 +7087,6 @@
             "name": "transport-scolaire-redon-agglomeration-format-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/342f132a-055a-45dd-a50a-6bef89c58444",
-            "url-override": "https://static.data.gouv.fr/resources/transport-scolaire-redon-agglomeration-format-gtfs/20250521-093604/gtfs-20250520190316z.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transport-scolaire-redon-agglomeration-format-gtfs",
@@ -7417,7 +7100,6 @@
             "name": "reseau-urbain-de-redon-agglomeration",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/83512/download",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-de-redon-agglomeration/20251017-090411/518-20251014.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-de-redon-agglomeration",
@@ -7431,7 +7113,6 @@
             "name": "lineotim-morlaix-communaute",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/6866358a-cb32-451b-8a88-067f704cc770",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/LINEOTIM_Complet.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/lineotim-morlaix-communaute",
@@ -7445,7 +7126,6 @@
             "name": "transports-urbains-bandol-sanary-s-mer",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/358ab51c-78e8-45a4-ae5a-a05722af6c09",
-            "url-override": "https://static.data.gouv.fr/resources/transports-urbains-bandol-sanary-s-mer/20250414-071645/gtfs-cassb-bandol-sanary-2025.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transports-urbains-bandol-sanary-s-mer",
@@ -7460,7 +7140,6 @@
             "name": "reseau-ca2bm-a-compter-du-1er-juin-2025",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/db348d20-dc9a-48c7-8120-30afa160a921",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-ca2bm-a-compter-du-1er-juin-2025/20250807-070026/ca2bm-lignes-regulieres-v8-ter-rectif-calendriers-navettes-jf-16-07-2025-gtfs-2025-08-07-08-59-13.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-ca2bm-a-compter-du-1er-juin-2025",
@@ -7474,7 +7153,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-roc-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/0346e2ae-a004-40be-8ded-ffff9046d29d",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_rochefort_ocean-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-roc-nva-m-1",
@@ -7488,7 +7166,6 @@
             "name": "reseau-de-transport-en-commun-trans-agglo-de-dlva",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/37f08652-500d-488e-a47f-8c9efc5ae704",
-            "url-override": "https://www.datasud.fr/fr/dataset/datasets/3941/resource/5123/download/",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-en-commun-trans-agglo-de-dlva",
@@ -7503,7 +7180,6 @@
             "name": "horaires-theoriques-du-reseau-tgl",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/8a839ea6-21f5-4503-a8e1-05fe0fd2aa8e",
-            "url-override": "https://static.data.gouv.fr/resources/horaires-theoriques-du-reseau-tgl/20250626-071202/tgl-septembre-2025-gtfs-2025-06-19-11-17-07.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-tgl",
@@ -7529,7 +7205,6 @@
             "name": "gtfs-reseau-arc-en-ciel-secteur-nord-perimetre-caudresis-catesis",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/83396/download",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-reseau-arc-en-ciel-secteur-nord-perimetre-caudresis-catesis/20250911-075554/gtfs-com-sco-59-p3b.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-reseau-arc-en-ciel-secteur-nord-perimetre-caudresis-catesis",
@@ -7543,7 +7218,6 @@
             "name": "fr-200052264-t0001-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80469/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0001-0000/fluo-grand-est-cabus-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0001-0000-1",
@@ -7557,7 +7231,6 @@
             "name": "offre-de-transports-urbain-du-reseau-amelys-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/39240e80-d3f4-4702-ba93-520fae414649",
-            "url-override": "https://static.data.gouv.fr/resources/offre-de-transports-urbain-du-reseau-amelys-gtfs/20251203-162444/gtfs-28-11-2025-05-07-2026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-urbain-du-reseau-amelys-gtfs",
@@ -7571,7 +7244,6 @@
             "name": "via-bastia-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f88dae7d-cf93-4a4b-aa82-9256d5f3cefc",
-            "url-override": "https://static.data.gouv.fr/resources/via-bastia-1/20241015-092049/viabastia-viabastia-v6-3-gtfs-2024-10-15-09-30-39.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/via-bastia-1",
@@ -7586,7 +7258,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-pass-thelle-bus-communaute-de-communes-thelloise--81068",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/44f6333d-58ab-4e0c-965e-5349d6d1cdcd",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=PASSTHELLE&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-pass-thelle-bus-communaute-de-communes-thelloise",
@@ -7600,7 +7271,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-pass-thelle-bus-communaute-de-communes-thelloise--81648",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2aeffed5-95e9-4587-a8f8-f52c32968566",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/tad/download?provider=PASSTHELLE&dataFormat=gtfs",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-pass-thelle-bus-communaute-de-communes-thelloise",
@@ -7615,7 +7285,6 @@
             "name": "offre-de-transport-ca-bergeracoise-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f5437c89-50b3-4d35-8d38-be8b9417f7a0",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_bergeracoise-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-ca-bergeracoise-1",
@@ -7629,7 +7298,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-vdg-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/4ea5fb1f-3b42-4bc4-a255-303250fca10d",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_val_de_garonne-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-vdg-nva-m-1",
@@ -7643,7 +7311,6 @@
             "name": "horaires-theoriques-et-temps-reel-du-reseau-buss-saintes-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f2d4be3b-50bc-4f9b-9818-30860890a864",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=buss-cdasaintes",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-buss-saintes-gtfs-gtfs-rt",
@@ -7656,7 +7323,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-du-reseau-buss-saintes-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=buss-cdasaintes",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/47aa1c93-4868-47da-ae43-e2fcbce3575f",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-buss-saintes-gtfs-gtfs-rt",
                 "spdx-identifier": "ODbL-1.0"
@@ -7669,7 +7336,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-sai-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/33f62e9d-5495-413e-ae74-070e52ab51f7",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_saintes-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-sai-nva-m-1",
@@ -7683,7 +7349,6 @@
             "name": "horaires-du-reseau-de-bus-intercom-3",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/5f2edbfa-9025-467d-b769-80f4b1ec4ba6",
-            "url-override": "https://static.data.gouv.fr/resources/horaires-du-reseau-de-bus-intercom-3/20251107-113750/gtfs-20251107-123001-open-data.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-du-reseau-de-bus-intercom-3",
@@ -7697,7 +7362,6 @@
             "name": "horaires-theoriques-du-reseau-maelis-montlucon-communaute-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/1ee93a61-23e0-49f0-bf76-b5c367d5e42c",
-            "url-override": "https://static.data.gouv.fr/resources/horaires-theoriques-du-reseau-maelis-montlucon-communaute-gtfs/20251014-145324/gtfs-2025-10-13-au-2026-07-05.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-maelis-montlucon-communaute-gtfs",
@@ -7711,7 +7375,6 @@
             "name": "uba-horaires-navettes-maritimes",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/83747/download",
-            "url-override": "https://static.data.gouv.fr/resources/uba-horaires-navettes-maritimes/20251209-094310/uniondes-arcachon-fr.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/uba-horaires-navettes-maritimes",
@@ -7725,7 +7388,6 @@
             "name": "lignes-arrets-et-horaires-theorique-du-reseau-de-transport-gtfs-et-netex-les-sables-dolonne-agglomeration",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d5920d40-ea72-4e22-b506-2ca583950282",
-            "url-override": "https://mobi-iti-pdl.okina.fr/static/mobiiti_les_sables_d_olonne/gtfs_imported-id_oleane.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/lignes-arrets-et-horaires-theorique-du-reseau-de-transport-gtfs-et-netex-les-sables-dolonne-agglomeration",
@@ -7739,7 +7401,6 @@
             "name": "reseau-couralin-grand-dax-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/3a010c2b-67da-404c-8cbb-85e62cae129c",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-couralin-grand-dax-1/20250921-051709/gtfs-couralin.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-couralin-grand-dax-1",
@@ -7753,7 +7414,6 @@
             "name": "tbk-offre-theorique-et-temps-reel-du-reseau-de-transports-du-pays-de-quimperle",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/e530ec1c-7432-4c3a-9908-e1c5fb44de3a",
-            "url-override": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/tbk/exports/gtfs-complet.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tbk-offre-theorique-et-temps-reel-du-reseau-de-transports-du-pays-de-quimperle",
@@ -7766,7 +7426,7 @@
         {
             "name": "tbk-offre-theorique-et-temps-reel-du-reseau-de-transports-du-pays-de-quimperle",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/quimperle/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/45279e49-9224-47a9-aafc-cd62623fb84d",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tbk-offre-theorique-et-temps-reel-du-reseau-de-transports-du-pays-de-quimperle",
                 "spdx-identifier": "etalab-2.0"
@@ -7791,7 +7451,6 @@
             "name": "reseau-transport-urbain-du-nord-grande-terre-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/dbfbff0f-46b6-44d5-a4d4-60d4ac645026",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-transport-urbain-du-nord-grande-terre-1/20250430-143341/urbain-cangt-v6-1-gtfs-2025-04-09-30.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-transport-urbain-du-nord-grande-terre-1",
@@ -7805,7 +7464,6 @@
             "name": "cherpa-horaires-lignes-regulieres",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/7d54a219-8fe7-4635-a9fc-cefe5e57462e",
-            "url-override": "https://static.data.gouv.fr/resources/cherpa-horaires-lignes-regulieres/20251218-155013/gtfs-cherpa-20251215-au-20260831.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/cherpa-horaires-lignes-regulieres",
@@ -7818,7 +7476,7 @@
         {
             "name": "cherpa-horaires-lignes-regulieres",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?src=true&dataset=agglopaysdissoire",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/bbc60d61-bf8f-40ec-9e3b-9c040cc2b06e",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/cherpa-horaires-lignes-regulieres",
                 "spdx-identifier": "etalab-2.0"
@@ -7831,7 +7489,6 @@
             "name": "transport-du-reseau-urbain-agglobus-et-de-transports-scolaires-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f17028a4-61ff-4b84-8856-f7c8937a2c28",
-            "url-override": "https://static.data.gouv.fr/resources/transport-du-reseau-urbain-agglobus-et-de-transports-scolaires-gtfs/20251229-134738/gtfs-rodezagglo.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transport-du-reseau-urbain-agglobus-et-de-transports-scolaires-gtfs",
@@ -7845,7 +7502,6 @@
             "name": "reseau-urbain-surf",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/665d6c43-598d-4d9d-aa98-206072f4dfa0",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-surf/20250926-080752/gtfs-20250926-100314-surf.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-surf",
@@ -7871,7 +7527,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-mdm-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/03ebd538-f9be-4eb5-ab22-2b72a0ea338c",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_du_marsan-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-mdm-nva-m-1",
@@ -7885,7 +7540,6 @@
             "name": "fr-200052264-t0010-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80477/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0010-0000/fluo-grand-est-sdz-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0010-0000-1",
@@ -7899,7 +7553,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-mobi-communaute-de-communes-du-pays-de-valois",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ad0a4757-eb8a-4c06-b459-51442466d5c4",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=CYPRE&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-mobi-communaute-de-communes-du-pays-de-valois",
@@ -7912,7 +7565,7 @@
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-mobi-communaute-de-communes-du-pays-de-valois",
             "type": "url",
-            "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=CYPRE&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a67e47a4-f718-49c9-b763-be81f91e15ce",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-mobi-communaute-de-communes-du-pays-de-valois",
                 "spdx-identifier": "etalab-2.0"
@@ -7925,7 +7578,6 @@
             "name": "gtfs-reseau-cmonbus",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/a6a32465-7366-47dc-a6fc-96f1d52b09d8",
-            "url-override": "https://app.pysae.com/api/v2/groups/cavaillon/gtfs/pub",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-reseau-cmonbus",
@@ -7938,7 +7590,7 @@
         {
             "name": "gtfs-reseau-cmonbus",
             "type": "url",
-            "url": "https://app.pysae.com/api/v2/groups/cavaillon/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/cc043d19-1258-433c-9d55-5c62fef2d038",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-reseau-cmonbus",
                 "spdx-identifier": "etalab-2.0"
@@ -7951,7 +7603,6 @@
             "name": "reseau-de-transport-du-grand-dole",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/81254/download",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-de-transport-du-grand-dole/20260113-075744/gtfs-dole.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-du-grand-dole",
@@ -7977,7 +7628,6 @@
             "name": "gtfs-du-reseau-lyneo",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/6b80d2f2-ecd4-4b52-b481-c8b715ae8948",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-du-reseau-lyneo/20251226-105541/gtfs-reseau-lyneo-26-12-2025.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-du-reseau-lyneo",
@@ -7990,7 +7640,6 @@
         {
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/9ffc26b2-d293-4ec5-9cf6-4690d542f019",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-transport-urbain-de-bernay/20251114-113532/horaires-ibus-2025-2026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-transport-urbain-de-bernay",
@@ -8003,7 +7652,7 @@
         {
             "name": "reseau-transport-urbain-de-bernay",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?src=true&dataset=bernay",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/622b4abe-e029-4a6b-bd59-ef849e9b005f",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-transport-urbain-de-bernay",
                 "spdx-identifier": "etalab-2.0"
@@ -8016,7 +7665,6 @@
             "name": "transport-urbain",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/34972a83-5b0f-4f99-b9b7-19593a4c6e1d",
-            "url-override": "https://static.data.gouv.fr/resources/transport-urbain/20250625-121550/tu-v2.0-01072025-30062026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transport-urbain",
@@ -8030,7 +7678,6 @@
             "name": "offre-de-transport-du-reseau-rivconnect-communaute-de-communes-rives-de-moselle",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/83277/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0056-0000/fluo-grand-est-riv-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-rivconnect-communaute-de-communes-rives-de-moselle",
@@ -8056,7 +7703,6 @@
             "name": "reseau-nemus",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/e833d9ed-201b-4154-aa16-45bc00939571",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-nemus/20250903-121926/gtfs-030925.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-nemus",
@@ -8069,7 +7715,7 @@
         {
             "name": "reseau-nemus",
             "type": "url",
-            "url": "https://flers-agglo.plateforme-2cloud.com/api/gtfsrt/2.0/tripupdates/FLERS-5197-3181-6523/bin?network=FA",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a16f63fd-32d2-42ef-9e58-7b616ecf7252",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-nemus",
                 "spdx-identifier": "etalab-2.0"
@@ -8094,7 +7740,6 @@
             "name": "gtfs-move-vendome",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c85977b8-7d18-439c-935c-935286503003",
-            "url-override": "https://app.pysae.com/api/v2/groups/vendome/gtfs/676e649e1b7a2efbadbbe403",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-move-vendome",
@@ -8107,7 +7752,7 @@
         {
             "name": "gtfs-move-vendome",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/vendome/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/68fc6b99-b51c-4a3c-9740-2edbc4a705bf",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-move-vendome",
                 "spdx-identifier": "etalab-2.0"
@@ -8120,7 +7765,6 @@
             "name": "coralie-concarneau-cornouaille-agglomeration-transport",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/becd68ea-3e7a-4336-b14a-dc3bdcf493c2",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/CORALIE.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/coralie-concarneau-cornouaille-agglomeration-transport",
@@ -8134,7 +7778,6 @@
             "name": "fr-200052264-t0015-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/82413/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0015-0000/fluo-grand-est-transavold-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0015-0000-1",
@@ -8159,7 +7802,7 @@
         {
             "name": "bycor-vaels-ouest-rhodanien",
             "type": "url",
-            "url": "https://www.mobility-parc.net/gbfs/v3/TARARE/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/67a68efd-ff91-4cbc-a8f6-8bdc2bb2fb64",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/bycor-vaels-ouest-rhodanien",
@@ -8172,7 +7815,6 @@
             "name": "horaires-theoriques-et-temps-reels-du-reseau-de-transports-lagglo-en-bus-communaute-dagglomeration-gap-tallard-durance",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/78b7910e-1e31-4f47-b0a8-949647205ffa",
-            "url-override": "https://gtfs-rt.infra-hubup.fr/cagtd/current/revision/gtfs",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reels-du-reseau-de-transports-lagglo-en-bus-communaute-dagglomeration-gap-tallard-durance",
@@ -8185,7 +7827,7 @@
         {
             "name": "horaires-theoriques-et-temps-reels-du-reseau-de-transports-lagglo-en-bus-communaute-dagglomeration-gap-tallard-durance",
             "type": "url",
-            "url": "https://gtfs-rt.infra-hubup.fr/cagtd/realtime",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/11f653e9-0d6a-4e87-8cda-3069b3c6b441",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reels-du-reseau-de-transports-lagglo-en-bus-communaute-dagglomeration-gap-tallard-durance",
                 "spdx-identifier": "etalab-2.0"
@@ -8198,7 +7840,6 @@
             "name": "offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c00d487c-4766-4ca1-b736-e7de110331d9",
-            "url-override": "https://static.data.gouv.fr/resources/offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs/20251230-134445/gtfs-30-12-2025-04-15.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-de-la-c-a-beaune-cote-sud-gtfs",
@@ -8224,7 +7865,6 @@
             "name": "gtfs-transports-a-la-demande-tad-coqueligo",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/5e4b3c12-dd7d-4dcf-a761-41024867e56d",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-transports-a-la-demande-tad-coqueligo/20250326-140933/coqueligo-coqueligo-tad-v3-gtfs-2025-03-26-15-08-21.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-transports-a-la-demande-tad-coqueligo",
@@ -8238,7 +7878,6 @@
             "name": "ar-bus-landerneau-daoulas-transport",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/80fc7c72-e21e-4458-a692-9da58db27566",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/ARBUS.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/ar-bus-landerneau-daoulas-transport",
@@ -8251,7 +7890,7 @@
         {
             "name": "ar-bus-landerneau-daoulas-transport",
             "type": "url",
-            "url": "https://www.korrigo.bzh/ftp/OPENDATA/gtfsrt/ARBUS.GtfsRt.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/613f9061-2d91-4a59-bc9b-26b69428ff87",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/ar-bus-landerneau-daoulas-transport",
                 "spdx-identifier": "ODbL-1.0"
@@ -8263,7 +7902,7 @@
         {
             "name": "ti-velo-1",
             "type": "url",
-            "url": "https://gbfs.partners.fifteen.eu/gbfs/2.2/landerneau/en/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/e32b6154-ab60-4eca-8271-0ce846c7bace",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/ti-velo-1",
@@ -8275,7 +7914,7 @@
         {
             "name": "bird-trottinettes-en-libre-service-a-laval-gbfs",
             "type": "url",
-            "url": "https://mds.bird.co/gbfs/v2/public/provider/bird/laval/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/49199c12-7d39-4b18-bae0-190cc5d7c8e7",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/bird-trottinettes-en-libre-service-a-laval-gbfs",
@@ -8287,7 +7926,7 @@
         {
             "name": "velos-a-assistance-electrique-en-libre-service-sables-dolonne-les-petites-reines",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/petitesreines/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/2c6fe2ac-f09a-4334-8857-6600ceb86c0f",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-sables-dolonne-les-petites-reines",
@@ -8300,7 +7939,6 @@
             "name": "elios-transports-urbains-du-grand-villeneuvois",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/9248b0d3-3675-491b-8990-8058f0fdbcb5",
-            "url-override": "https://static.data.gouv.fr/resources/elios-transports-urbains-du-grand-villeneuvois/20250902-085502/gtfs-elios-grand-villeneuvois-septembre-2025.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/elios-transports-urbains-du-grand-villeneuvois",
@@ -8314,7 +7952,6 @@
             "name": "regie-des-transports-baag-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/47ead4b7-dc95-41f0-916a-7411d9f6b79b",
-            "url-override": "https://static.data.gouv.fr/resources/regie-des-transports-baag-gtfs/20251217-131705/gtfs-baag-17122025.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/regie-des-transports-baag-gtfs",
@@ -8328,7 +7965,6 @@
             "name": "cosibus-coutances-mer-et-bocage",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/82312/download",
-            "url-override": "https://static.data.gouv.fr/resources/cosibus-coutances-mer-et-bocage/20250819-074628/pt-th-offer-cosibus-gtfs-20250703-923-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/cosibus-coutances-mer-et-bocage",
@@ -8341,7 +7977,7 @@
         {
             "name": "bird-trottinettes-en-libre-service-a-bastia-gbfs",
             "type": "url",
-            "url": "https://mds.bird.co/gbfs/v2/public/provider/bird/bastia/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/3153d7ae-b000-4cef-a4b9-89c30c9d3390",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/bird-trottinettes-en-libre-service-a-bastia-gbfs",
@@ -8354,7 +7990,6 @@
             "name": "offre-de-transport-cc-montesquieu",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/fd030551-a63e-441a-98f0-231186f35d82",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/montesquieu-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-cc-montesquieu",
@@ -8368,7 +8003,6 @@
             "name": "gtfs-periodes-scolaires",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/0602751c-36aa-445d-88e2-aa4c51c13205",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-periodes-scolaires/20251212-184356/gtfs-cluses-12122025-19042026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-periodes-scolaires",
@@ -8382,7 +8016,6 @@
             "name": "fr-200052264-t0012-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80443/download",
-            "url-override": "https://exs.grandest2.cityway.fr/GTFS.aspx?Key=OPENDATA&OperatorCode=EPY",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0012-0000-1",
@@ -8408,7 +8041,6 @@
             "name": "deepmob-dieppe-maritime",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80680/download",
-            "url-override": "https://static.data.gouv.fr/resources/deepmob-dieppe-maritime/20251215-143305/pt-th-offer-deepmob-gtfs-20251215-334-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/deepmob-dieppe-maritime",
@@ -8434,7 +8066,6 @@
             "name": "tiva-scolaire-secondaires-intravire-intercom-de-la-vire-au-noireau-2025-2026",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/4d6b5107-fec7-41bb-9115-bbaafb7e71f1",
-            "url-override": "https://static.data.gouv.fr/resources/tiva-scolaire-secondaires-intravire-intercom-de-la-vire-au-noireau-2025-2026/20251217-180553/sco.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tiva-scolaire-secondaires-intravire-intercom-de-la-vire-au-noireau-2025-2026",
@@ -8448,7 +8079,6 @@
             "name": "tiva-intercom-de-la-vire-au-noireau",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/82316/download",
-            "url-override": "https://static.data.gouv.fr/resources/amibus-intercom-de-la-vire-au-noireau/20240927-093538/pt-th-offer-amibus-gtfs-20240817-303-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tiva-intercom-de-la-vire-au-noireau",
@@ -8462,7 +8092,6 @@
             "name": "tiva-a-la-demande-service-de-transport-a-la-demande-intercom-de-la-vire-au-noireau-2025-2026",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f3b71a3c-85fd-48c3-a3f0-30b988a4e64b",
-            "url-override": "https://static.data.gouv.fr/resources/tiva-a-la-demande-service-de-transport-a-la-demande-intercom-de-la-vire-au-noireau-2025-2026/20251208-170106/tiva-a-la-demande.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tiva-a-la-demande-service-de-transport-a-la-demande-intercom-de-la-vire-au-noireau-2025-2026",
@@ -8476,7 +8105,6 @@
             "name": "reseau-urbain-pondibus",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/57c8ace6-014d-40cd-b2b5-a9c630f87123",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-pondibus/20250830-111837/gtfs-20250830-130434-pondibus.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-pondibus",
@@ -8489,7 +8117,7 @@
         {
             "name": "reseau-urbain-pondibus",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/pondibus/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/365ca136-0b94-4c28-9931-a812e792e108",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-pondibus",
                 "spdx-identifier": "ODbL-1.0"
@@ -8502,7 +8130,6 @@
             "name": "horaires-theoriques-et-temps-reel-du-reseau-titus-rosny-sous-bois-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ed7049d4-4063-457c-ab65-4a26c640e0a1",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=reseau-titus",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-titus-rosny-sous-bois-gtfs-gtfs-rt",
@@ -8515,7 +8142,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-du-reseau-titus-rosny-sous-bois-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=reseau-titus",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/7dd97f96-2fb2-4647-8498-ef234ed0faaa",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-titus-rosny-sous-bois-gtfs-gtfs-rt",
                 "spdx-identifier": "ODbL-1.0"
@@ -8528,7 +8155,6 @@
             "name": "le-taco-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/5b2dfdce-8ab2-41b2-a318-65f884e3ead2",
-            "url-override": "https://static.data.gouv.fr/resources/le-taco-1/20260105-100620/gtfs-20250901-20260831-tdv-taco.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/le-taco-1",
@@ -8541,7 +8167,7 @@
         {
             "name": "le-taco-1",
             "type": "url",
-            "url": "https://app.pysae.com/api/v2/groups/airbus-marignane/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/807dd36f-5813-487a-b410-20032bfbe3ad",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/le-taco-1",
                 "spdx-identifier": "etalab-2.0"
@@ -8553,7 +8179,7 @@
         {
             "name": "optymo-velo-en-libre-service",
             "type": "url",
-            "url": "https://data.optymo.fr/vls/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/48eaedee-a28c-4d6a-8229-88d5ad2cd1c8",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/optymo-velo-en-libre-service",
@@ -8566,7 +8192,6 @@
             "name": "offre-transport-en-commun-du-reseau-transpor-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/bbbd5a29-2fbf-47ae-84fd-6d1ebb758eeb",
-            "url-override": "https://static.data.gouv.fr/resources/offre-transport-en-commun-du-reseau-transpor-gtfs/20260113-141453/transpor-hiver20252026v2sanstad-gtfs-20260113-151439.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-transport-en-commun-du-reseau-transpor-gtfs",
@@ -8592,7 +8217,6 @@
             "name": "neva-granville-terre-et-mer",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/82721/download",
-            "url-override": "https://static.data.gouv.fr/resources/neva-granville-terre-et-mer/20251120-090443/pt-th-offer-neva-gtfs-20251107-302-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/neva-granville-terre-et-mer",
@@ -8630,7 +8254,6 @@
             "name": "transport-en-commun-de-la-ville-dorange-ccpop-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d6c75600-f730-421e-93df-74a143d3e723",
-            "url-override": "https://exs.sud.cityway.fr/gtfs.aspx?key=SUD&operatorCode=ORANGE",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transport-en-commun-de-la-ville-dorange-ccpop-1",
@@ -8644,7 +8267,6 @@
             "name": "fr-200052264-t0026-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80447/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0026-0000/fluo-grand-est-isibus-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0026-0000-1",
@@ -8657,7 +8279,7 @@
         {
             "name": "flux-gbfs-montenvelo",
             "type": "url",
-            "url": "https://gbfs.partners.fifteen.eu/gbfs/2.2/mont_blanc/en/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/62038fda-7385-46da-a5ee-5f61469da589",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/flux-gbfs-montenvelo",
@@ -8670,7 +8292,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-airemob-communaute-de-communes-de-laire-cantilienne",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/1f143621-2afa-4aa8-a958-d5399e709347",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=CCAC&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-airemob-communaute-de-communes-de-laire-cantilienne",
@@ -8683,7 +8304,7 @@
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-airemob-communaute-de-communes-de-laire-cantilienne",
             "type": "url",
-            "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=CCAC&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/1f78d701-f1f1-4093-ba11-45134d544cdf",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-airemob-communaute-de-communes-de-laire-cantilienne",
                 "spdx-identifier": "etalab-2.0"
@@ -8696,7 +8317,6 @@
             "name": "fr-200052264-t0027-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80463/download",
-            "url-override": "https://exs.grandest2.cityway.fr/GTFS.aspx?Key=OPENDATA&OperatorCode=MOVIA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0027-0000-1",
@@ -8722,7 +8342,6 @@
             "name": "reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche--79272",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ba477c37-93d1-4900-8958-baf3c6de9d57",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche/20250917-112833/gtfs-dsp-tcap-17-09-25.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche",
@@ -8736,7 +8355,6 @@
             "name": "reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche--81342",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/5120cc52-6cc0-46b7-83b0-4c5cfd8f920c",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche/20250917-112807/gtfs-scol-tcap-17-09-25.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-interurbain-et-scolaire-de-la-communaute-dagglomeration-privas-centre-ardeche",
@@ -8750,7 +8368,6 @@
             "name": "offre-de-transport-du-reseau-linggo-en-ville-petr-du-pays-de-langres",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80403/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0029-0000/fluo-grand-est-lan-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-linggo-en-ville-petr-du-pays-de-langres",
@@ -8764,7 +8381,6 @@
             "name": "fr-200052264-t0006-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80410/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0006-0000/fluo-grand-est-cht-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0006-0000-1",
@@ -8778,7 +8394,6 @@
             "name": "arrets-horaires-et-parcours-theoriques-des-reseaux-naq-tut-nva-m-1",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/79ab3997-524a-48a3-baec-9f40f37f7bd1",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/ca_tulle-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-des-reseaux-naq-tut-nva-m-1",
@@ -8791,7 +8406,7 @@
         {
             "name": "bird-trottinettes-en-libre-service-a-chalons-en-champagne-gbfs",
             "type": "url",
-            "url": "https://mds.bird.co/gbfs/v2/public/provider/bird/chalonsenchampagne/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/d6702f05-1623-49ab-b9ce-0ae444b45c53",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/bird-trottinettes-en-libre-service-a-chalons-en-champagne-gbfs",
@@ -8804,7 +8419,6 @@
             "name": "donnees-du-reseau-evad-1--80973",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/429c8587-676a-4ed3-8279-e67403bc36f4",
-            "url-override": "https://static.data.gouv.fr/resources/donnees-du-reseau-evad-1/20260114-164613/gtfs-evad12012026-05072026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-du-reseau-evad-1",
@@ -8818,7 +8432,6 @@
             "name": "donnees-du-reseau-evad-1--83746",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/e8b38261-a2df-4f48-8749-93d56c468454",
-            "url-override": "https://static.data.gouv.fr/resources/donnees-du-reseau-evad-1/20251209-123614/gtfs-scolaire.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-du-reseau-evad-1",
@@ -8832,7 +8445,6 @@
             "name": "donnees-gtfs-du-reseau-de-transports-public-du-grand-cahors",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/1f768fa6-ee56-44d8-b322-75b946128fd8",
-            "url-override": "https://static.data.gouv.fr/resources/donnees-gtfs-du-reseau-de-transports-public-du-grand-cahors/20250903-064002/gtfs-.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-gtfs-du-reseau-de-transports-public-du-grand-cahors",
@@ -8846,7 +8458,6 @@
             "name": "horaires-theoriques-du-reseau-urbain-de-laon-tul-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ab24abac-0a10-4695-9d4d-c0df885b1970",
-            "url-override": "https://s3.eu-west-1.amazonaws.com/files.orchestra.ratpdev.com/networks/tul-gares/exports/medias.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-urbain-de-laon-tul-gtfs",
@@ -8860,7 +8471,6 @@
             "name": "saonibus-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-la-cc-dsv",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/19a7a109-54c0-4a40-ab60-4d5ca43ce823",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=SAONIBUS&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/saonibus-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-la-cc-dsv",
@@ -8873,7 +8483,7 @@
         {
             "name": "saonibus-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-la-cc-dsv",
             "type": "url",
-            "url": "https://api.oura3.cityway.fr/dataflow/realtime/stop-monitoring?Provider=SAONIBUS&DataFormat=GTFS-RT",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/10565553-7538-45d8-b8da-d1fa3c681efb",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/saonibus-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-la-cc-dsv",
                 "spdx-identifier": "ODbL-1.0"
@@ -8886,7 +8496,6 @@
             "name": "donnees-theoriques-et-temps-reel",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/e91ff63e-2c15-4c86-8e69-499ceec7bd97",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/aubenas?apiKey=6527571c533049035b6a0d41252853243b1f2a68",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel",
@@ -8899,7 +8508,7 @@
         {
             "name": "donnees-theoriques-et-temps-reel",
             "type": "url",
-            "url": "https://gtfs-rt.infra-hubup.fr/toutenbus/realtime",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/af576ebf-d3a4-4a0f-b692-8ee580cb1877",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel",
                 "spdx-identifier": "etalab-2.0"
@@ -8911,7 +8520,7 @@
         {
             "name": "bird-trottinettes-en-libre-service-a-gap-gbfs",
             "type": "url",
-            "url": "https://mds.bird.co/gbfs/v2/public/provider/bird/gap/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/dbb236e8-21a1-4e8d-adc6-025ae3758cbe",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/bird-trottinettes-en-libre-service-a-gap-gbfs",
@@ -8924,7 +8533,6 @@
             "name": "horaires-theoriques-et-temps-reel-du-reseau-luneo-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/94b9beba-c897-46ca-98a4-a78bf320047a",
-            "url-override": "https://app.pysae.com/api/v2/groups/luneo/gtfs/pub",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-luneo-gtfs-gtfs-rt",
@@ -8937,7 +8545,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-du-reseau-luneo-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/luneo/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/0e17b681-e017-46e2-a792-b3b6ead2c06c",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-luneo-gtfs-gtfs-rt",
                 "spdx-identifier": "ODbL-1.0"
@@ -8950,7 +8558,6 @@
             "name": "fr-200052264-t0023-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80465/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0023-0000/fluo-grand-est-lebus-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0023-0000-1",
@@ -8976,7 +8583,6 @@
             "name": "fr-200052264-t0022-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80475/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0022-0000/fluo-grand-est-lesit-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0022-0000-1",
@@ -8989,7 +8595,7 @@
         {
             "name": "velos-a-assistance-electrique-en-libre-service-velomoove-bassin-de-pompey--83717",
             "type": "url",
-            "url": "https://gbfs.partners.fifteen.eu/gbfs/2.2/pompey/en/geofencing_zones.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/af389d13-d0cc-4ee6-ae67-4c8c6e0e74eb",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-velomoove-bassin-de-pompey",
@@ -9001,7 +8607,7 @@
         {
             "name": "velos-a-assistance-electrique-en-libre-service-velomoove-bassin-de-pompey--83718",
             "type": "url",
-            "url": "https://gbfs.partners.fifteen.eu/gbfs/2.2/pompey/en/system_pricing_plans.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/5bc7bc88-285c-4cf2-91cf-62999ed993a5",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-velomoove-bassin-de-pompey",
@@ -9013,7 +8619,7 @@
         {
             "name": "velos-a-assistance-electrique-en-libre-service-velomoove-bassin-de-pompey--83720",
             "type": "url",
-            "url": "https://gbfs.partners.fifteen.eu/gbfs/2.2/pompey/en/vehicle_types.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/9eddda26-e867-4b11-ac69-568a05639f76",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-velomoove-bassin-de-pompey",
@@ -9025,7 +8631,7 @@
         {
             "name": "velos-a-assistance-electrique-en-libre-service-velomoove-bassin-de-pompey--83723",
             "type": "url",
-            "url": "https://gbfs.partners.fifteen.eu/gbfs/2.2/pompey/en/system_information.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/9cff5e9a-8f40-4c93-a36a-a3ee478703d7",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-velomoove-bassin-de-pompey",
@@ -9037,7 +8643,7 @@
         {
             "name": "velos-a-assistance-electrique-en-libre-service-velomoove-bassin-de-pompey--83724",
             "type": "url",
-            "url": "https://gbfs.partners.fifteen.eu/gbfs/2.2/pompey/en/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/254a6ab7-9787-42c9-ba40-a61fd450f701",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-velomoove-bassin-de-pompey",
@@ -9050,7 +8656,6 @@
             "name": "horaires-theoriques-et-temps-reel-du-reseau-alliance-auch-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/cf9e898c-9ba6-4820-a51a-93709c07f891",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=auch-alliance",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-alliance-auch-gtfs-gtfs-rt",
@@ -9063,7 +8668,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-du-reseau-alliance-auch-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=auch-alliance",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/ee7325a5-172f-430e-afe7-4072e0cf1321",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-alliance-auch-gtfs-gtfs-rt",
                 "spdx-identifier": "ODbL-1.0"
@@ -9075,7 +8680,7 @@
         {
             "name": "larbresle-velo-en-livre-service",
             "type": "url",
-            "url": "https://www.mobility-parc.net/gbfs/v3/ARBRESLE/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/5ce83dd4-7b41-4e6f-afe4-baf6719b5757",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/larbresle-velo-en-livre-service",
@@ -9088,7 +8693,6 @@
             "name": "gtfs-au-10-decembre-2025",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2f510784-2957-48e3-b01c-b0e4f9938da7",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-au-10-decembre-2025/20251223-104613/gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-au-10-decembre-2025",
@@ -9102,7 +8706,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-sablons-bus-communaute-de-communes-des-sablons--81070",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/1364ed96-7246-4344-a04c-34bd06ef2b0c",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=SABLONS&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-sablons-bus-communaute-de-communes-des-sablons",
@@ -9116,7 +8719,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-sablons-bus-communaute-de-communes-des-sablons--81651",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/daba957b-c833-46ad-9bc1-12f3347ac4d9",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/tad/download?provider=SABLONS&dataFormat=gtfs",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-sablons-bus-communaute-de-communes-des-sablons",
@@ -9131,7 +8733,6 @@
             "name": "ficibus-fecamp-caux-littoral",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/82311/download",
-            "url-override": "https://static.data.gouv.fr/resources/ficibus-fecamp-caux-littoral/20250902-183744/pt-th-offer-ficibus-gtfs-20250901-381-opendata-1-.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/ficibus-fecamp-caux-littoral",
@@ -9144,7 +8745,7 @@
         {
             "name": "ficibus-fecamp-caux-littoral",
             "type": "url",
-            "url": "https://gtfs.bus-tracker.fr/gtfs-rt/ficibus/trip-updates",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/b30879dc-089f-4213-8cf6-5f51afb28e4f",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/ficibus-fecamp-caux-littoral",
                 "spdx-identifier": "etalab-2.0"
@@ -9157,7 +8758,6 @@
             "name": "reseau-urbain-le-vib",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/87091347-c7fa-4e63-8fb5-005891ece43b",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-le-vib/20251220-102736/gtfs-20251216-091117-levib-hb-du-01-12-25-au-31-05-26.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-le-vib",
@@ -9195,7 +8795,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-le-bus-communaute-de-communes-du-clermontois--81056",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/960fa36a-d183-4140-ae64-462d92a06eb8",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=LEBUS&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-le-bus-communaute-de-communes-du-clermontois",
@@ -9209,7 +8808,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-le-bus-communaute-de-communes-du-clermontois--81652",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ef552f35-b49b-43d5-8bbc-ad95efdc3d95",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/tad/download?provider=LEBUS&dataFormat=gtfs",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-le-bus-communaute-de-communes-du-clermontois",
@@ -9224,7 +8822,6 @@
             "name": "offre-de-transport-du-reseau-elsa-petr-selestat-alsace-centrale",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80401/download",
-            "url-override": "https://exs.grandest2.cityway.fr/GTFS.aspx?Key=OPENDATA&OperatorCode=CCSelestat",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-elsa-petr-selestat-alsace-centrale",
@@ -9249,7 +8846,7 @@
         {
             "name": "tier-dott-gbfs-ol-vallee",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/ol-vallee/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/492c8fff-1f2b-4667-a5df-09f5dcefa7e3",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-ol-vallee",
@@ -9262,7 +8859,6 @@
             "name": "offre-de-transport-cc-du-thouarsais",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/83533/download",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/cc_du_thouarsais-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-cc-du-thouarsais",
@@ -9276,7 +8872,6 @@
             "name": "arrets-lignes-regulieres-reseau-de-transport-urbain-a-autun",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b587f007-9b23-4b2a-a609-9368a4c2c490",
-            "url-override": "https://static.data.gouv.fr/resources/arrets-lignes-regulieres-reseau-de-transport-urbain-a-autun/20251030-071946/ligne-a-autun-ca-roule.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-lignes-regulieres-reseau-de-transport-urbain-a-autun",
@@ -9290,7 +8885,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-tohm-communaute-de-communes-des-pays-doise-et-dhalatte",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/6fdd303a-7b76-4742-b877-d0923c59505b",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=TOHM&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tohm-communaute-de-communes-des-pays-doise-et-dhalatte",
@@ -9303,7 +8897,7 @@
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-tohm-communaute-de-communes-des-pays-doise-et-dhalatte",
             "type": "url",
-            "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=TOHM&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/4605100a-7121-4530-87e0-8d7f2d611727",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-tohm-communaute-de-communes-des-pays-doise-et-dhalatte",
                 "spdx-identifier": "etalab-2.0"
@@ -9316,7 +8910,6 @@
             "name": "ecla-lons-agglo-mobilites",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ec61df69-830c-4ca7-9d78-9a81c515e9de",
-            "url-override": "https://static.data.gouv.fr/resources/ecla-lons-agglo-mobilites/20250507-095356/gtfs-ecla-l1-l2-l3-l4-07-05-2025.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/ecla-lons-agglo-mobilites",
@@ -9330,7 +8923,6 @@
             "name": "fr-200052264-t0003-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80441/download",
-            "url-override": "https://exs.grandest2.cityway.fr/GTFS.aspx?Key=OPENDATA&OperatorCode=TUB",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0003-0000-1",
@@ -9356,7 +8948,6 @@
             "name": "argentanbus-argentan-intercom",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/82315/download",
-            "url-override": "https://static.data.gouv.fr/resources/argentanbus-argentan-intercom/20251229-084836/pt-th-offer-argentanbus-gtfs-20251226-811-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/argentanbus-argentan-intercom",
@@ -9370,7 +8961,6 @@
             "name": "offre-de-transports-jybus-a-rumilly",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/9ba40024-aa3c-4e5c-b065-47eef0edf4e6",
-            "url-override": "https://static.data.gouv.fr/resources/offre-de-transports-jybus-a-rumilly/20251210-144631/gtfs-jybus.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transports-jybus-a-rumilly",
@@ -9384,7 +8974,6 @@
             "name": "le-bus-pont-audemer-val-de-risle",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/82310/download",
-            "url-override": "https://static.data.gouv.fr/resources/le-bus-pont-audemer-val-de-risle/20250819-074312/pt-th-offer-lebus-gtfs-20250812-817-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/le-bus-pont-audemer-val-de-risle",
@@ -9398,7 +8987,6 @@
             "name": "reseau-lagglo-bus-de-lagglo-foix-varilhes",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/8c9dd4f7-f6a2-4760-915e-89e8f9666c5b",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-lagglo-bus-de-lagglo-foix-varilhes/20251217-143135/gtfs-1er-decembre2025.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-lagglo-bus-de-lagglo-foix-varilhes",
@@ -9412,7 +9000,6 @@
             "name": "horaires-theoriques-du-reseau-moova-communaute-dagglomeration-de-vesoul-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/0d6e6c56-8926-49b3-87e2-13c6f57c136b",
-            "url-override": "https://static.data.gouv.fr/resources/horaires-theoriques-du-reseau-moova-communaute-dagglomeration-de-vesoul-gtfs/20250901-213608/gtfs-pan-2.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-moova-communaute-dagglomeration-de-vesoul-gtfs",
@@ -9438,7 +9025,6 @@
             "name": "offre-de-transport-cc-jalles-eau-bourde",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/6fa85772-cc88-43ae-88b9-290e2f9345ff",
-            "url-override": "https://www.pigma.org/public/opendata/nouvelle_aquitaine_mobilites/publication/jalle_eau_bourde-aggregated-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-cc-jalles-eau-bourde",
@@ -9451,7 +9037,7 @@
         {
             "name": "oloron-velo-en-libre-service",
             "type": "url",
-            "url": "https://www.mobility-parc.net/gbfs/v3/OLORON/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/be553e86-366c-4905-86b8-3cfd340ca657",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/oloron-velo-en-libre-service",
@@ -9464,7 +9050,6 @@
             "name": "donnees-theoriques-et-temps-reel-du-reseau-libbus-communaute-de-communes-du-pays-noyonnais",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/3074dfb5-2209-44b4-891a-a86694ecaeec",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=LIBBUS&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-libbus-communaute-de-communes-du-pays-noyonnais",
@@ -9477,7 +9062,7 @@
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-libbus-communaute-de-communes-du-pays-noyonnais",
             "type": "url",
-            "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=LIBBUS&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/0610565a-91a6-4d83-8e2d-bd9c0cd241a8",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-libbus-communaute-de-communes-du-pays-noyonnais",
                 "spdx-identifier": "etalab-2.0"
@@ -9490,7 +9075,6 @@
             "name": "navettes-de-loire-forez-agglomeration",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/4536fa0a-b880-47ba-9f94-42a6303e584b",
-            "url-override": "https://static.data.gouv.fr/resources/navettes-de-loire-forez-agglomeration/20250909-134941/navettes-urbaines-lfa.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/navettes-de-loire-forez-agglomeration",
@@ -9504,7 +9088,6 @@
             "name": "reseau-urbain-brevibus",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b8d1007f-567e-48c4-9c40-bee205f1e688",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-brevibus/20251230-092509/gtfs-20251211-122930-brevibus-hors-bord-250825-au-300426-v3-1.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-brevibus",
@@ -9517,7 +9100,7 @@
         {
             "name": "reseau-urbain-brevibus",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/brevibus/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/dd56dfc5-85b6-43f9-8b1b-8eebd4cb2c2e",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-brevibus",
                 "spdx-identifier": "ODbL-1.0"
@@ -9530,7 +9113,6 @@
             "name": "navette-a-la-voile-pour-les-glenan",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c6be5123-466e-4989-8843-549bee825750",
-            "url-override": "https://maxime-siret.github.io/gtfs-sailcoop/latest.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/navette-a-la-voile-pour-les-glenan",
@@ -9545,7 +9127,6 @@
             "name": "bybus-bayeux-intercom",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/82313/download",
-            "url-override": "https://static.data.gouv.fr/resources/bybus-bayeux-intercom/20250904-125822/pt-th-offer-bybus-gtfs-20250904-611-opendata-1-.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/bybus-bayeux-intercom",
@@ -9558,7 +9139,7 @@
         {
             "name": "tier-dott-gbfs-bourgoin-jallieu",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/bourgoin-jallieu/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/d1ab5c31-2246-4a5d-a4a7-359007258954",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tier-dott-gbfs-bourgoin-jallieu",
@@ -9571,7 +9152,6 @@
             "name": "fiches-horaires-reseau-urbain-mio-ccmillaugrandscausses",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b38a8202-1d7e-4345-964c-f07a335ea90b",
-            "url-override": "https://static.data.gouv.fr/resources/fiches-horaires-reseau-urbain-mio-ccmillaugrandscausses/20250929-083050/gtfs-20250731-1-.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fiches-horaires-reseau-urbain-mio-ccmillaugrandscausses",
@@ -9586,7 +9166,6 @@
             "name": "donnees-de-mobilite",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/39bc7064-a387-4eef-9fb3-05fe3c00782b",
-            "url-override": "https://static.data.gouv.fr/resources/donnees-de-mobilite/20260107-150213/gtfs-20260105-090453-villeo.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-de-mobilite",
@@ -9600,7 +9179,6 @@
             "name": "offre-de-transport-du-reseau-de-la-communaute-de-communes-des-pays-du-sel-et-du-vermois",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/82907/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0054-0000/fluo-grand-est-selverm-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-du-reseau-de-la-communaute-de-communes-des-pays-du-sel-et-du-vermois",
@@ -9626,7 +9204,6 @@
             "name": "agglobus",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/4b6bb4e3-86de-491c-8a0a-7892a02ccb60",
-            "url-override": "https://static.data.gouv.fr/resources/agglobus/20241216-125701/241216-agglobus-janvier-2025.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/agglobus",
@@ -9640,7 +9217,6 @@
             "name": "tad-arrens-marsous-lourdes",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/382a2cc7-336b-49ff-9fbd-f355629701b6",
-            "url-override": "https://static.data.gouv.fr/resources/tad-arrens-marsous-lourdes/20250605-142621/arrens-lourdes-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tad-arrens-marsous-lourdes",
@@ -9655,7 +9231,6 @@
             "name": "reseau-urbain-reso",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2fc8108a-5b91-455a-8d10-1c938d360a9f",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-reso/20251212-113918/gtfs-20251209-horsbord-reso-1-.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-reso",
@@ -9668,7 +9243,7 @@
         {
             "name": "reseau-urbain-reso",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/transdev-8z2Q/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/0fbf9dc8-d2db-405d-ade4-fdd04a6f8272",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-reso",
                 "spdx-identifier": "ODbL-1.0"
@@ -9681,7 +9256,6 @@
             "name": "fr-200052264-t0025-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/82388/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0025-0000/fluo-grand-est-tmm-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0025-0000-1",
@@ -9694,7 +9268,7 @@
         {
             "name": "pays-du-coquelicot-velo-en-libre-service",
             "type": "url",
-            "url": "https://www.mobility-parc.net/gbfs/v3/COQUELICOT/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/8bbd3172-421d-4ca0-abb8-7feb6c96b204",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/pays-du-coquelicot-velo-en-libre-service",
@@ -9707,7 +9281,6 @@
             "name": "fr-200052264-t0011-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80772/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0011-0000/fluo-grand-est-tiv-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0011-0000-1",
@@ -9733,7 +9306,6 @@
             "name": "hobus-honfleur",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/82711/download",
-            "url-override": "https://static.data.gouv.fr/resources/hobus-honfleur/20251229-095527/pt-th-offer-hobus-gtfs-20251226-808-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/hobus-honfleur",
@@ -9771,7 +9343,6 @@
             "name": "vikibus-yvetot-normandie",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/81975/download",
-            "url-override": "https://static.data.gouv.fr/resources/vikibus-yvetot-normandie/20260116-123130/pt-th-offer-vikibus-gtfs-20260113-317-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/vikibus-yvetot-normandie",
@@ -9808,7 +9379,7 @@
         {
             "name": "velos-a-assistance-electrique-en-libre-service-saumur-ogalo-cyclette",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/ogalo/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/73105a37-138d-4338-8880-2fc0c8417f3b",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-saumur-ogalo-cyclette",
@@ -9820,7 +9391,7 @@
         {
             "name": "bird-trottinettes-en-libre-service-a-vichy-gbfs",
             "type": "url",
-            "url": "https://mds.bird.co/gbfs/v2/public/provider/bird/vichy/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/9ecc6475-23b9-44f0-933f-434ce0374f26",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/bird-trottinettes-en-libre-service-a-vichy-gbfs",
@@ -9833,7 +9404,6 @@
             "name": "tico-bus-horaires-theoriques-du-reseau-de-transport-urbain-tico--79864",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/10bf603d-9302-435e-a1dd-a60d91a645ee",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=MONTLUEL&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tico-bus-horaires-theoriques-du-reseau-de-transport-urbain-tico",
@@ -9847,7 +9417,6 @@
             "name": "tico-bus-horaires-theoriques-du-reseau-de-transport-urbain-tico--80383",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/13a04a39-0bb3-4e4f-825e-cf481e6cea92",
-            "url-override": "https://api.mlt4.cityway.fr/dataflow/tad/download?provider=3CM",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tico-bus-horaires-theoriques-du-reseau-de-transport-urbain-tico",
@@ -9861,7 +9430,6 @@
             "name": "giverny-vernon-gare-sncf",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/81177/download",
-            "url-override": "https://static.data.gouv.fr/resources/giverny-vernon-gare-sncf/20250520-114718/pt-th-offer-sngonavettegiverny-gtfs-20250520-706-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/giverny-vernon-gare-sncf",
@@ -9875,7 +9443,7 @@
         {
             "name": "pays-dopale",
             "type": "url",
-            "url": "https://www.mobility-parc.net/gbfs/v3/Opale/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/38a663d1-b9a5-40af-af36-ae4451fc54a5",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/pays-dopale",
@@ -9888,7 +9456,6 @@
             "name": "colibri-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-la-ccmp",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/dbd0bd0e-933a-4a21-8772-efdf41778e64",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=COLIBRI&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/colibri-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-la-ccmp",
@@ -9901,7 +9468,7 @@
         {
             "name": "colibri-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-la-ccmp",
             "type": "url",
-            "url": "https://api.oura3.cityway.fr/dataflow/realtime/stop-monitoring?Provider=COLIBRI&DataFormat=GTFS-RT",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/543f962e-3f4d-4bad-bb5e-7bac71f85aef",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/colibri-horaires-theoriques-et-temps-reel-du-reseau-de-transport-urbain-de-la-ccmp",
                 "spdx-identifier": "ODbL-1.0"
@@ -9914,7 +9481,6 @@
             "name": "moca-communaute-de-communes-caux-austreberthe",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/82309/download",
-            "url-override": "https://static.data.gouv.fr/resources/moca-communaute-de-communes-caux-austreberthe/20260116-123703/pt-th-offer-moca-gtfs-20260107-303-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/moca-communaute-de-communes-caux-austreberthe",
@@ -9951,7 +9517,7 @@
         {
             "name": "velos-a-assistance-electrique-en-libre-service-laon-velocite",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/velocite/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/26df505b-ce0e-4154-9648-2231c3733df9",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-laon-velocite",
@@ -9964,7 +9530,6 @@
             "name": "reseau-cvlmobilite-plan-de-transport-theorique-ligne-a-format-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/6348dadb-600c-42c8-bbea-f6ac09505ed3",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-cvlmobilite-plan-de-transport-theorique-ligne-a-format-gtfs/20250706-123815/cvlm-lignea-07072025.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-cvlmobilite-plan-de-transport-theorique-ligne-a-format-gtfs",
@@ -9977,7 +9542,7 @@
         {
             "name": "reseau-cvlmobilite-plan-de-transport-theorique-ligne-a-format-gtfs",
             "type": "url",
-            "url": "https://cvlmobilite.plateforme-2cloud.com/api/gtfsrt/2.0/tripupdates/CVLMOBILITE-4423-7657-4931/bin",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/2c2bf555-2861-4e4e-8aa0-6636787cb2f9",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-cvlmobilite-plan-de-transport-theorique-ligne-a-format-gtfs",
                 "spdx-identifier": "etalab-2.0"
@@ -9990,7 +9555,6 @@
             "name": "horaires-theoriques-du-reseau-neobus-communaute-de-communes-de-louest-vosgien-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/e25586ac-9c14-4872-b00e-e66cd23d4413",
-            "url-override": "https://static.data.gouv.fr/resources/horaires-theoriques-du-reseau-neobus-communaute-de-communes-de-louest-vosgien-gtfs/20251231-083603/gtfs-sadap-neobus.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-neobus-communaute-de-communes-de-louest-vosgien-gtfs",
@@ -10004,7 +9568,6 @@
             "name": "reseau-a-citadina-porto-vecchio-horaires-theoriques-et-temps-reel",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/74f0577f-f709-49db-9750-53c9341f6e50",
-            "url-override": "https://pysae.com/api/v2/groups/porto-vecchio/gtfs/pub",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-a-citadina-porto-vecchio-horaires-theoriques-et-temps-reel",
@@ -10017,7 +9580,7 @@
         {
             "name": "reseau-a-citadina-porto-vecchio-horaires-theoriques-et-temps-reel",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/porto-vecchio/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a792a365-b5bc-48b8-81eb-512e8e83af08",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-a-citadina-porto-vecchio-horaires-theoriques-et-temps-reel",
                 "spdx-identifier": "etalab-2.0"
@@ -10030,7 +9593,6 @@
             "name": "fr-200052264-t0041-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80439/download",
-            "url-override": "https://api.grandest2.cityway.fr/exs/GTFS?Key=OPENDATA&OperatorCode=Obernai",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0041-0000-1",
@@ -10056,7 +9618,6 @@
             "name": "donnees-de-transport-en-commun-reseau-altigo-communaute-de-communes-du-brianconnais-format-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/3ee23301-f454-4175-ba53-4734c30d5245",
-            "url-override": "https://static.data.gouv.fr/resources/donnees-de-transport-en-commun-reseau-altigo-communaute-de-communes-du-brianconnais-format-gtfs/20260106-082305/altigo-gtfs-2026-01-06-09-22-11.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-de-transport-en-commun-reseau-altigo-communaute-de-communes-du-brianconnais-format-gtfs",
@@ -10070,7 +9631,6 @@
             "name": "issoudun-offre-theorique-mobilite-reseau-urbain",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/485e9781-ac86-44c7-8289-3a7df46abe9d",
-            "url-override": "https://fr.ftp.opendatasoft.com/centrevaldeloire/OKINAGTFS/GTFS_AO/ISSOUDUN.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/issoudun-offre-theorique-mobilite-reseau-urbain",
@@ -10084,7 +9644,6 @@
             "name": "aravis-bus-hiver-2025-2026",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/14769e22-a9cd-42b8-85a7-2e0f556e8091",
-            "url-override": "https://static.data.gouv.fr/resources/aravis-bus-hiver-2025-2026/20251210-145252/export-gtfs-aravis-hiver-2026-hiver20252026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/aravis-bus-hiver-2025-2026",
@@ -10098,7 +9657,6 @@
             "name": "tudbus-douarnenez-communaute-transport",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d30403b4-6ff8-4a37-a661-8220b18e3cc5",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/TUDBUS.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/tudbus-douarnenez-communaute-transport",
@@ -10112,7 +9670,6 @@
             "name": "donnees-theoriques-du-reseau-hopla-communaute-de-communes-de-la-plaine-destrees--81519",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b892a9c7-eda3-4d95-a70b-89b2391e81b0",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/offre-tc/download?provider=HOPLA&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-hopla-communaute-de-communes-de-la-plaine-destrees",
@@ -10126,7 +9683,6 @@
             "name": "donnees-theoriques-du-reseau-hopla-communaute-de-communes-de-la-plaine-destrees--81649",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c6279e07-8e38-459a-b96a-96e4109d0816",
-            "url-override": "https://api.oisemob.cityway.fr/dataflow/tad/download?Provider=HOPLA&dataFormat=gtfs&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-hopla-communaute-de-communes-de-la-plaine-destrees",
@@ -10140,7 +9696,7 @@
         {
             "name": "estrees-saint-denis",
             "type": "url",
-            "url": "https://www.mobility-parc.net/gbfs/v3/ESTREES/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/40084d35-c4f3-41ee-bc39-11366c658d15",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/estrees-saint-denis",
@@ -10153,7 +9709,6 @@
             "name": "transport-urbain-du-bassin",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/0163a7b9-f4b1-4d9b-9af1-dcc0e583c3b4",
-            "url-override": "https://static.data.gouv.fr/resources/transport-urbain-du-bassin/20250217-154406/transports-urbains-du-bassin-version-2-6-gtfs-2024-12-16-11-39-36.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transport-urbain-du-bassin",
@@ -10167,7 +9722,6 @@
             "name": "horaires-theoriques-et-temps-reel-du-reseau-respire-ile-de-re-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f167d4d3-cd32-475b-a12f-0403534679e5",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=iledere75923021",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-respire-ile-de-re-gtfs-gtfs-rt",
@@ -10180,7 +9734,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-du-reseau-respire-ile-de-re-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=iledere75923021",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/89a81efd-a8f4-4558-9988-9e7c56ab15fe",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-respire-ile-de-re-gtfs-gtfs-rt",
                 "spdx-identifier": "ODbL-1.0"
@@ -10193,7 +9747,6 @@
             "name": "navettes-stations-hiver-2025-2026-reseau-vai",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f8a8d797-035b-4adf-a447-a8624639232e",
-            "url-override": "https://static.data.gouv.fr/resources/navettes-stations-hiver-2025-2026-reseau-vai/20251230-085133/navettes-stations-vai-hiver-2025-2026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/navettes-stations-hiver-2025-2026-reseau-vai",
@@ -10207,7 +9760,6 @@
             "name": "reseau-vai-embrun",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/bb9234b1-3837-4765-b630-276dc8bdabea",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-vai-embrun/20250827-125315/transports-vai-embrun-2025-2026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-vai-embrun",
@@ -10221,7 +9773,6 @@
             "name": "mobivals-horaires-theoriques-du-reseau-de-transport-urbain-de-valserhone",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/bdbc488f-d0fa-42ae-8e05-a1c291a9abdf",
-            "url-override": "https://api.oura3.cityway.fr/dataflow/offre-tc/download?provider=MOBIVALS&dataFormat=GTFS&dataProfil=OPENDATA",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/mobivals-horaires-theoriques-du-reseau-de-transport-urbain-de-valserhone",
@@ -10235,7 +9786,6 @@
             "name": "reseau-urbain-la-navette-commune-de-gaillac",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d0579894-2c5a-42c1-a44c-d550af952f49",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-la-navette-commune-de-gaillac/20250904-131222/gtfs-gaillac.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-la-navette-commune-de-gaillac",
@@ -10248,7 +9798,7 @@
         {
             "name": "vallee-vezere-velo-en-libre-service",
             "type": "url",
-            "url": "https://www.mobility-parc.net/gbfs/v3/LASCAUX/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/5785e479-1a1d-4972-837d-b85ab94c64c6",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/vallee-vezere-velo-en-libre-service",
@@ -10261,7 +9811,6 @@
             "name": "biscabus",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/7e4a061d-60d8-498b-aee1-b4f23d942a0c",
-            "url-override": "https://static.data.gouv.fr/resources/biscabus/20250623-141503/gtfs-biscabus-2025-06-15.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/biscabus",
@@ -10275,7 +9824,7 @@
         {
             "name": "velos-a-assistance-electrique-en-libre-service-pointe-a-pitre-la-guadeloupe-karuvelo",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/karu/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/cd32c0d9-b195-4914-9a18-05258be247f1",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-pointe-a-pitre-la-guadeloupe-karuvelo",
@@ -10288,7 +9837,6 @@
             "name": "transport-urbain-3cma-bus",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ff226a89-a0f7-4e6d-af0c-3b34b54306ae",
-            "url-override": "https://static.data.gouv.fr/resources/transport-urbain-3cma-bus/20250910-101944/2025-09-10-3cmabus.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transport-urbain-3cma-bus",
@@ -10302,7 +9850,6 @@
             "name": "gtfs-reseau-chamonix-mobilite",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/83a2f241-a0a4-4901-b77b-8a71572a9f6a",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-reseau-chamonix-mobilite/20251217-112258/gtfs-standard-hiver-2025-2026.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-reseau-chamonix-mobilite",
@@ -10316,7 +9863,6 @@
             "name": "bacs-de-ecouflant-cantenay-epinard-et-pruille",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/83579/download",
-            "url-override": "https://static.data.gouv.fr/resources/bacs-de-ecouflant-cantenay-epinard-et-pruille/20251105-095039/bacs-alm-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/bacs-de-ecouflant-cantenay-epinard-et-pruille",
@@ -10331,7 +9877,6 @@
             "name": "reseau-urbain-la-navette-commune-de-graulhet",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/257e5818-a7cc-49a4-8ad1-3e84827e6458",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-la-navette-commune-de-graulhet/20250904-131627/gtfs-graulhet.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-la-navette-commune-de-graulhet",
@@ -10345,7 +9890,6 @@
             "name": "ville-damboise-offre-theorique-mobilite-reseau-urbain",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/937d0757-36c0-4f96-95a4-287b58048c2d",
-            "url-override": "https://fr.ftp.opendatasoft.com/centrevaldeloire/OKINAGTFS/GTFS_AO/AMBOISE.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/ville-damboise-offre-theorique-mobilite-reseau-urbain",
@@ -10359,7 +9903,6 @@
             "name": "horaires-theoriques-et-temps-reel-du-reseau-maybus-mayenne-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/220e0fb8-fe04-4d99-9fca-cc812eaadfc3",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=maybus",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-maybus-mayenne-gtfs-gtfs-rt",
@@ -10372,7 +9915,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-du-reseau-maybus-mayenne-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=maybus",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/6a1ef3cc-13cc-4770-a347-f183dc6accd6",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-maybus-mayenne-gtfs-gtfs-rt",
                 "spdx-identifier": "ODbL-1.0"
@@ -10385,7 +9928,6 @@
             "name": "reseau-digo-cote-landes-nature",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/cf6776cd-2f5c-4190-8bec-3578d7f87372",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-digo-cote-landes-nature/20250805-083958/gtfs-cote-landes-nature.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-digo-cote-landes-nature",
@@ -10400,7 +9942,6 @@
             "name": "horaires-theoriques-et-temps-reel-du-reseau-transports-urbains-mendois-mende-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2f42baea-fbe1-4b01-bf4a-8232fd83b24e",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=tum",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-transports-urbains-mendois-mende-gtfs-gtfs-rt",
@@ -10413,7 +9954,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-du-reseau-transports-urbains-mendois-mende-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=tum",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/9b9013ec-4cbb-4f18-b44a-1e94088320a8",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-transports-urbains-mendois-mende-gtfs-gtfs-rt",
                 "spdx-identifier": "ODbL-1.0"
@@ -10426,7 +9967,6 @@
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-ligne-cogolin",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/8d670add-a215-486a-bf96-2b44b3b6aebe",
-            "url-override": "https://pysae.com/api/v2/groups/keolis-hH93/gtfs/pub",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-ligne-cogolin",
@@ -10441,7 +9981,6 @@
             "name": "transports-urbains-st-cyr-s-mer",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/a67da149-19bc-445d-b2d3-855fd82aa240",
-            "url-override": "https://static.data.gouv.fr/resources/transports-urbains-st-cyr-s-mer/20250401-095332/sud-sainte-baume-janvier2025-st-cyr.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transports-urbains-st-cyr-s-mer",
@@ -10456,7 +9995,6 @@
             "name": "fr-200052264-t0030-0000-1",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/80471/download",
-            "url-override": "https://www.datagrandest.fr/metadata/fluo-grand-est/FR-200052264-T0030-0000/fluo-grand-est-smd-gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/fr-200052264-t0030-0000-1",
@@ -10470,7 +10008,6 @@
             "name": "gtfs-transport-horaires-des-lignes-de-la-communaute-dile-rousse-balagne-a-balanina",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f88c086a-4fe1-4af1-a027-f809d4422b65",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-transport-horaires-des-lignes-de-la-communaute-dile-rousse-balagne-a-balanina/20250627-205558/a-balanina.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-horaires-des-lignes-de-la-communaute-dile-rousse-balagne-a-balanina",
@@ -10483,7 +10020,7 @@
         {
             "name": "velos-a-assistance-electrique-en-libre-service-argeles-sur-mer-velo-daqui-1",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/velodaqui/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/4575c57e-54b6-4190-97f3-41df095f6e1e",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-argeles-sur-mer-velo-daqui-1",
@@ -10496,7 +10033,6 @@
             "name": "horaires-theoriques-et-temps-reel-du-reseau-oloron-sainte-marie-la-navette-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/10bb8fff-521d-4b27-a85e-79ae704f1ccc",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=oloron",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-oloron-sainte-marie-la-navette-gtfs-gtfs-rt",
@@ -10509,7 +10045,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-du-reseau-oloron-sainte-marie-la-navette-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=oloron",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/afee6b6e-2c3f-4317-9d0a-d70540acf8d8",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-oloron-sainte-marie-la-navette-gtfs-gtfs-rt",
                 "spdx-identifier": "ODbL-1.0"
@@ -10522,7 +10058,6 @@
             "name": "breizhgo-bateaux--81478",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/8a2c923c-d308-4391-801e-2369cdde7749",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_BATEAU_ARZ.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-bateaux",
@@ -10536,7 +10071,6 @@
             "name": "breizhgo-bateaux--81479",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/9ef537b6-fbeb-468f-9d6d-47c1d0d98504",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_BATEAU_BREHAT.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-bateaux",
@@ -10550,7 +10084,6 @@
             "name": "breizhgo-bateaux--81480",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/705809de-4712-4c52-add3-03c4d9b6d621",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_BATEAU_29.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-bateaux",
@@ -10564,7 +10097,6 @@
             "name": "breizhgo-bateaux--81481",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c09012e4-cb57-41da-94c5-013a19c99e14",
-            "url-override": "https://www.korrigo.bzh/ftp/OPENDATA/BREIZHGO_BATEAU_56.gtfs.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-bateaux",
@@ -10578,7 +10110,6 @@
             "name": "gtfs-pybus-le-reseau-urbain-de-parthenay",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/95654461-59d1-4a33-8830-f90d55e8a217",
-            "url-override": "https://pysae.com/api/v2/groups/parthenay/gtfs/675464600aa7a35621cdd070",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-pybus-le-reseau-urbain-de-parthenay",
@@ -10592,7 +10123,7 @@
         {
             "name": "gtfs-pybus-le-reseau-urbain-de-parthenay",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/noirmoutiers/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/ab934941-2bd2-49e2-a83c-0dcddf95b1b9",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-pybus-le-reseau-urbain-de-parthenay",
                 "spdx-identifier": "etalab-2.0"
@@ -10607,7 +10138,6 @@
             "name": "gtfs-transport-via-corsica-corte-a-la-vallee-de-la-restonica-ligne-c13",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ba2f71b6-23ca-4b51-b319-bd9576933d94",
-            "url-override": "https://static.data.gouv.fr/resources/gtfs-transport-via-corsica-corte-a-la-vallee-de-la-restonica-ligne-c13/20250421-153345/via-corsica-restonica-c13.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-transport-via-corsica-corte-a-la-vallee-de-la-restonica-ligne-c13",
@@ -10622,7 +10152,6 @@
             "name": "horaires-theoriques-du-reseau-figeac-le-bus-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ab2d1451-dddd-4814-bc5c-8e219834a3e3",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=figeac",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-figeac-le-bus-gtfs",
@@ -10635,7 +10164,7 @@
         {
             "name": "horaires-theoriques-du-reseau-figeac-le-bus-gtfs",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=figeac",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/0057d63f-cf69-4d67-8c44-3c546ec7d403",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-du-reseau-figeac-le-bus-gtfs",
                 "spdx-identifier": "ODbL-1.0"
@@ -10647,7 +10176,7 @@
         {
             "name": "vallee-dossau-velo-en-libre-service",
             "type": "url",
-            "url": "https://www.mobility-parc.net/gbfs/v3/OSSAU/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/fc097849-f4c7-42e1-95fc-3372697ed8b6",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/vallee-dossau-velo-en-libre-service",
@@ -10659,7 +10188,7 @@
         {
             "name": "gevaudan-velo-en-libre-service",
             "type": "url",
-            "url": "https://www.mobility-parc.net/gbfs/v3/GEVAUDAN/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/34a6a65f-c30e-4ff6-9f34-515796e4583a",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gevaudan-velo-en-libre-service",
@@ -10672,7 +10201,6 @@
             "name": "reseau-urbain-nosbus",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/5f1dfae0-7972-4caa-8a5d-e2d90a285585",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-nosbus/20250825-100800/gtfs-nosbus-20250813-85-a-bord-hors-bord.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-nosbus",
@@ -10685,7 +10213,7 @@
         {
             "name": "reseau-urbain-nosbus",
             "type": "url",
-            "url": "https://app.pysae.com/api/v4/groups/nosbus/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/8bd532f4-8813-4313-be7c-304b8f8f47a7",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-nosbus",
                 "spdx-identifier": "ODbL-1.0"
@@ -10698,7 +10226,6 @@
             "name": "noirmoutier-gratibus-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/ce6d5603-41cf-4fed-b93f-ed95859003b5",
-            "url-override": "https://static.data.gouv.fr/resources/noirmoutier-gratibus-gtfs-gtfs-rt/20250624-094949/noirmoutier-2025-v4-1-.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/noirmoutier-gratibus-gtfs-gtfs-rt",
@@ -10713,7 +10240,6 @@
             "name": "horaires-theoriques-et-temps-reel-du-reseau-sarlatbus-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f1119940-adc5-4d2e-af7d-5535e50da539",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=Sarlat",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-sarlatbus-gtfs-gtfs-rt",
@@ -10726,7 +10252,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-du-reseau-sarlatbus-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=Sarlat",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/1bffdcb5-1839-4725-90da-ca69d1ee05e6",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-du-reseau-sarlatbus-gtfs-gtfs-rt",
                 "spdx-identifier": "ODbL-1.0"
@@ -10739,7 +10265,6 @@
             "name": "horaires-theoriques-et-temps-reel-des-navettes-de-la-ligne-bagneres-la-mongie-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/2a189c2d-7ccd-4b2e-bca0-40df0734fe0a",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=bigorre-mongie",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-de-la-ligne-bagneres-la-mongie-gtfs-gtfs-rt",
@@ -10752,7 +10277,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-des-navettes-de-la-ligne-bagneres-la-mongie-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=bigorre-mongie",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/13e21700-b412-4a2b-9701-93218dbb77ec",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-de-la-ligne-bagneres-la-mongie-gtfs-gtfs-rt",
                 "spdx-identifier": "ODbL-1.0"
@@ -10765,7 +10290,6 @@
             "name": "reseau-cvlmobilite-plan-de-transport-theorique-la-navette-lete-a-chinon-format-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/af410692-57e7-44a3-b888-4efccdf77014",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-cvlmobilite-plan-de-transport-theorique-la-navette-lete-a-chinon-format-gtfs/20250624-073609/lanavette-leteachinon-2025-v3.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-cvlmobilite-plan-de-transport-theorique-la-navette-lete-a-chinon-format-gtfs",
@@ -10780,7 +10304,6 @@
             "name": "reseau-de-transports-collectifs-de-la-ccgq",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/bf92984d-4441-4cad-9879-b7209acba875",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-de-transports-collectifs-de-la-ccgq/20251216-110900/gtfsv1.6.4.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transports-collectifs-de-la-ccgq",
@@ -10794,7 +10317,6 @@
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-cavalaire-ete",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/7b2f319f-a028-4db7-826f-1bd71d636a01",
-            "url-override": "https://pysae.com/api/v2/groups/cavalaire/gtfs/pub",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-cavalaire-ete",
@@ -10809,7 +10331,6 @@
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-cavalaire-sur-mer-hiver",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/7c5842e2-0420-4e60-a2ad-90c077c03505",
-            "url-override": "https://pysae.com/api/v2/groups/cavalaire/gtfs/pub",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-cavalaire-sur-mer-hiver",
@@ -10823,7 +10344,7 @@
         {
             "name": "velos-a-assistance-electrique-en-libre-service-des-ports-de-piriac-sur-mer-et-de-la-turballe",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/rhoule/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/66354ca6-1590-4473-b697-95ea988e1378",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-des-ports-de-piriac-sur-mer-et-de-la-turballe",
@@ -10836,7 +10357,6 @@
             "name": "navettes-bourg-saint-maurice",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/76210b43-2647-413a-84ed-adf07b0a7392",
-            "url-override": "https://static.data.gouv.fr/resources/navettes-bourg-saint-maurice/20260113-093044/gtfs-13-01-2026-05-00-la-ronde.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/navettes-bourg-saint-maurice",
@@ -10851,7 +10371,6 @@
             "name": "transports-en-commun-pays-des-ecrins",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/83467/download",
-            "url-override": "https://www.datasud.fr/fr/dataset/datasets/4311/resource/5843/download/",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transports-en-commun-pays-des-ecrins",
@@ -10864,7 +10383,7 @@
         {
             "name": "transports-en-commun-pays-des-ecrins",
             "type": "url",
-            "url": "https://app.pysae.com/api/v2/groups/pays-des-ecrins/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/252fd29f-4a13-4e38-9e9e-6d3c09e9bb5a",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transports-en-commun-pays-des-ecrins",
                 "spdx-identifier": "etalab-2.0"
@@ -10877,7 +10396,6 @@
             "name": "les-navettes-du-giffre-horaires-hiver-2023-2024",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/58b67800-a341-44f8-9a31-864d578b9757",
-            "url-override": "https://static.data.gouv.fr/resources/les-navettes-du-giffre-horaires-hiver-2023-2024/20240119-105247/gtfs-les-navettes-du-giffre-2024-v1-valide-pan.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/les-navettes-du-giffre-horaires-hiver-2023-2024",
@@ -10890,7 +10408,7 @@
         {
             "name": "porte-de-vassiviere-vls",
             "type": "url",
-            "url": "https://www.mobility-parc.net/gbfs/v3/VASSIVIERE/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/1abc8d61-57ad-4d7d-95ee-efaf679f3fd9",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/porte-de-vassiviere-vls",
@@ -10903,7 +10421,6 @@
             "name": "arrets-horaires-et-circuit-de-la-lignes-yeu-continent-gtfs",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b57c66f2-ecaf-4934-a530-753bcb8aad04",
-            "url-override": "https://app.mecatran.com/utw/ws/gtfsfeed/static/pdlYeuContinent?apiKey=2c715462180f36483d5f24340c706b627f2f2361",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/arrets-horaires-et-circuit-de-la-lignes-yeu-continent-gtfs",
@@ -10917,7 +10434,6 @@
             "name": "reseau-urbain-lislenbus-commune-de-lisle-sur-tarn",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/75f3dd86-0840-445a-92a6-b329bdc61e0c",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-urbain-lislenbus-commune-de-lisle-sur-tarn/20250904-132204/gtfs-lisle.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-lislenbus-commune-de-lisle-sur-tarn",
@@ -10931,7 +10447,6 @@
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-navette-estivale-grimaud",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/7a182d63-ebe2-4490-8bc8-188ae7312c23",
-            "url-override": "https://pysae.com/api/v2/groups/suma-22ua/gtfs/pub",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-navette-estivale-grimaud",
@@ -10946,7 +10461,6 @@
             "name": "navette-pontorson-le-mont-st-michel",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/7e0312ef-a6e0-41ab-a75a-2b782a4b1d6b",
-            "url-override": "https://static.data.gouv.fr/resources/navette-pontorson-le-mont-st-michel/20251215-141949/pt-th-offer-navettestmichel-gtfs-20251212-733-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/navette-pontorson-le-mont-st-michel",
@@ -10960,7 +10474,6 @@
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-ligne-de-la-croix-valmer",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/bf169a63-e51b-44b3-bca0-e7aaa3335109",
-            "url-override": "https://pysae.com/api/v2/groups/croix-valmer/gtfs/pub",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-ligne-de-la-croix-valmer",
@@ -10975,7 +10488,6 @@
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-navette-reguliere-saint-tropez",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/147fd87d-9898-42a9-af88-748c0ac9bb52",
-            "url-override": "https://pysae.com/api/v2/groups/st-tropez/gtfs/pub",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-navette-reguliere-saint-tropez",
@@ -10988,7 +10500,7 @@
         {
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-navette-reguliere-saint-tropez",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/st-tropez/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/c9e695c5-59db-4e1e-8016-ee5b98399dc9",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-navette-reguliere-saint-tropez",
                 "spdx-identifier": "etalab-2.0"
@@ -11001,7 +10513,6 @@
             "name": "navette-chorges-chanteloube-ete-2025-reseau-vai",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/619cfea8-a866-40bc-b431-b7f85af6066f",
-            "url-override": "https://static.data.gouv.fr/resources/navette-chorges-chanteloube-ete-2025-reseau-vai/20250626-103805/horaires-vai-chorges-chanteloube-ete-2025.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/navette-chorges-chanteloube-ete-2025-reseau-vai",
@@ -11016,7 +10527,6 @@
             "name": "bagnoles-de-lorne",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/82314/download",
-            "url-override": "https://static.data.gouv.fr/resources/bagnoles-de-lorne/20251110-083004/pt-th-offer-bagnoles-gtfs-20251104-313-opendata.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/bagnoles-de-lorne",
@@ -11031,7 +10541,6 @@
             "name": "skibus-courchevel-hiver",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/9090506e-731b-4aec-b5ea-116ae6902ce0",
-            "url-override": "https://static.data.gouv.fr/resources/skibus-courchevel-hiver/20251201-204244/gtfs-01-12-2025-05-00.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/skibus-courchevel-hiver",
@@ -11045,7 +10554,6 @@
             "name": "transport-urbain-par-cable-hiver-2025-26",
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/83744/download",
-            "url-override": "https://static.data.gouv.fr/resources/transport-urbain-par-cable-hiver-2025-26/20251211-092237/rmu-courchevel-20251210.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/transport-urbain-par-cable-hiver-2025-26",
@@ -11059,7 +10567,6 @@
             "name": "navettes-tignes",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/9f5669e6-202f-4166-99e4-0e15586e1473",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=tignes",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/navettes-tignes",
@@ -11072,7 +10579,7 @@
         {
             "name": "navettes-tignes",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=tignes",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a93d2e49-c4c3-4f8c-8e03-ce346c2d53b2",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/navettes-tignes",
                 "spdx-identifier": "etalab-2.0"
@@ -11085,7 +10592,6 @@
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-navette-estivale-ramatuelle",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/629ffcc9-152e-4526-9720-3ccf944c97e2",
-            "url-override": "https://pysae.com/api/v2/groups/keolis-yr25/gtfs/pub",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-navette-estivale-ramatuelle",
@@ -11100,7 +10606,6 @@
             "name": "meribus-hiver",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/092c3d95-d415-46c6-a07f-92d6e45453b1",
-            "url-override": "https://static.data.gouv.fr/resources/meribus-hiver/20241227-091327/gtfs-27-12-24.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/meribus-hiver",
@@ -11115,7 +10620,6 @@
             "name": "navettes-val-disere",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d6c3eae8-fab6-4ff2-adc2-32bb2d213dd7",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=valdisere",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/navettes-val-disere",
@@ -11128,7 +10632,7 @@
         {
             "name": "navettes-val-disere",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=valdisere",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/28c1bf4a-90d8-4360-baf3-ceaea2a1941f",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/navettes-val-disere",
                 "spdx-identifier": "etalab-2.0"
@@ -11141,7 +10645,6 @@
             "name": "horaires-theoriques-et-temps-reel-des-navettes-hivernales-de-lalpe-dhuez-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/c3fa69f0-f8b1-4324-be67-be72baf80ceb",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=alpe-huez",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-hivernales-de-lalpe-dhuez-gtfs-gtfs-rt",
@@ -11155,7 +10658,6 @@
             "name": "horaires-theoriques-et-temps-reel-de-la-station-de-ski-valmorel-gtfs-gtfs-rt",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/300108a3-f8c1-4bc8-873e-f1243d49716b",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=valmorel",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-de-la-station-de-ski-valmorel-gtfs-gtfs-rt",
@@ -11168,7 +10670,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-de-la-station-de-ski-valmorel-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=valmorel",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/136b953f-2b70-4c01-85ef-eb71169d0656",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-de-la-station-de-ski-valmorel-gtfs-gtfs-rt",
                 "spdx-identifier": "ODbL-1.0"
@@ -11181,7 +10683,6 @@
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-ligne-le-rayol-canadel-sur-mer",
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d4d91019-c15a-4733-bd2d-0ebf17d69993",
-            "url-override": "https://pysae.com/api/v2/groups/rayol-canadel/gtfs/pub",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-ligne-le-rayol-canadel-sur-mer",
@@ -11195,7 +10696,7 @@
         {
             "name": "velos-a-assistance-electrique-en-libre-service-vernou-en-sologne-vernou-velo",
             "type": "url",
-            "url": "https://api.gbfs.ecovelo.mobi/vernouvelo/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/5c0a4e1c-97ae-4c71-8314-ade36d60f414",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-vernou-en-sologne-vernou-velo",
@@ -11267,7 +10768,7 @@
         {
             "name": "breizhgo-car",
             "type": "url",
-            "url": "https://www.korrigo.bzh/ftp/OPENDATA/gtfsrt/BREIZHGO_CAR_RLP.GtfsRt.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/c83539f2-b19e-46fe-a6f1-98fd2030a395",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/breizhgo-car",
                 "spdx-identifier": "ODbL-1.0"
@@ -11281,7 +10782,7 @@
         {
             "name": "offre-de-transport-tam-en-temps-reel-gtfs-rt-urbain-et-suburbain",
             "type": "url",
-            "url": "https://data.montpellier3m.fr/GTFS/Urbain/Alert.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/8d83572e-0b49-4dba-9691-c25aec6b5b5b",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-tam-en-temps-reel-gtfs-rt-urbain-et-suburbain",
                 "spdx-identifier": "ODbL-1.0"
@@ -11295,7 +10796,7 @@
         {
             "name": "offre-de-transport-tam-en-temps-reel-gtfs-rt-urbain-et-suburbain",
             "type": "url",
-            "url": "https://data.montpellier3m.fr/GTFS/Urbain/TripUpdate.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/297e8061-5435-409a-aa94-4170f215ef69",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-tam-en-temps-reel-gtfs-rt-urbain-et-suburbain",
                 "spdx-identifier": "ODbL-1.0"
@@ -11323,7 +10824,7 @@
         {
             "name": "gtfs-sankeo",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?src=true&dataset=sankeo-scolaire",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/793437a0-d3df-4b77-89d5-72525d49800b",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/gtfs-sankeo",
                 "spdx-identifier": "etalab-2.0"
@@ -11365,7 +10866,7 @@
         {
             "name": "donnees-tcat-troyes-champagne-metropole-1",
             "type": "url",
-            "url": "http://94.143.218.42:13485/ProfilGtfsRt2_0RSProducer-TCAT/Alert.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/cab95ea5-0366-466f-a016-fda666083113",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-tcat-troyes-champagne-metropole-1",
                 "spdx-identifier": "ODbL-1.0"
@@ -11379,7 +10880,7 @@
         {
             "name": "donnees-tcat-troyes-champagne-metropole-1",
             "type": "url",
-            "url": "http://94.143.218.42:13485/ProfilGtfsRt2_0RSProducer-TCAT/TripUpdate.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/8dc66569-b744-4d22-95df-f8496e8eddb6",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-tcat-troyes-champagne-metropole-1",
                 "spdx-identifier": "ODbL-1.0"
@@ -11393,7 +10894,7 @@
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-corolis-interurbain-communaute-dagglomeration-du-beauvaisis",
             "type": "url",
-            "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=COROLIS_INT&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/774a4d3c-3af0-4233-907e-b01543adb47c",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-corolis-interurbain-communaute-dagglomeration-du-beauvaisis",
                 "spdx-identifier": "etalab-2.0"
@@ -11407,7 +10908,7 @@
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-axo-communaute-dagglomeration-creil-sud-oise",
             "type": "url",
-            "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=AXO&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/353eac69-85e8-47ee-9e2c-a17a6146f966",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-axo-communaute-dagglomeration-creil-sud-oise",
                 "spdx-identifier": "etalab-2.0"
@@ -11421,7 +10922,7 @@
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-pass-thelle-bus-communaute-de-communes-thelloise",
             "type": "url",
-            "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=PASSTHELLE&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/7f983f50-d0e8-441a-9e31-24affa02efe5",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-pass-thelle-bus-communaute-de-communes-thelloise",
                 "spdx-identifier": "etalab-2.0"
@@ -11435,7 +10936,7 @@
         {
             "name": "donnees-du-reseau-evad-1",
             "type": "url",
-            "url": "https://evad.nuamouv.com/tempsreel/api/gtfs-rt/trip_update",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a8779e50-c43e-4f8d-a7f7-f4f95eeed38a",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-du-reseau-evad-1",
                 "spdx-identifier": "etalab-2.0"
@@ -11449,7 +10950,7 @@
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-sablons-bus-communaute-de-communes-des-sablons",
             "type": "url",
-            "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=SABLONS&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/15c9ecd8-c077-4694-8cf2-11d575c3f571",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-sablons-bus-communaute-de-communes-des-sablons",
                 "spdx-identifier": "etalab-2.0"
@@ -11477,7 +10978,7 @@
         {
             "name": "donnees-theoriques-et-temps-reel-du-reseau-le-bus-communaute-de-communes-du-clermontois",
             "type": "url",
-            "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=LEBUS&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/ad1dd49f-5a24-4ba6-8313-940aa55f89b4",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-et-temps-reel-du-reseau-le-bus-communaute-de-communes-du-clermontois",
                 "spdx-identifier": "etalab-2.0"
@@ -11519,7 +11020,7 @@
         {
             "name": "donnees-theoriques-du-reseau-hopla-communaute-de-communes-de-la-plaine-destrees",
             "type": "url",
-            "url": "https://api.oisemob.cityway.fr/dataflow/horaire-tc-tr/download?provider=HOPLA&dataFormat=gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/35431ce0-2b02-4585-b125-55849208b6b5",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-hopla-communaute-de-communes-de-la-plaine-destrees",
                 "spdx-identifier": "etalab-2.0"
@@ -11533,7 +11034,7 @@
         {
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-ligne-cogolin",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/keolis-hH93/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/f70d2bfc-bd00-4483-8bee-5e63e061da0c",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-ligne-cogolin",
                 "spdx-identifier": "etalab-2.0"
@@ -11547,7 +11048,7 @@
         {
             "name": "noirmoutier-gratibus-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/noirmoutiers/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/e3f2ac4c-758b-4dbd-9854-aa4d95c27d16",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/noirmoutier-gratibus-gtfs-gtfs-rt",
                 "spdx-identifier": "etalab-2.0"
@@ -11561,7 +11062,7 @@
         {
             "name": "reseau-cvlmobilite-plan-de-transport-theorique-la-navette-lete-a-chinon-format-gtfs",
             "type": "url",
-            "url": "https://app.pysae.com/api/v2/groups/cc-cvl-navette-estivale/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/82608db8-ab62-48d8-83de-decaed8828b3",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-cvlmobilite-plan-de-transport-theorique-la-navette-lete-a-chinon-format-gtfs",
                 "spdx-identifier": "etalab-2.0"
@@ -11575,7 +11076,7 @@
         {
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-cavalaire-ete",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/cavalaire/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/4c4bff81-2262-46d5-bdfe-0f9b8f011791",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-cavalaire-ete",
                 "spdx-identifier": "etalab-2.0"
@@ -11589,7 +11090,7 @@
         {
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-cavalaire-sur-mer-hiver",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/cavalaire-h/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/9de19eb9-e492-452f-aa17-5e9a9c646a87",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-cavalaire-sur-mer-hiver",
                 "spdx-identifier": "etalab-2.0"
@@ -11603,7 +11104,7 @@
         {
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-navette-estivale-grimaud",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/suma-22ua/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/889cbca3-5042-4e8a-b334-44c3cc6d9ca7",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-navette-estivale-grimaud",
                 "spdx-identifier": "etalab-2.0"
@@ -11617,7 +11118,7 @@
         {
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-ligne-de-la-croix-valmer",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/croix-valmer/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/70ae510d-acad-4f36-a801-c7ed0227f65f",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-ligne-de-la-croix-valmer",
                 "spdx-identifier": "etalab-2.0"
@@ -11631,7 +11132,7 @@
         {
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-navette-estivale-ramatuelle",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/keolis-yr25/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/2e5fef94-2227-4daf-b979-4f3eac3c6eb4",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-navette-estivale-ramatuelle",
                 "spdx-identifier": "etalab-2.0"
@@ -11645,7 +11146,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-des-navettes-hivernales-de-lalpe-dhuez-gtfs-gtfs-rt",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=alpe-huez",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/8b8b8c8b-58a7-4c9e-97da-8c21d10ecb54",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-des-navettes-hivernales-de-lalpe-dhuez-gtfs-gtfs-rt",
                 "spdx-identifier": "ODbL-1.0"
@@ -11659,7 +11160,7 @@
         {
             "name": "golfe-de-saint-tropez-donnees-mobilite-tc-ligne-le-rayol-canadel-sur-mer",
             "type": "url",
-            "url": "https://pysae.com/api/v2/groups/rayol-canadel/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/bfc5382b-62eb-4b11-994f-213383c468f8",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/golfe-de-saint-tropez-donnees-mobilite-tc-ligne-le-rayol-canadel-sur-mer",
                 "spdx-identifier": "etalab-2.0"
@@ -11672,7 +11173,7 @@
         },
         {
             "type": "url",
-            "url": "https://data.montpellier3m.fr/GTFS/Suburbain/Alert.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/5b1a9be1-2fed-4233-b2e6-7d26e7acd85e",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-tam-en-temps-reel-gtfs-rt-urbain-et-suburbain",
                 "spdx-identifier": "ODbL-1.0"
@@ -11686,7 +11187,7 @@
         },
         {
             "type": "url",
-            "url": "https://data.montpellier3m.fr/GTFS/Suburbain/TripUpdate.pb",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/4f7aa71d-a7e5-4c03-8074-03a233304266",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/offre-de-transport-tam-en-temps-reel-gtfs-rt-urbain-et-suburbain",
                 "spdx-identifier": "ODbL-1.0"
@@ -11701,7 +11202,6 @@
         {
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/d358344a-ed1e-4d74-b092-9cbc517b10a8",
-            "url-override": "https://static.data.gouv.fr/resources/agence-agglobus/20260105-150907/fichiers-gtfs-2026-v3-semop-agglobus-1.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/agence-agglobus",
@@ -11730,7 +11230,6 @@
         {
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/3b659ebb-8c17-46f4-a8ac-78c4129a4a29",
-            "url-override": "https://static.data.gouv.fr/resources/jeu-de-donnee-spl-estival-2025/20251229-033845/gtfs-2026-splestival-vf.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/jeu-de-donnee-spl-estival-2025",
@@ -11756,7 +11255,7 @@
         },
         {
             "type": "url",
-            "url": "https://backend.citiz.fr/public/provider/1/gbfs/v3.0/gbfs.json",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/0a81bd24-df76-4d1f-a712-3265b1ee75d8",
             "spec": "gbfs",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/citiz-autopartage-grand-est",
@@ -11781,7 +11280,6 @@
         {
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f884648b-d687-4448-bc4c-2fc988ea0aed",
-            "url-override": "https://data.orleans-metropole.fr/api/v2/catalog/datasets/om-mobilite-tao-tad-gtfsflex/alternative_exports/gtfs_flex_tao_012026_062026_zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/description-de-loffre-tad-tao-gtfs-flex-orleans-metropole",
@@ -11870,7 +11368,6 @@
         {
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/b0687cf2-03f5-4d39-8412-01b3d93e0d2b",
-            "url-override": "https://app.pysae.com/api/v4/groups/caux-seine-agglo/gtfs/pub",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-caux-seine-mobilite-rezobus",
@@ -11883,7 +11380,6 @@
         {
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/bd5489c2-5f32-4b06-8d55-e5a6f4fd6a51",
-            "url-override": "https://data.chateauroux-metropole.fr/api/v2/catalog/datasets/reseau-de-bus-urbain_horizon/alternative_exports/gtfs_20260105_zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-bus-urbain-horizon",
@@ -11896,7 +11392,6 @@
         {
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/f9aa3acb-49d8-4a42-9951-1c31e39a3af8",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-de-bus-urbain-horizon/20260109-125620/gtfs-20260105.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-bus-urbain-horizon",
@@ -11909,7 +11404,6 @@
         {
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/89e09fb6-0bf6-4ca5-95f3-50444ab6c681",
-            "url-override": "https://www.datasud.fr/fr/dataset/datasets/2268/resource/6459/download/",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-transcove-de-la-communaute-dagglomeration-ventoux-comtat-venaissin",
@@ -11946,7 +11440,6 @@
         {
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/117daa0d-0708-43aa-a562-7d5b3d6570b0",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-de-transport-en-commun-trans-agglo-de-dlva/20260107-075252/gtfs-695e0e00e75be-0701.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-en-commun-trans-agglo-de-dlva",
@@ -11971,7 +11464,6 @@
         {
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/7d399812-e018-4e35-b3ae-a5ba44c8ad91",
-            "url-override": "https://static.data.gouv.fr/resources/donnees-theoriques-du-reseau-urbain-de-flers-agglo-au-format-gtfs/20251230-082209/nemus-gtfs-du-01-01-26-au-31-08-26.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-urbain-de-flers-agglo-au-format-gtfs",
@@ -11984,7 +11476,7 @@
         {
             "name": "donnees-theoriques-du-reseau-urbain-de-flers-agglo-au-format-gtfs",
             "type": "url",
-            "url": "https://flers-agglo.plateforme-2cloud.com/api/gtfsrt/2.0/tripupdates/FLERS-5197-3181-6523/bin?network=104",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/f8d5faf0-7662-41c1-97e2-dca45f77a3d6",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-theoriques-du-reseau-urbain-de-flers-agglo-au-format-gtfs",
                 "spdx-identifier": "etalab-2.0"
@@ -11996,7 +11488,6 @@
         {
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/bfc5c9da-7c0d-4f75-801d-be7e15d13e24",
-            "url-override": "https://static.data.gouv.fr/resources/reseau-de-transport-urbains-dignois/20260108-152955/rtud-version-12-gtfs-2026-01-08-16-27-04.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-de-transport-urbains-dignois",
@@ -12009,7 +11500,6 @@
         {
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/eff9558e-4575-429f-bbe1-0cd37f1e6432",
-            "url-override": "https://static.data.gouv.fr/resources/donnees-de-mobilite/20240306-080523/gtfs-20231212-082604-villeo.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/donnees-de-mobilite",
@@ -12036,7 +11526,6 @@
         {
             "type": "http",
             "url": "https://transport.data.gouv.fr/resources/83787/download",
-            "url-override": "https://static.data.gouv.fr/resources/skibus-vallee-des-belleville/20251218-092339/gtfs-test-16-12-2025-16-36.zip",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/skibus-vallee-des-belleville",
@@ -12049,7 +11538,6 @@
         {
             "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/5dcdb39b-aee3-4a0f-a9a9-be225f5a8b78",
-            "url-override": "https://zenbus.net/gtfs/static/download.zip?dataset=sitac-calais-rt",
             "fix": true,
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-aux-formats-gtfs-et-gtfs-rt-du-reseau-sitac",
@@ -12062,7 +11550,7 @@
         {
             "name": "horaires-theoriques-et-temps-reel-aux-formats-gtfs-et-gtfs-rt-du-reseau-sitac",
             "type": "url",
-            "url": "https://zenbus.net/gtfs/rt/poll.proto?dataset=sitac-calais-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/a6086d6b-049b-4fe8-b52a-4bdcf863db83",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/horaires-theoriques-et-temps-reel-aux-formats-gtfs-et-gtfs-rt-du-reseau-sitac",
                 "spdx-identifier": "etalab-2.0"
@@ -12073,7 +11561,7 @@
         },
         {
             "type": "url",
-            "url": "https://app.pysae.com/api/v4/groups/caux-seine-agglo/gtfs-rt",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/ea44be8d-36ef-4aac-b56f-98b78eb54382",
             "license": {
                 "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-caux-seine-mobilite-rezobus",
                 "spdx-identifier": "ODbL-1.0"

--- a/src/update-france.py
+++ b/src/update-france.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
                 )
                 source = {
                     "type": "url",
-                    "url": resource["original_url"],
+                    "url": resource["url"],
                     "spec": "gbfs",
                     "license": {},
                     "x-data-gov-fr-res-id": resource["id"],
@@ -126,7 +126,6 @@ if __name__ == "__main__":
                 source = {
                     "type": "http",
                     "url": resource["url"],
-                    "url-override": resource["original_url"],
                     "fix": True,
                     "license": {},
                     "x-data-gov-fr-res-id": resource["id"],


### PR DESCRIPTION
Many feeds don't have stable urls, the redirects fix that.

We stopped using them, as some used to return a csv containing multiple links instead of the GTFS directly, but this no longer seems to be the case.