### PR TITLE
jp: Add cityofkawasaki bus feed

### DIFF
--- a/feeds/jp.json
+++ b/feeds/jp.json
@@ -20,6 +20,17 @@
             "transitland-atlas-id": "f-hiroden~jp",
             "fix": true
         },
+	{
+	    "name": "transportationbureau-cityofkawasaki",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-transportationbureau~cityofkawasaki~alllines~jp"
+	},
+	{
+	    "name": "transportationbureau-cityofkawasaki",
+	    "spec": "gtfs-rt",
+	    "type": "transitland-atlas",
+	    "transitland-atlas-id": "f-transportationbureau~cityofkawasaki~alllines~jp~rt"
+	},
         {
             "name": "tokyo-rail",
             "type": "http",


### PR DESCRIPTION
This pull request adds new transit feeds for the City of Kawasaki to the `feeds/jp.json` file. The additions include both static and real-time feeds, expanding coverage for Kawasaki transit data.

- https://www.transit.land/feeds/f-transportationbureau~cityofkawasaki~alllines~jp
- https://www.transit.land/feeds/f-transportationbureau~cityofkawasaki~alllines~jp~rt