### PR TITLE
Add feed for morocco

### DIFF
--- a/feeds/ma.json
+++ b/feeds/ma.json
@@ -1,0 +1,18 @@
+{
+    "maintainers": [
+        {
+            "name": "Carl Schwan",
+            "github": "carlschwan"
+        }
+    ],
+    "sources": [
+        {
+            "name": "oncf",
+            "type": "http",
+            "url": "https://github.com/CarlSchwan/rail_maroc_oncf/raw/refs/heads/carl/expiration-date/oncf_gtfs.zip",
+            "license": {
+                "spdx-identifier": "ODbL-1.0"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
In preparation for my trip to Morocco soon :)  This is includes the only feed available in GTFS for ONCF (Office National des Chemins de Fer)

I also found another feed for Tétouan by  @bouhormq but it's 4 years old and likely quite outdated (see https://www.trufi-association.org/how-trufi-code-launched-an-app-and-career/)