### PR TITLE
hu: add chairlift GTFS

### DIFF
--- a/feeds/hu.json
+++ b/feeds/hu.json
@@ -37,6 +37,11 @@
             "url": "https://gy-mate.hu/gtfs/gtfs_hu_funicular.zip"
         },
         {
+            "name": "bkk-chairlift",
+            "type": "http",
+            "url": "https://gy-mate.hu/gtfs/gtfs_hu_chairlift.zip"
+        },
+        {
             "name": "bkk",
             "type": "url",
             "spec": "gtfs-rt",


### PR DESCRIPTION
Add a self-created GTFS of the Budapest Chairlift. It's a simple line with regular headways.

The feed is automatically built and updated from [gy-mate/gtfs-feeds](https://github.com/gy-mate/gtfs-feeds/tree/302cc05268ff405eff4d34dfcd0ff108bb24def6/hu_chairlift). It's currently valid for the rest of 2026.