### PR TITLE
Add RT feeds from next.zbiorkom.live

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -348,19 +348,18 @@
             "name": "TransportGZM",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://github.com/TransportGZM-GTFS-mirror/TransportGZM-GTFS-normal/releases/latest/download/TransportGZM-GTFS.zip",
+            "url": "https://mkuran.pl/gtfs/gzm.zip",
             "license": {
                 "spdx-identifier": "CC-BY-4.0"
-            },
-            "fix": true
+            }
         },
         {
             "name": "TransportGZM",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfsrt.transportgzm.pl:5443/gtfsrt/gzm/tripUpdates",
+            "url": "https://next.zbiorkom.live/api6-open/bydgoszcz/gtfsRealtime/default/tripUpdates",
             "license": {
-                "spdx-identifier": "CC-BY-4.0"
+                "spdx-identifier": "MIT"
             }
         },
         {
@@ -595,6 +594,15 @@
             "fix": true
         },
         {
+            "name": "Wschód-Express",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://next.zbiorkom.live/api6-open/bialystok/gtfsRealtime/WSCHODEXPRESS/tripUpdates",
+            "license": {
+                "spdx-identifier": "MIT"
+            }
+        },
+        {
             "name": "PKS-Nova-Supraśl",
             "type": "http",
             "spec": "gtfs",
@@ -671,6 +679,15 @@
                 "spdx-identifier": "CC0-1.0"
             },
             "fix": true
+        },
+        {
+            "name": "Opole",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://next.zbiorkom.live/api6-open/opole/gtfsRealtime/default/tripUpdates",
+            "license": {
+                "spdx-identifier": "MIT"
+            }
         },
         {
             "name": "Arriva",


### PR DESCRIPTION
- GZM: current RT source is broken for at least a couple months. RT from zbiorkom.live uses a different base feed.
- Opole and  Wschód Express: two operators with no RT untill now

See a comment from @DomeQdev about the new RT feeds: https://github.com/public-transport/transitous/pull/1928#issuecomment-3868010450