### PR TITLE
hu: add Üröm GTFS

### DIFF
--- a/feeds/hu.json
+++ b/feeds/hu.json
@@ -52,6 +52,11 @@
             "transitland-atlas-id": "f-u2mmz-budaörsvárosönkormányzata"
         },
         {
+            "name": "urom",
+            "type": "http",
+            "url": "https://gy-mate.hu/gtfs/gtfs_hu_urom.zip"
+        },
+        {
             "name": "mvk",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u2wc-mvkzrt"


### PR DESCRIPTION
Add a self-created GTFS of the Üröm local bus network.

The feed is automatically built and updated from [gy-mate/gtfs-feeds](https://github.com/gy-mate/gtfs-feeds/tree/da4a3e3d186fc9eaa1bb1d5ea28b9b8a988f002e/hu_urom). It's currently valid for the rest of the 2026/27 contract of the operator.