### PR TITLE
Add infrastructure for generating a "meta station" GTFS feed

### DIFF
--- a/.woodpecker/data-import.yml
+++ b/.woodpecker/data-import.yml
@@ -25,6 +25,7 @@ steps:
       - git submodule update --init --checkout --remote
       - ./ci/fetch-feeds.py timer
       - ./src/garbage-collect.py
+      - ./src/generate-metastations.py --config metastations/metastations.yml --output out/transitous_meta
       - ./src/generate-attribution.py
   import:
     image: ghcr.io/public-transport/transitous/import:latest

--- a/metastations/metastations.yml
+++ b/metastations/metastations.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Volker Krause <vkrause@kde.org>
+# SPDX-License-Identifier: CC0-1.0
+
+# Meta-station mapping
+# This maps Wikidata item ids for a city to a set of stations
+# The city item defines the (translated) names, the stations define the geo coordinates considered
+# to be part of this meta-station.
+#
+# Use this for:
+# - cities with multiple equally important terminus stations
+#
+# Do not use this for:
+# - cities with a single "main" station, e.g. to map the city name to that stop
+# - cities with multiple important/main stations that are on the same long-distance/high-speed lines,
+#   ie. where reaching one from the other is usually "cheap"
+
+# London
+Q84:
+    - Q219867 # King's Cross
+    - Q720102 # St Pancras
+    - Q795691 # Waterloo Station
+    - Q800751 # Euston Station
+    - Q801124 # Liverpool Street
+
+# Paris
+Q90:
+    - Q745942 # Nord
+    - Q757180 # Est
+    - Q747541 # Gare de Lyon
+    - Q631114 # Montparnasse
+    - Q1494179 # Austerlitz

--- a/src/generate-metastations.py
+++ b/src/generate-metastations.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Volker Krause <vkrause@kde.org>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import argparse
+import csv
+from ruamel.yaml import YAML
+import pathlib
+import requests
+import os
+
+parser = argparse.ArgumentParser(description='Transitous meta-station GTFS feed generator.')
+parser.add_argument('--config', type=str, help="Configuration file describing the meta station mapping", default="metastations/metastations.yml")
+parser.add_argument('--output', type=str, help="GTFS feed output folder", default="out/transitous_meta")
+arguments = parser.parse_args()
+
+
+if __name__ == "__main__":
+
+    stops = []
+    stop_groups = []
+    translations = []
+    with open(arguments.config) as f:
+        yaml = YAML(typ="rt")
+        config = yaml.load(f)
+
+        headers = {"User-Agent": "org.transitous.metastation-generator"}
+        for metastation in config:
+            print(metastation)
+            metareq = requests.get(f"https://www.wikidata.org/w/rest.php/wikibase/v1/entities/items/{metastation}/labels", headers=headers)
+            metadata = metareq.json()
+            stop = {
+                "stop_id": metastation,
+                "stop_name": metadata["en"],
+                "stop_lat": 0,
+                "stop_lon": 0,
+                "location_type": 0
+            }
+            stops.append(stop)
+
+            for lang, name in metadata.items():
+                if len(lang) != 2 or (lang != "en" and name == metadata["en"]):
+                    continue
+                translation = {
+                    "table_name": "stops",
+                    "field_name": "stop_name",
+                    "language": lang,
+                    "record_id": metastation,
+                    "translation": name
+                }
+                translations.append(translation)
+
+            for station in config[metastation]:
+                print(station)
+                stationreq = requests.get(f"https://www.wikidata.org/w/rest.php/wikibase/v1/entities/items/{station}", headers=headers)
+                stationdata = stationreq.json()
+                coord = stationdata["statements"]["P625"][0]["value"]["content"]
+                stop = {
+                    "stop_id": station,
+                    "stop_name": stationdata["labels"]["en"],
+                    "stop_lat": coord["latitude"],
+                    "stop_lon": coord["longitude"],
+                    "location_type": 0
+                }
+                stops.append(stop)
+                stop_group = {
+                    "stop_group_id": metastation,
+                    "stop_id": station,
+                }
+                stop_groups.append(stop_group)
+
+    os.makedirs(arguments.output, exist_ok=True)
+
+    # create dummy files we need for MOTIS to recognize this as a valid GTFS feed
+    pathlib.Path(os.path.join(arguments.output, "calendar_dates.txt")).touch(exist_ok=True)
+    pathlib.Path(os.path.join(arguments.output, "routes.txt")).touch(exist_ok=True)
+    pathlib.Path(os.path.join(arguments.output, "stop_times.txt")).touch(exist_ok=True)
+    pathlib.Path(os.path.join(arguments.output, "trips.txt")).touch(exist_ok=True)
+
+    # dummy agency data to define a timezone
+    agency = {
+        "agency_id": "transitous",
+        "agency_name": "Transitous",
+        "agency_url": "https://transitous.org",
+        "agency_timezone": "Etc/UTC",
+    }
+    with open(os.path.join(arguments.output, "agency.txt"), 'w') as f:
+        writer = csv.DictWriter(f, fieldnames=agency.keys())
+        writer.writeheader()
+        writer.writerow(agency)
+
+    # write stops
+    with open(os.path.join(arguments.output, "stops.txt"), 'w') as f:
+        writer = csv.DictWriter(f, fieldnames=["stop_id", "stop_name", "stop_lat", "stop_lon", "location_type"])
+        writer.writeheader()
+        for stop in stops:
+            writer.writerow(stop)
+
+    # write stop_group_elements
+    with open(os.path.join(arguments.output, "stop_group_elements.txt"), 'w') as f:
+        writer = csv.DictWriter(f, fieldnames=["stop_group_id", "stop_id"])
+        writer.writeheader()
+        for group in stop_groups:
+            writer.writerow(group)
+
+    # write translations
+    with open(os.path.join(arguments.output, "translations.txt"), 'w') as f:
+        writer = csv.DictWriter(f, fieldnames=["table_name", "field_name", "language", "record_id", "translation"])
+        writer.writeheader()
+        for t in translations:
+            writer.writerow(t)

--- a/src/generate-motis-config.py
+++ b/src/generate-motis-config.py
@@ -78,6 +78,8 @@ if __name__ == "__main__":
             "datasets", before="Modified by generate-motis-config.py"
         )
         config["timetable"]["datasets"] = {}
+        if os.path.exists("out/transitous_meta"):
+            config["timetable"]["datasets"]["transitous-meta"] = {"path": "transitous_meta"}
         config["gbfs"]["feeds"] = {}
         config["gbfs"]["proxy"] = FEED_PROXY
 


### PR DESCRIPTION
Meta stations allow using e.g. "London" or "Paris" as destination while referring to a set of (main) stations in the city. This affects sufficiently few cities that we can maintain this mapping manually, as this only really produces the result for multiple terminus stations with limited connectivity between each other on long-distance modes.