### PR TITLE
Restore European Sleeper and fix its route type

### DIFF
--- a/feeds/nl.json
+++ b/feeds/nl.json
@@ -50,8 +50,9 @@
             "transitland-atlas-id": "f-u-nl",
             "fix": true,
             "keep-agency-names": [
-                "Eu Sleeper"
-            ]
+                "European Sleeper"
+            ],
+            "script": "nl-ovapi.lua"
         },
         {
             "name": "ovapi",

--- a/scripts/nl-ovapi.lua
+++ b/scripts/nl-ovapi.lua
@@ -1,0 +1,13 @@
+-- SPDX-FileCopyrightText: Volker Krause <vkrause@kde.org>
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+require "scripts.motis"
+
+function process_route(route)
+    -- correct route type for European Sleeper
+    if route:get_route_type() == 2 and route:get_agency():get_name() == "European Sleeper" then
+        route:set_clasz(NIGHT_RAIL)
+        route:set_route_type(105)
+    end
+    return true
+end


### PR DESCRIPTION
The agency name in the nl-ovapi feed changed, also filtering them out. While at it, also correctly mark it as night rail.