### PR TITLE
Replace Kalisz PKS feed with proxy

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -495,7 +495,7 @@
             "name": "PKS-Kalisz",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://pks.kalisz.pl/wp-content/uploads/2025/07/PKS-20250528.zip",
+            "url": "https://gtfs.kasznia.net/static/kalisz-pks.zip",
             "license": {
                 "spdx-identifier": "CC0-1.0"
             }


### PR DESCRIPTION
Feed has unstable link and is now proxied through my VPS and residential server (source page blocks webpages on non polish IPs, so it's not possible to use `function` parameter)