### PR TITLE
Revert "Remove Stadtwerke Landshut agency from DELFI feed"

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -34,8 +34,7 @@
                 "FlixBus-de",
                 "EUROSTAR",
                 "Bremer Straßenbahn AG",
-                "Verkehrsgemeinschaft Osnabrück",
-                "Stadtwerke Landshut"
+                "Verkehrsgemeinschaft Osnabrück"
             ],
             "http-options": {
                 "fetch-interval-days": 2


### PR DESCRIPTION
Reverts public-transport/transitous#1822. Latest DELFI feed now only contains the later agency.