### PR TITLE
Consistently use set_route_type with set_clasz

### DIFF
--- a/scripts/pl-Koleje-Mazowieckie.lua
+++ b/scripts/pl-Koleje-Mazowieckie.lua
@@ -6,13 +6,15 @@ require "scripts.motis"
 function process_route(route)
     if route:get_id() == "ZL" then
         route:set_clasz(BUS)
-        route:set_route_type(700)
+        route:set_route_type(700) --BUS_SERVICE in future motis
 	elseif string.find(route:get_id(), "Z") then
 		route:set_clasz(BUS)
-		route:set_route_type(714) --rail replacement bus
+		route:set_route_type(714) --RAIL_REPLACEMENT_BUS_SERVICE in future motis
 	elseif string.find(route:get_id(), "RE") then
+		route:set_route_type(100) --RAILWAY_SERVICE in future motis
 		route:set_clasz(REGIONAL_FAST_RAIL)
 	else
+		route:set_route_type(106) --REGIONAL_RAIL_SERVICE in future motis
 		route:set_clasz(REGIONAL_RAIL)
 	end
 	return true

--- a/scripts/pl-Koleje-Wielkopolskie.lua
+++ b/scripts/pl-Koleje-Wielkopolskie.lua
@@ -4,5 +4,6 @@
 require "scripts.motis"
 
 function process_route(route)
+	route:set_route_type(106) --REGIONAL_RAIL_SERVICE in future motis
 	route:set_clasz(REGIONAL_RAIL)
 end

--- a/scripts/pl-PKP-Intercity.lua
+++ b/scripts/pl-PKP-Intercity.lua
@@ -5,16 +5,16 @@ require "scripts.motis"
 
 function process_route(route)
   if string.find(route:get_short_name(), "ZKA") then
-    route:set_route_type(714) -- rail replacement bus
+    route:set_route_type(714) --RAIL_REPLACEMENT_BUS_SERVICE in future motis
     route:set_clasz(BUS)
   elseif route:get_short_name() == "EIP" then
-    route:set_route_type(101)
+    route:set_route_type(101) --HIGH_SPEED_RAIL_SERVICE in future motis
     route:set_clasz(HIGHSPEED_RAIL)
   elseif route:get_short_name() == "EN" then
-    route:set_route_type(102)
+    route:set_route_type(105) --SLEEPER_RAIL_SERVICE in future motis
     route:set_clasz(NIGHT_RAIL)
   else
-    route:set_route_type(102)
+    route:set_route_type(102) --LONG_DISTANCE_TRAINS_SERVICE in future motis
     route:set_clasz(LONG_DISTANCE)
   end
 end

--- a/scripts/pl-PKP-SKM.lua
+++ b/scripts/pl-PKP-SKM.lua
@@ -4,6 +4,7 @@
 require "scripts.motis"
 
 function process_route(route)
+  route:set_route_type(109) -- SUBURBAN_RAILWAY_SERVICE in future motis
 	route:set_clasz(SUBURBAN)
 end
 

--- a/scripts/pl-PolRegio.lua
+++ b/scripts/pl-PolRegio.lua
@@ -13,11 +13,13 @@ end
 
 function process_route(route)
 	if route:get_short_name() == "REG" then
+		route:set_route_type(106) --REGIONAL_RAIL_SERVICE in future motis
 		route:set_clasz(REGIONAL_RAIL)
 	elseif route:get_short_name() == "IR" then
+		route:set_route_type(100) --RAILWAY_SERVICE in future motis
 		route:set_clasz(REGIONAL_FAST_RAIL)
 	elseif route:get_short_name() == "ZKA REG" then
 		route:set_clasz(BUS)
-		route:set_route_type(714) -- rail replacement bus
+		route:set_route_type(714) --RAIL_REPLACEMENT_BUS_SERVICE in future motis
 	end
 end

--- a/scripts/pl-RegioJet.lua
+++ b/scripts/pl-RegioJet.lua
@@ -5,8 +5,10 @@ require "scripts.motis"
 
 function process_route(route)
     if string.find(route:get_id(), "WEB/11755") then
+        route:set_route_type(104) -- SLEEPER_RAIL_SERVICE in future motis
         route:set_clasz(NIGHT_RAIL)
     else
+        route:set_route_type(102) -- LONG_DISTANCE_TRAINS_SERVICE in future motis
         route:set_clasz(LONG_DISTANCE)
     end
 end

--- a/scripts/pl-SKM-Warszawa.lua
+++ b/scripts/pl-SKM-Warszawa.lua
@@ -4,5 +4,6 @@
 require "scripts.motis"
 
 function process_route(route)
+  	route:set_route_type(109) -- SUBURBAN_RAILWAY_SERVICE in future motis
 	route:set_clasz(SUBURBAN)
 end


### PR DESCRIPTION
Due to https://github.com/motis-project/motis/issues/1294 only setting `clasz` does not work. This PR consistently sets route_type along with clasz in scripts for Poland. Also added comments which const to use when updating to a future motis relase (containing this commit: https://github.com/motis-project/motis/commit/d3aeade35f4b7172b25555cc9f8949a6ef317f36)