### PR TITLE
Fix ALSA coach route types

### DIFF
--- a/feeds/es.json
+++ b/feeds/es.json
@@ -54,7 +54,8 @@
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "script": "es-alsa.lua"
         },
         {
             "name": "Autobús-Comarca-de-Pamplona",

--- a/scripts/es-alsa.lua
+++ b/scripts/es-alsa.lua
@@ -1,0 +1,13 @@
+-- SPDX-FileCopyrightText: Volker Krause <vkrause@kde.org>
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+require "scripts.motis"
+
+-- local and long-distance services are mixed in this feed, route_short_name == ALSA
+-- seems to match the long-distance services
+function process_route(route)
+    if route:get_route_type() == 3 and route:get_short_name() == "ALSA" then
+        route:set_clasz(COACH)
+        route:set_route_type(200)
+  end
+end


### PR DESCRIPTION
This was also previously covered by the MOTIS coach heuristic, and is a bit messy as ALSA mixes local and long-distance services in the same feed.