### PR TITLE
hu: remove Weekendbus feed

### DIFF
--- a/feeds/hu.json
+++ b/feeds/hu.json
@@ -115,12 +115,6 @@
             "url": "https://gtfs.menetbrand.com/download/varpalota"
         },
         {
-            "name": "Weekendbus",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-u2mw-weekendbus",
-            "fix": true
-        },
-        {
             "name": "Kecskemét",
             "type": "http",
             "url": "https://timetable.keko.hu/Kecskemet_GTFS.zip",


### PR DESCRIPTION
As it turns out, Volánbusz took over some of their lines in 2025 and they are already in their GTFS. Regarding their other lines: another company took them over without producing a GTFS feed, unfortunately. (I've opened a TODO for it: https://github.com/gy-mate/gtfs-feeds/issues/4.)

Closes #1909.