### PR TITLE
Replace DottBerlin with DottDE

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -227,9 +227,9 @@
             "spec": "gbfs"
         },
         {
-            "name": "DottBerlin",
+            "name": "DottDE",
             "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/berlin/gbfs.json",
+            "url": "https://gbfs.api.ridedott.com/public/v2/countries/de/gbfs.json",
             "spec": "gbfs"
         },
         {


### PR DESCRIPTION
The file at `countries/de` contains the GBFS for all of Germany, as opposed to just Berlin. Fixes #1977 