### PR TITLE
fix: es: Fix Metro Bilbao GTFS

### DIFF
--- a/feeds/es.json
+++ b/feeds/es.json
@@ -1153,10 +1153,6 @@
             "name": "Metro-Bilbao",
             "type": "http",
             "url": "https://ctb-gtfs.s3.eu-south-2.amazonaws.com/metrobilbao.zip",
-            "fix": true,
-            "http-options": {
-                "fetch-interval-days": 1
-            },
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.ctb.eus/en/pages/legal-notice"


### PR DESCRIPTION
Change the Metro Bilbao feed to the one coming from the regional transport consortium (CTB).
It's the source nap.transportes.gob.es was getting their data from, but somehow they stopped getting updates, as the latest update is from December 2026, and they only have data until 15th of January 2026. While the feed from CTB keeps getting daily updates. So this change cuts the middleman and gets the up to date data directly from the source.