### PR TITLE
Fix Blablacar Bus route type

### DIFF
--- a/feeds/eu.json
+++ b/feeds/eu.json
@@ -32,7 +32,8 @@
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u0-ouibus",
             "url-override": "https://www.data.gouv.fr/api/1/datasets/r/fd54f81f-4389-4e73-be75-491133d011c3",
-            "fix": true
+            "fix": true,
+            "script": "eu-blablacarbus.lua"
         },
         {
             "name": "blablacar-bus",

--- a/scripts/eu-blablacarbus.lua
+++ b/scripts/eu-blablacarbus.lua
@@ -1,0 +1,12 @@
+-- SPDX-FileCopyrightText: Volker Krause <vkrause@kde.org>
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+require "scripts.motis"
+
+-- change generic bus type to long-distance coach
+function process_route(route)
+    if route:get_route_type() == 3 then
+        route:set_clasz(COACH)
+        route:set_route_type(200)
+  end
+end


### PR DESCRIPTION
MOTIS v2.8 doesn't have the coach detection heuristic anymore, so those were now only shown as regular busses.