### PR TITLE
fix incorrect 'spdx_identifier' to 'spdx-identifier' in some feeds

### DIFF
--- a/feeds/au-nsw.json
+++ b/feeds/au-nsw.json
@@ -16,7 +16,7 @@
             "mdb-id": "mdb-2449",
             "fix": true,
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             }
         },
         {
@@ -24,7 +24,7 @@
             "type": "http",
             "url": "https://opendata.transport.nsw.gov.au/data/dataset/a5ecd906-ce73-484c-8cea-fa6fecfe368e/resource/e25092cc-67a1-469c-b57a-20793c259486/download/ondemand_gtfsflex.zip",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "use-gtfsclean": false
         },
@@ -34,7 +34,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/schedule/metro",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -50,7 +50,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/realtime/metro",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -64,7 +64,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/metro",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -78,7 +78,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/sydneytrains",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -86,7 +86,9 @@
                 }
             },
             "script": "au-nsw-sydney-trains.lua",
-            "drop-agency-names": ["NSW Trains"],
+            "drop-agency-names": [
+                "NSW Trains"
+            ],
             "skip": true,
             "skip-reason": "rate-limiting"
         },
@@ -96,7 +98,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/realtime/sydneytrains",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -110,7 +112,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/sydneytrains",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -125,7 +127,7 @@
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/nswtrains",
             "fix": true,
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -141,7 +143,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/nswtrains",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -155,7 +157,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/nswtrains",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -169,7 +171,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/ferries/sydneyferries",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -185,7 +187,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/ferries/sydneyferries",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -199,7 +201,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/ferries",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -213,7 +215,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/ferries/MFF",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -229,7 +231,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/ferries/MFF",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -243,7 +245,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/ferries",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -257,7 +259,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/lightrail/innerwest",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -273,7 +275,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/lightrail/innerwest",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -287,7 +289,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/lightrail",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -301,7 +303,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/lightrail/cbdandsoutheast",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -317,7 +319,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/lightrail/cbdandsoutheast",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -331,7 +333,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/lightrail",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -345,7 +347,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/lightrail/parramatta",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -361,7 +363,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/lightrail/parramatta",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -375,7 +377,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/lightrail",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -389,7 +391,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/lightrail/newcastle",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -405,7 +407,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/lightrail/newcastle",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -419,7 +421,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/lightrail",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -433,7 +435,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/OSMBSC001",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -449,7 +451,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -463,7 +465,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -477,7 +479,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/OSMBSC002",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -493,7 +495,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -507,7 +509,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -521,7 +523,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/OSMBSC003",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -537,7 +539,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -551,7 +553,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -565,7 +567,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/OSMBSC004",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -581,7 +583,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -595,7 +597,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -609,7 +611,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/OSMBSC008",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -625,7 +627,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -639,7 +641,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -653,7 +655,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/OSMBSC009",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -669,7 +671,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -683,7 +685,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -697,7 +699,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/OSMBSC010",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -713,7 +715,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -727,7 +729,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -741,7 +743,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/OSMBSC011",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -757,7 +759,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -771,7 +773,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -785,7 +787,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/OSMBSC012",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -801,7 +803,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -815,7 +817,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -829,7 +831,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/SBSC006",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -845,7 +847,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -859,7 +861,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -873,7 +875,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/GSBC001",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -889,7 +891,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -903,7 +905,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -917,7 +919,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/GSBC002",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -933,7 +935,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -947,7 +949,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -961,7 +963,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/GSBC003",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -977,7 +979,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -991,7 +993,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1005,7 +1007,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/GSBC004",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1021,7 +1023,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1035,7 +1037,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1049,7 +1051,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/GSBC007",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1065,7 +1067,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1079,7 +1081,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1093,7 +1095,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/GSBC008",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1109,7 +1111,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1123,7 +1125,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1137,7 +1139,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/GSBC009",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1153,7 +1155,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1167,7 +1169,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1181,7 +1183,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/GSBC010",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1197,7 +1199,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1211,7 +1213,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1225,7 +1227,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/GSBC014",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1241,7 +1243,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1255,7 +1257,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1269,7 +1271,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/NISC001",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1285,7 +1287,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1299,7 +1301,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1313,7 +1315,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/regionbuses/centralwestandorana",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1329,7 +1331,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/regionbuses/centralwestandorana",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1343,7 +1345,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/regionbuses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1357,7 +1359,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/regionbuses/farwest",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1373,7 +1375,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/regionbuses/farwest",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1387,7 +1389,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/regionbuses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1401,7 +1403,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/regionbuses/newenglandnorthwest",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1417,7 +1419,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/regionbuses/newenglandnorthwest",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1431,7 +1433,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/regionbuses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1445,7 +1447,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/regionbuses/northcoast",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1461,7 +1463,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/regionbuses/northcoast",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1475,7 +1477,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/regionbuses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1489,7 +1491,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/regionbuses/riverinamurray",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1505,7 +1507,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/regionbuses/riverinamurray",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1519,7 +1521,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/regionbuses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1533,7 +1535,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/regionbuses/riverinamurray",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1549,7 +1551,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/regionbuses/riverinamurray",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1563,7 +1565,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/regionbuses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1577,7 +1579,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/regionbuses/southeasttablelands",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1593,7 +1595,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/regionbuses/southeasttablelands",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1607,7 +1609,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/regionbuses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1621,7 +1623,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/regionbuses/sydneysurrounds",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1637,7 +1639,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/regionbuses/sydneysurrounds",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1651,7 +1653,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/regionbuses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1665,7 +1667,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/regionbuses/centralwestandorana2",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1681,7 +1683,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/regionbuses/centralwestandorana2",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1695,7 +1697,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/regionbuses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1709,7 +1711,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/regionbuses/northcoast2",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1725,7 +1727,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/regionbuses/northcoast2",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1739,7 +1741,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/regionbuses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1753,7 +1755,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/regionbuses/northcoast3",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1769,7 +1771,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/regionbuses/northcoast3",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1783,7 +1785,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/regionbuses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1797,7 +1799,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/regionbuses/riverinamurray2",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1813,7 +1815,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/regionbuses/riverinamurray2",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1827,7 +1829,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/regionbuses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1841,7 +1843,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/regionbuses/southeasttablelands2",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1857,7 +1859,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/regionbuses/southeasttablelands2",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1871,7 +1873,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/regionbuses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1885,7 +1887,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/regionbuses/newcastlehunter",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1901,7 +1903,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/regionbuses/newcastlehunter",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1915,7 +1917,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/regionbuses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1929,7 +1931,7 @@
             "spec": "gtfs",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/schedule/buses/ReplacementBus",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "http-options": {
                 "headers": {
@@ -1945,7 +1947,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v1/gtfs/realtime/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"
@@ -1959,7 +1961,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/buses",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "Authorization": "apikey eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJPRE5PRmoyZ3lXZEkxVzNfcXdTYVBqUUVnRldLMG9IV0lrS2VvZTdvUzhjIiwiaWF0IjoxNzU0MTY3MzQ4fQ.SEms0C7NpuZFHIz2mwisET8VzDrHqKGYVKt2rqGpkMU"

--- a/feeds/au-nt.json
+++ b/feeds/au-nt.json
@@ -12,7 +12,7 @@
             "spec": "gtfs",
             "url": "https://dli.nt.gov.au/data-feeds/bus-gtfs/google-transit-darwin.zip",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "fix": true
         },
@@ -22,7 +22,7 @@
             "spec": "gtfs",
             "url": "https://dipl.nt.gov.au/data-feeds/bus-gtfs/gtfs-alice-new.zip",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "fix": true
         }

--- a/feeds/au-tas.json
+++ b/feeds/au-tas.json
@@ -13,7 +13,7 @@
             "url": "https://www.transport.tas.gov.au/public_transport/gtfs-data",
             "function": "data_tasmania_latest_resource",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "fix": true
         }

--- a/feeds/au-vic.json
+++ b/feeds/au-vic.json
@@ -12,7 +12,7 @@
             "spec": "gtfs",
             "url": "https://gitlab.com/applecuckoo/gtfs-fixes/-/jobs/artifacts/main/raw/vic-gtfs.zip?job=victoria-mirror#1/google_transit.zip",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "fix": true
         },
@@ -22,7 +22,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/vline/vehicle-positions",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "KeyId": "ffb807b0-9a50-4123-b4d7-ce762f81d84b"
@@ -34,7 +34,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/vline/trip-updates",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "KeyId": "ffb807b0-9a50-4123-b4d7-ce762f81d84b"
@@ -46,7 +46,7 @@
             "spec": "gtfs",
             "url": "https://gitlab.com/applecuckoo/gtfs-fixes/-/jobs/artifacts/main/raw/vic-gtfs.zip?job=victoria-mirror#2/google_transit.zip",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "fix": true,
             "script": "au-vic-Transport-Victoria-metro-trains.lua"
@@ -57,7 +57,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/metro/service-alerts",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "KeyId": "ffb807b0-9a50-4123-b4d7-ce762f81d84b"
@@ -69,7 +69,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/metro/vehicle-positions",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "KeyId": "ffb807b0-9a50-4123-b4d7-ce762f81d84b"
@@ -81,7 +81,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/metro/trip-updates",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "KeyId": "ffb807b0-9a50-4123-b4d7-ce762f81d84b"
@@ -93,7 +93,7 @@
             "spec": "gtfs",
             "url": "https://gitlab.com/applecuckoo/gtfs-fixes/-/jobs/artifacts/main/raw/vic-gtfs.zip?job=victoria-mirror#3/google_transit.zip",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "fix": true
         },
@@ -103,7 +103,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/tram/service-alerts",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "KeyId": "ffb807b0-9a50-4123-b4d7-ce762f81d84b"
@@ -115,7 +115,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/tram/vehicle-positions",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "KeyId": "ffb807b0-9a50-4123-b4d7-ce762f81d84b"
@@ -127,7 +127,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/tram/trip-updates",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "KeyId": "ffb807b0-9a50-4123-b4d7-ce762f81d84b"
@@ -139,7 +139,7 @@
             "spec": "gtfs",
             "url": "https://gitlab.com/applecuckoo/gtfs-fixes/-/jobs/artifacts/main/raw/vic-gtfs.zip?job=victoria-mirror#4/google_transit.zip",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "fix": true
         },
@@ -149,7 +149,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/bus/vehicle-positions",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "KeyId": "ffb807b0-9a50-4123-b4d7-ce762f81d84b"
@@ -161,7 +161,7 @@
             "spec": "gtfs-rt",
             "url": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/bus/trip-updates",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "headers": {
                 "KeyId": "ffb807b0-9a50-4123-b4d7-ce762f81d84b"
@@ -173,7 +173,7 @@
             "spec": "gtfs",
             "url": "https://gitlab.com/applecuckoo/gtfs-fixes/-/jobs/artifacts/main/raw/vic-gtfs.zip?job=victoria-mirror#5/google_transit.zip",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "fix": true
         },
@@ -183,7 +183,7 @@
             "spec": "gtfs",
             "url": "https://gitlab.com/applecuckoo/gtfs-fixes/-/jobs/artifacts/main/raw/vic-gtfs.zip?job=victoria-mirror#6/google_transit.zip",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "fix": true
         },
@@ -193,7 +193,7 @@
             "spec": "gtfs",
             "url": "https://gitlab.com/applecuckoo/gtfs-fixes/-/jobs/artifacts/main/raw/vic-gtfs.zip?job=victoria-mirror#10/google_transit.zip",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "fix": true
         },
@@ -203,7 +203,7 @@
             "spec": "gtfs",
             "url": "https://gitlab.com/applecuckoo/gtfs-fixes/-/jobs/artifacts/main/raw/vic-gtfs.zip?job=victoria-mirror#11/google_transit.zip",
             "license": {
-                "spdx_identifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "fix": true
         }

--- a/feeds/gr.json
+++ b/feeds/gr.json
@@ -21,7 +21,7 @@
             "type": "http",
             "url": "https://www.gitlab.com/Lach-anonym/athens-gtfs/-/jobs/artifacts/main/raw/gtfs-rail.zip?job=download-republish-gtfs",
             "license": {
-                "spdx_identifier": "CC-BY-SA-4.0"
+                "spdx-identifier": "CC-BY-SA-4.0"
             },
             "fix": true,
             "extend-calendar": true

--- a/feeds/nz.json
+++ b/feeds/nz.json
@@ -149,23 +149,23 @@
             "spec": "gtfs",
             "url": "https://data.trilliumtransit.com/gtfs/hbrc-nz/hbrc-nz.zip",
             "license": {
-                "spdx_identifier": "CC-BY-4.0",
+                "spdx-identifier": "CC-BY-4.0",
                 "url": "https://www.gobay.co.nz/general-transit-feed-specification/"
             }
         },
         {
             "name": "JOLT-Hutt-Valley",
-            "type":"transitland-atlas",
+            "type": "transitland-atlas",
             "transitland-atlas-id": "f-jolt~hutt~valley~gbfs"
         },
         {
             "name": "JOLT-New-Plymouth",
-            "type":"transitland-atlas",
+            "type": "transitland-atlas",
             "transitland-atlas-id": "f-jolt~new~plymouth~gbfs"
         },
         {
             "name": "JOLT-Selwyn",
-            "type":"transitland-atlas",
+            "type": "transitland-atlas",
             "transitland-atlas-id": "f-jolt~selwyn~gbfs"
         }
     ]


### PR DESCRIPTION
Incorrect 'spdx_identifier' json key in some feeds resulted in `"spdx_license_identifier": null,` in https://api.transitous.org/gtfs/license.json