### PR TITLE
es: Generate from Mobility Database

### DIFF
--- a/feeds/es.json
+++ b/feeds/es.json
@@ -20,8 +20,7 @@
     "sources": [
         {
             "name": "AECFA-slots",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1096",
+            "type": "mobility-database",
             "fix": true,
             "skip": true,
             "skip-reason": "Not correct GTFS, too bad for automatic fixing",
@@ -30,24 +29,12 @@
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2727"
         },
         {
             "name": "Alavabus",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1362",
-            "fix": true,
-            "http-options": {
-                "fetch-interval-days": 1,
-                "headers": {
-                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
-                }
-            }
-        },
-        {
-            "name": "ALSA-autobuses",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1133",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -55,24 +42,36 @@
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
             },
-            "script": "es-alsa.lua"
+            "mdb-id": "mdb-2824"
         },
         {
-            "name": "Autobús-Comarca-de-Pamplona",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1177",
+            "name": "ALSA-autobuses",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "script": "es-alsa.lua",
+            "mdb-id": "mdb-2825"
+        },
+        {
+            "name": "Autobús-Comarca-de-Pamplona",
+            "type": "mobility-database",
+            "fix": true,
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            },
+            "mdb-id": "mdb-2719"
         },
         {
             "name": "Autobús-de-la-isla-de-Ibiza",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1273",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -83,12 +82,12 @@
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://eivissa.tib.org/web/cie/cataleg-dades"
-            }
+            },
+            "mdb-id": "mdb-2797"
         },
         {
             "name": "Autobús-de-la-isla-de-Menorca",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1363",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -99,31 +98,32 @@
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://menorca.tib.org/web/cime/cataleg-dades"
-            }
+            },
+            "mdb-id": "mdb-2763"
         },
         {
             "name": "Autobús-en-Cantabria",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1560",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2748"
         },
         {
             "name": "Autobuses-Empresa-Casas",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1578",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2754"
         },
         {
             "name": "Autobuses-interurbanos-de-la-Comunidad-de-Madrid",
@@ -147,12 +147,13 @@
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "expired"
         },
         {
             "name": "Autobuses-La-Unión-(ALU)",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1266",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -163,72 +164,72 @@
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.ctb.eus/en/dataset/horarios-la-union-bilbao-vitoria-por-autopista"
-            }
+            },
+            "mdb-id": "mdb-2718"
         },
         {
             "name": "Autobuses-Samar",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1165",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2712"
         },
         {
             "name": "Autobuses-Sarbus-–-La-Vallesana",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1581",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2755"
         },
         {
             "name": "Autobuses-TCC-Barcelona",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1580",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2749"
         },
         {
             "name": "Autobuses-urbanos-de-Alicante",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1607",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2822"
         },
         {
             "name": "Autobuses-Urbanos-de-Ciudad-Real",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1599",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2765"
         },
         {
             "name": "Autobuses-urbanos-de-San-Vicente-del-Raspeig",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1566",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -237,12 +238,12 @@
                 }
             },
             "skip": true,
-            "skip-reason": "Feed expired"
+            "skip-reason": "Feed expired",
+            "mdb-id": "mdb-2815"
         },
         {
             "name": "Autobuses-Urbanos-Dos-Hermanas",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1582",
+            "type": "mobility-database",
             "fix": true,
             "skip": true,
             "skip-reason": "expired",
@@ -251,19 +252,20 @@
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2711"
         },
         {
             "name": "Autobuses-Xunta-de-Galicia",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1584",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2821"
         },
         {
             "name": "Autobús-interurbano-Comunidad-Valenciana",
@@ -282,15 +284,15 @@
         },
         {
             "name": "Autobús-interurbano-de-Cataluña",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1364",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2796"
         },
         {
             "name": "Autobús-interurbano-de-Navarra",
@@ -302,7 +304,9 @@
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "expired"
         },
         {
             "name": "Autobús-interurbano-de-Tenerife",
@@ -322,8 +326,7 @@
         },
         {
             "name": "Autobus-Madrid-Aranda-de-Duero-Burgo-de-Osma",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1561",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -332,7 +335,8 @@
                 }
             },
             "skip": true,
-            "skip-reason": "Feed expired"
+            "skip-reason": "Feed expired",
+            "mdb-id": "mdb-2813"
         },
         {
             "name": "Autobús-metropolitano-Barcelona",
@@ -348,91 +352,90 @@
         },
         {
             "name": "Autobús-metropolitano-Barcelona",
-            "type": "url",
-            "spec": "gtfs-rt",
-            "url": "https://www.ambmobilitat.cat/transit/trips-updates/trips.bin"
+            "type": "mobility-database",
+            "mdb-id": "mdb-2368"
         },
         {
             "name": "Autobusos-de-Lleida",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1579",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2753"
         },
         {
             "name": "Autobús-Principado-de-Asturias",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1178",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2827"
         },
         {
             "name": "Autobús-urbano-de-Ávila",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1170",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2772",
+            "skip": true,
+            "skip-reason": "expired"
         },
         {
             "name": "Autobús-urbano-de-Cáceres",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1493",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            },          
+            },
             "license": {
                 "spdx-identifier": "CC-BY-3.0",
                 "url": "https://opendata.caceres.es/dataset/autobuses-caceres"
-            }
-            
+            },
+            "mdb-id": "mdb-2714"
         },
         {
             "name": "Autobús-urbano-de-Castellón-de-la-Plana",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1572",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2771"
         },
         {
             "name": "Autobús-urbano-de-Córdoba",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1573",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2713"
         },
         {
             "name": "Autobús-urbano-de-Fuengirola",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1710",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -441,67 +444,70 @@
                 }
             },
             "skip": true,
-            "skip-reason": "Feed expired"
+            "skip-reason": "Feed expired",
+            "mdb-id": "mdb-2798"
         },
         {
             "name": "Autobús-urbano-de-Girona",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1570",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2751"
         },
         {
             "name": "Autobús-urbano-de-Granada",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1564",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2769"
         },
         {
             "name": "Autobús-urbano-de-Huesca",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1172",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2819",
+            "skip": true,
+            "skip-reason": "expired"
         },
         {
             "name": "Autobús-urbano-de-la-Coruña",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1574",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2767"
         },
         {
             "name": "Autobús-urbano-de-Las-Palmas-de-Gran-Canaria",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1295",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2783"
         },
         {
             "name": "Autobús-urbano-de-Madrid",
@@ -543,20 +549,19 @@
         },
         {
             "name": "Autobús-urbano-de-Mataró",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1173",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2768"
         },
         {
             "name": "Autobús-urbano-de-Ourense",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1586",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -565,43 +570,46 @@
                 }
             },
             "skip": true,
-            "skip-reason": "Feed expired"
+            "skip-reason": "Feed expired",
+            "mdb-id": "mdb-2804"
         },
         {
             "name": "Autobús-urbano-de-Palma-de-Mallorca",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1495",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2782"
         },
         {
             "name": "Autobús-urbano-de-Soria",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1174",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2818",
+            "skip": true,
+            "skip-reason": "expired"
         },
         {
             "name": "Autobús-urbano-de-Tarrasa",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1175",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2716"
         },
         {
             "name": "Autobús-urbano-de-Valencia",
@@ -617,56 +625,7 @@
         },
         {
             "name": "Autobús-urbano-de-Valladolid",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1563",
-            "fix": true,
-            "http-options": {
-                "fetch-interval-days": 1,
-                "headers": {
-                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
-                }
-            }
-        },
-        {
-            "name": "Autobús-y-tranvía-de-Sevilla",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1567",
-            "fix": true,
-            "http-options": {
-                "fetch-interval-days": 1,
-                "headers": {
-                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
-                }
-            }
-        },
-        {
-            "name": "Autocares-Autocorb",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1171",
-            "fix": true,
-            "http-options": {
-                "fetch-interval-days": 1,
-                "headers": {
-                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
-                }
-            }
-        },
-        {
-            "name": "Autocares-Baraza",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1169",
-            "fix": true,
-            "http-options": {
-                "fetch-interval-days": 1,
-                "headers": {
-                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
-                }
-            }
-        },
-        {
-            "name": "Bilbobus",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1460",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -674,10 +633,59 @@
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
             },
-                "license": {
+            "mdb-id": "mdb-2730"
+        },
+        {
+            "name": "Autobús-y-tranvía-de-Sevilla",
+            "type": "mobility-database",
+            "fix": true,
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            },
+            "mdb-id": "mdb-2770"
+        },
+        {
+            "name": "Autocares-Autocorb",
+            "type": "mobility-database",
+            "fix": true,
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            },
+            "mdb-id": "mdb-2779"
+        },
+        {
+            "name": "Autocares-Baraza",
+            "type": "mobility-database",
+            "fix": true,
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            },
+            "mdb-id": "mdb-2774"
+        },
+        {
+            "name": "Bilbobus",
+            "type": "mobility-database",
+            "fix": true,
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            },
+            "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.ctb.eus/en/dataset/horario-lineas-bilbobus"
-                }
+            },
+            "mdb-id": "mdb-2681"
         },
         {
             "name": "Bilbobus",
@@ -703,7 +711,7 @@
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.ctb.eus/en/dataset/horarios-lineas-bizkaibus"
-                    }
+            }
         },
         {
             "name": "Bizkaibus",
@@ -744,24 +752,26 @@
         },
         {
             "name": "Puente-Colgante-Bizkaia",
-            "type": "http",
-            "url": "https://ctb-gtfs.s3.eu-south-2.amazonaws.com/puentebizkaia.zip",
+            "type": "mobility-database",
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.ctb.eus/en/dataset/horarios-puente-colgante"
-            }
+            },
+            "mdb-id": "mdb-1162"
         },
         {
             "name": "Bus-urbano-de-Segovia",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1559",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2816",
+            "skip": true,
+            "skip-reason": "expired"
         },
         {
             "name": "Cercanías-Madrid",
@@ -773,7 +783,9 @@
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "skip": true,
+            "skip-reason": "expired"
         },
         {
             "name": "Cercanías-Renfe",
@@ -793,62 +805,58 @@
         },
         {
             "name": "Cercanías-Renfe",
-            "type": "url",
-            "spec": "gtfs-rt",
-            "url": "https://gtfsrt.renfe.com/trip_updates.pb",
+            "type": "mobility-database",
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.renfe.com/dataset/horarios-viaje-cercanias"
-            }
+            },
+            "mdb-id": "mdb-2834"
         },
         {
             "name": "Cercanías-Renfe",
-            "type": "url",
-            "spec": "gtfs-rt",
-            "url": "https://gtfsrt.renfe.com/alerts.pb",
+            "type": "mobility-database",
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.renfe.com/dataset/incidencias-avisos"
-            }
+            },
+            "mdb-id": "mdb-2833"
         },
         {
             "name": "Cercanías-Renfe",
-            "type": "url",
-            "spec": "gtfs-rt",
-            "url": "https://gtfsrt.renfe.com/vehicle_positions.pb",
+            "type": "mobility-database",
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.renfe.com/dataset/ubicacion-vehiculos"
-            }
+            },
+            "mdb-id": "mdb-2835"
         },
         {
             "name": "Donostiabus-(Dbus)",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1196",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2682"
         },
         {
             "name": "EMT-Tarragona",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1694",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2777"
         },
         {
             "name": "Euskotren",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1263",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -859,7 +867,8 @@
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.ctb.eus/en/dataset/horarios-servicios-euskotren"
-            }
+            },
+            "mdb-id": "mdb-2715"
         },
         {
             "name": "Ferrocarriles-de-la-Generalitat-de-Cataluña",
@@ -873,9 +882,9 @@
                 }
             },
             "license": {
-                "spdx-identifier": "CC-BY-4.0", 
+                "spdx-identifier": "CC-BY-4.0",
                 "url": "https://dadesobertes.fgc.cat/explore/dataset/gtfs_zip/"
-                }
+            }
         },
         {
             "name": "Ferrocarriles-de-la-Generalitat-de-Cataluña",
@@ -883,38 +892,37 @@
             "url": "https://dadesobertes.fgc.cat/explore/dataset/trip-updates-gtfs_realtime/files/735985017f62fd33b2fe46e31ce53829/download/",
             "spec": "gtfs-rt",
             "license": {
-                "spdx-identifier": "CC-BY-4.0", 
+                "spdx-identifier": "CC-BY-4.0",
                 "url": "https://dadesobertes.fgc.cat/explore/dataset/trip-updates-gtfs_realtime/"
-                }
+            }
         },
         {
             "name": "Ferry-Baleària",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1527",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2814"
         },
         {
             "name": "Ferry-Fred.Olsen",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1528",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2722"
         },
         {
             "name": "Feve",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1131",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -925,12 +933,12 @@
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.renfe.com/dataset/horario-feve"
-            }
+            },
+            "mdb-id": "mdb-2717"
         },
         {
             "name": "Funicular-de-Artxanda",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1264",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -941,7 +949,8 @@
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.ctb.eus/en/dataset/horarios-funicular-artxanda"
-            }
+            },
+            "mdb-id": "mdb-2680"
         },
         {
             "name": "LeioaBus",
@@ -954,183 +963,183 @@
         },
         {
             "name": "Lurraldebus-Arrasate",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1198",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2733"
         },
         {
             "name": "Lurraldebus-auif",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1199",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2724"
         },
         {
             "name": "Lurraldebus-Eibar",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1200",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2735"
         },
         {
             "name": "Lurraldebus-Ekialdebus",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1201",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2731"
         },
         {
             "name": "Lurraldebus-Euskotren-bus",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1202",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2756"
         },
         {
             "name": "Lurraldebus-Goierrialdea",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1229",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2732"
         },
         {
             "name": "Lurraldebus-Guipuzcoana",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1204",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2736"
         },
         {
             "name": "Lurraldebus-Hernani",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1230",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2734"
         },
         {
             "name": "Lurraldebus-Lasarte",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1231",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2760"
         },
         {
             "name": "Lurraldebus-Oiartzun",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1232",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2725"
         },
         {
             "name": "Lurraldebus-Pesa",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1233",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2776"
         },
         {
             "name": "Lurraldebus-Rentería",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1234",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2759"
         },
         {
             "name": "Lurraldebus-TBH-(Interurbano-Tolosa-Buruntzaldea)",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1608",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2757"
         },
         {
             "name": "Lurraldebus-Tolosaldea",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1235",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2726"
         },
         {
             "name": "Lurraldebus-Zarautz",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1237",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2728"
         },
         {
             "name": "Bermibusa",
@@ -1149,7 +1158,7 @@
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.ctb.eus/en/dataset/horarios-erandiobus"
             }
-        },      
+        },
         {
             "name": "Metro-Bilbao",
             "type": "http",
@@ -1191,15 +1200,15 @@
         },
         {
             "name": "Metro-de-Granada",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1568",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2784"
         },
         {
             "name": "Metro-de-Madrid",
@@ -1227,27 +1236,27 @@
         },
         {
             "name": "Metro-de-Sevilla",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1583",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2781"
         },
         {
             "name": "Metro-de-Valencia",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1168",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2830"
         },
         {
             "name": "Metro-Ligero-y-Tranvía-Comunidad-de-Madrid",
@@ -1275,31 +1284,33 @@
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://datos.tenerife.es/en/datos/conjuntos-de-datos/informacion-sobre-el-sistema-de-transporte-de-metropolitano-de-tenerife-tranvia?return=aHR0cHM6Ly9kYXRvcy50ZW5lcmlmZS5lcy9lbi9kYXRvcy9jb25qdW50b3MtZGUtZGF0b3M="
-            }
+            },
+            "skip": true,
+            "skip-reason": "expired"
         },
         {
             "name": "Ouigo",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1766",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2785"
         },
         {
             "name": "Pujol-autobuses",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1577",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2750"
         },
         {
             "name": "RENFE---Media,-Larga-Distancia-y-AVE",
@@ -1329,63 +1340,65 @@
         },
         {
             "name": "Reus-Transport",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1788",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2803",
+            "skip": true,
+            "skip-reason": "expired"
         },
         {
             "name": "Salamanca-de-Transportes-S.A.-",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1598",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2823"
         },
         {
             "name": "Sarfa-autobuses",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1576",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2764"
         },
         {
             "name": "Transbordador-Puente-Bizkaia",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1270",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2789"
         },
         {
             "name": "Transporte-metropolitano-Andalucía",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1562",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2721"
         },
         {
             "name": "Transporte-metropolitano-de-Barcelona-(Bus-y-Metro)",
@@ -1401,8 +1414,7 @@
         },
         {
             "name": "Transporte-público-de-la-Isla-de-Mallorca",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1272",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -1413,31 +1425,32 @@
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://www.tib.org/ca/sobre-ctm/portal-de-transparencia/dades-obertes"
-            }
+            },
+            "mdb-id": "mdb-2766"
         },
         {
             "name": "Transportes-de-Murcia",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1597",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2828"
         },
         {
             "name": "Transportes-Urbanos-de-Santander",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1602",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2762"
         },
         {
             "name": "Transportes-Urbanos-de-Vitoria-(TUVISA)",
@@ -1455,39 +1468,39 @@
         },
         {
             "name": "Transporte-urbano-de-Zaragoza",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1176",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2773"
         },
         {
             "name": "Tranvía-de-Murcia",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1569",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2729"
         },
         {
             "name": "Tranvía-de-Zaragoza",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1687",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2801"
         },
         {
             "name": "Tranvía-Metropolitano-Barcelona",
@@ -1515,32 +1528,31 @@
         },
         {
             "name": "Trenes-y-tranvías-de-Alicante-y-Costa-Blanca",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1167",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2829"
         },
         {
             "name": "Unauto",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1575",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
                 "headers": {
                     "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
                 }
-            }
+            },
+            "mdb-id": "mdb-2723"
         },
         {
             "name": "VAC-124.-Huesca-Lleida-con-hijuelas",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1713",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -1549,12 +1561,12 @@
                 }
             },
             "skip": true,
-            "skip-reason": "Feed expired"
+            "skip-reason": "Feed expired",
+            "mdb-id": "mdb-2809"
         },
         {
             "name": "VAC-231.-Madrid,-Piedrabuena-(Ciudad-Real)-y-Agudo-(Ciudad-Real)",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1711",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -1563,12 +1575,12 @@
                 }
             },
             "skip": true,
-            "skip-reason": "Feed expired"
+            "skip-reason": "Feed expired",
+            "mdb-id": "mdb-2811"
         },
         {
             "name": "VAC-232.-Madrid,-Málaga-y-Algeciras-(Cádiz)",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1132",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -1577,12 +1589,12 @@
                 }
             },
             "skip": true,
-            "skip-reason": "Feed expired"
+            "skip-reason": "Feed expired",
+            "mdb-id": "mdb-2817"
         },
         {
             "name": "VAC-245.-Huesca-Barcelona",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1712",
+            "type": "mobility-database",
             "fix": true,
             "http-options": {
                 "fetch-interval-days": 1,
@@ -1591,13 +1603,16 @@
                 }
             },
             "skip": true,
-            "skip-reason": "Feed expired"
+            "skip-reason": "Feed expired",
+            "mdb-id": "mdb-2810"
         },
         {
             "name": "Trasnportes-Insular-de-La-Palma-(TILP)",
             "type": "http",
             "url": "https://www.arcgis.com/sharing/rest/content/items/a00541a34b4b432aa7c9937f34b3e19e/data",
-            "fix": "true"
+            "fix": "true",
+            "skip": true,
+            "skip-reason": "expired"
         }
     ]
 }

--- a/feeds/es.json
+++ b/feeds/es.json
@@ -180,7 +180,7 @@
             "mdb-id": "mdb-2712"
         },
         {
-            "name": "Autobuses-Sarbus-–-La-Vallesana",
+            "name": "Autobuses-Sarbus",
             "type": "mobility-database",
             "fix": true,
             "http-options": {
@@ -353,7 +353,8 @@
         {
             "name": "Autobús-metropolitano-Barcelona",
             "type": "mobility-database",
-            "mdb-id": "mdb-2368"
+            "mdb-id": "mdb-2368",
+            "spec": "gtfs-rt"
         },
         {
             "name": "Autobusos-de-Lleida",
@@ -508,32 +509,6 @@
                 }
             },
             "mdb-id": "mdb-2783"
-        },
-        {
-            "name": "Autobús-urbano-de-Madrid",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1097",
-            "fix": true,
-            "skip": true,
-            "skip-reason": "headway_secs is in minutes which makes timetable entirely wrong",
-            "http-options": {
-                "fetch-interval-days": 1,
-                "headers": {
-                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
-                }
-            }
-        },
-        {
-            "name": "Autobús-urbano-de-Madrid-(CRTM)",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1135",
-            "fix": true,
-            "http-options": {
-                "fetch-interval-days": 1,
-                "headers": {
-                    "ApiKey": "b2be1741-ed99-41e7-99bf-924b32694633"
-                }
-            }
         },
         {
             "name": "Autobús-urbano-de-Málaga",
@@ -810,7 +785,8 @@
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.renfe.com/dataset/horarios-viaje-cercanias"
             },
-            "mdb-id": "mdb-2834"
+            "mdb-id": "mdb-2834",
+            "spec": "gtfs-rt"
         },
         {
             "name": "Cercanías-Renfe",
@@ -819,7 +795,8 @@
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.renfe.com/dataset/incidencias-avisos"
             },
-            "mdb-id": "mdb-2833"
+            "mdb-id": "mdb-2833",
+            "spec": "gtfs-rt"
         },
         {
             "name": "Cercanías-Renfe",
@@ -828,7 +805,8 @@
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.renfe.com/dataset/ubicacion-vehiculos"
             },
-            "mdb-id": "mdb-2835"
+            "mdb-id": "mdb-2835",
+            "spec": "gtfs-rt"
         },
         {
             "name": "Donostiabus-(Dbus)",
@@ -872,19 +850,8 @@
         },
         {
             "name": "Ferrocarriles-de-la-Generalitat-de-Cataluña",
-            "type": "http",
-            "url": "https://nap.transportes.gob.es/api/Fichero/download/1571",
-            "fix": true,
-            "http-options": {
-                "fetch-interval-days": 1,
-                "headers": {
-                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
-                }
-            },
-            "license": {
-                "spdx-identifier": "CC-BY-4.0",
-                "url": "https://dadesobertes.fgc.cat/explore/dataset/gtfs_zip/"
-            }
+            "type": "mobility-database",
+            "mdb-id": "mdb-1856"
         },
         {
             "name": "Ferrocarriles-de-la-Generalitat-de-Cataluña",
@@ -1313,7 +1280,7 @@
             "mdb-id": "mdb-2750"
         },
         {
-            "name": "RENFE---Media,-Larga-Distancia-y-AVE",
+            "name": "RENFE-Larga-Distancia-y-AVE",
             "type": "http",
             "url": "https://nap.transportes.gob.es/api/Fichero/download/1098",
             "fix": true,
@@ -1329,7 +1296,7 @@
             }
         },
         {
-            "name": "RENFE---Media,-Larga-Distancia-y-AVE",
+            "name": "RENFE-Larga-Distancia-y-AVE",
             "type": "url",
             "spec": "gtfs-rt",
             "url": "https://gtfsrt.renfe.com/trip_updates_LD.pb",
@@ -1613,6 +1580,433 @@
             "fix": "true",
             "skip": true,
             "skip-reason": "expired"
+        },
+        {
+            "name": "Transportes-interurbanos-de-Tenerife-(TITSA)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-787"
+        },
+        {
+            "name": "Consorcio-Regional-de-Transportes-de-Madrid-CRTM-I",
+            "type": "mobility-database",
+            "mdb-id": "mdb-791",
+            "fix": true
+        },
+        {
+            "name": "Consorcio-Regional-de-Transportes-de-Madrid",
+            "type": "mobility-database",
+            "mdb-id": "mdb-792"
+        },
+        {
+            "name": "EMT-Madrid",
+            "type": "mobility-database",
+            "mdb-id": "mdb-793",
+            "skip": true,
+            "skip-reason": "Huge number of duplicated trips"
+        },
+        {
+            "name": "Metro-de-Madrid",
+            "type": "mobility-database",
+            "mdb-id": "mdb-794"
+        },
+        {
+            "name": "EMT-Valencia",
+            "type": "mobility-database",
+            "mdb-id": "mdb-795",
+            "fix": true
+        },
+        {
+            "name": "TUVISA-(Transportes-Urbanos-de-Vitoria)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-797"
+        },
+        {
+            "name": "Àrea-Metropolitana-de-Barcelona-(AMB)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-892"
+        },
+        {
+            "name": "TRAM-Barcelona",
+            "type": "mobility-database",
+            "mdb-id": "mdb-1003"
+        },
+        {
+            "name": "TRAM-Barcelona-Besós",
+            "type": "mobility-database",
+            "mdb-id": "mdb-1004"
+        },
+        {
+            "name": "Metro-de-Málaga",
+            "type": "mobility-database",
+            "mdb-id": "mdb-1017"
+        },
+        {
+            "name": "Bizkaibus",
+            "type": "mobility-database",
+            "mdb-id": "mdb-1135"
+        },
+        {
+            "name": "La-Burundesa-S.A.",
+            "type": "mobility-database",
+            "mdb-id": "mdb-1316",
+            "fix": true
+        },
+        {
+            "name": "Generalitat-Valenciana-(Intercity-bus)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-1870"
+        },
+        {
+            "name": "Consorcio-de-Transportes-de-Mallorca",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2141"
+        },
+        {
+            "name": "Empresa-Malagueña-de-Transportes-(EMT)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2212"
+        },
+        {
+            "name": "Empresa-Malagueña-de-Transportes-(EMT)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2213",
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "Empresa-Malagueña-de-Transportes-(EMT)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2214",
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "Empresa-Malagueña-de-Transportes-(EMT)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2215",
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "Transports-Metropolitans-de-Barcelona-(TMB)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2359",
+            "skip": true,
+            "skip-reason": "Already in Transporte-metropolitano-de-Barcelona-(Bus-y-Metro)"
+        },
+        {
+            "name": "Àrea-Metropolitana-de-Barcelona-(AMB)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2369",
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "EMTF",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2400"
+        },
+        {
+            "name": "EMTF",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2401",
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "EMTF",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2402",
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "EMTF",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2403",
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "Renfe-commuter-trains-(Cercanias)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2653",
+            "skip": true,
+            "skip-reason": "Already from NAP with rt"
+        },
+        {
+            "name": "Metro-Bilbao",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2683"
+        },
+        {
+            "name": "La-Regional-Vallisoletana-S.A",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2691"
+        },
+        {
+            "name": "Bilbobus",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2698",
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "Consorcio-Regional-de-Transportes-de-Madrid-CRTM-C",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2720",
+            "skip": true,
+            "skip-reason": "expired"
+        },
+        {
+            "name": "Oñati-urban-(Oñatiko-herribusa)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2737",
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            }
+        },
+        {
+            "name": "Autocares-Rías-Baixas-(Rías-Baixas-Coaches)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2752",
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            }
+        },
+        {
+            "name": "Tolosa-City-Council-(Urbano-de-Tolosa)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2758",
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            }
+        },
+        {
+            "name": "Direxis-Masats",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2761",
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            }
+        },
+        {
+            "name": "Direxis-TGO-(Transportes-Generales-de-Olesa)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2775"
+        },
+        {
+            "name": "Rodil",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2778",
+            "skip": true,
+            "skip-reason": "expired"
+        },
+        {
+            "name": "Costa-Coaches",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2780",
+            "skip": true,
+            "skip-reason": "expired"
+        },
+        {
+            "name": "Viagón-Coaches",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2786",
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            }
+        },
+        {
+            "name": "Alvarez-Travelers-Coaches",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2787",
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            }
+        },
+        {
+            "name": "Kbus-(Barakaldo-urban)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2788",
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            }
+        },
+        {
+            "name": "Sopela-Town-Hall",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2790",
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            }
+        },
+        {
+            "name": "Erandio-City-Council-(Erandio!-Busa)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2793",
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            }
+        },
+        {
+            "name": "Lázara-Coaches",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2794",
+            "skip": true,
+            "skip-reason": "expired"
+        },
+        {
+            "name": "Ancebus",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2795",
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            }
+        },
+        {
+            "name": "Bermibusa",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2799",
+            "skip": true,
+            "skip-reason": "duplicate"
+        },
+        {
+            "name": "Consorcio-Regional-de-Transportes-de-Madrid-CRTM-L",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2802"
+        },
+        {
+            "name": "Cots-Alsina",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2805",
+            "fix": true,
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            }
+        },
+        {
+            "name": "Eixbus-S.At",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2806",
+            "skip": true,
+            "skip-reason": "Invalid GTFS"
+        },
+        {
+            "name": "Albarracín-Movilidad",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2807",
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            },
+            "skip": true,
+            "skip-reason": "Internal server error"
+        },
+        {
+            "name": "La-Veloz-SA",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2808",
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            }
+        },
+        {
+            "name": "Autobús-urbano-de-Madrid-(CRTM)",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2820",
+            "fix": true
+        },
+        {
+            "name": "Barcelona-ATM",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2826",
+            "http-options": {
+                "fetch-interval-days": 1,
+                "headers": {
+                    "ApiKey": "e8143a1e-d12e-4a01-9b08-caf3071e4853"
+                }
+            },
+            "skip": true,
+            "skip-reason": "Already in Transporte-metropolitano-de-Barcelona-(Bus-y-Metro)"
+        },
+        {
+            "name": "Autoridad-de-Transporte-Metropolitano-del-Área-de-",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2832",
+            "skip": true,
+            "skip-reason": "duplicate"
+        },
+        {
+            "name": "Catalonia-Intercity-Bus",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2926",
+            "skip": true,
+            "skip-reason": "Same as from NAP"
+        },
+        {
+            "name": "Syndicat-des-Mobilités-Pays-Basque-Adour",
+            "type": "mobility-database",
+            "mdb-id": "tdg-80701"
+        },
+        {
+            "name": "Syndicat-des-Mobilités-Pays-Basque-Adour",
+            "type": "mobility-database",
+            "mdb-id": "tdg-80702",
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "Syndicat-des-Mobilités-Pays-Basque-Adour",
+            "type": "mobility-database",
+            "mdb-id": "tdg-80703",
+            "spec": "gtfs-rt"
+        },
+        {
+            "name": "Guaguas-Municipales",
+            "type": "mobility-database",
+            "mdb-id": "tld-767"
+        },
+        {
+            "name": "Palma-de-Mallorca",
+            "type": "mobility-database",
+            "mdb-id": "tld-4324",
+            "skip": true,
+            "skip-reason": "Same as from NAP"
+        },
+        {
+            "name": "TranspRober",
+            "type": "mobility-database",
+            "mdb-id": "tld-4890"
         }
     ]
 }

--- a/feeds/es.json
+++ b/feeds/es.json
@@ -705,7 +705,9 @@
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.ctb.eus/en/dataset/etxebarribus"
-            }
+            },
+            "skip": true,
+            "skip-reason": "expired"
         },
         {
             "name": "KBus-Barakaldo",
@@ -926,7 +928,9 @@
             "license": {
                 "spdx-identifier": "CC-BY-4.0",
                 "url": "https://data.ctb.eus/en/dataset/horarios-lejoanbusa"
-            }
+            },
+            "skip": true,
+            "skip-reason": "expired"
         },
         {
             "name": "Lurraldebus-Arrasate",

--- a/src/fetch.py
+++ b/src/fetch.py
@@ -105,11 +105,8 @@ def check_feed_not_expired(feed_info: Iterable[dict],
     today = datetime.now(tz=feed_timezone)
 
     def feed_info_latest():
-        valid_entries = list(map(
-            lambda row:
-                "feed_end_date" not in row or not row["feed_end_date"] or
-                parse_gtfs_date(row["feed_end_date"], feed_timezone),
-            feed_info))
+        date_rows = filter(lambda row: "feed_end_date" in row and row["feed_end_date"], feed_info)
+        valid_entries = list(map(lambda row: parse_gtfs_date(row["feed_end_date"], feed_timezone), date_rows))
         if valid_entries:
             return max(valid_entries)
         else:

--- a/src/fetch.py
+++ b/src/fetch.py
@@ -445,9 +445,9 @@ class Fetcher:
 
             if source.skip:
                 if source.skip_reason != "":
-                    print("Skipping " + source.name + ": " + source.skip_reason)
+                    print("Skipping " + region_name + "-" + source.name + ": " + source.skip_reason)
                 else:
-                    print("Skipping " + source.name)
+                    print("Skipping " + region_name + "-" + source.name)
                 continue
 
 


### PR DESCRIPTION
We were lacking a structured way of maintaining this file, I propose using the Mobility Database as the primary source of feeds, and skipping what we don't want.