### PR TITLE
reverse proxy: OJP endpoint

### DIFF
--- a/ansible/roles/nginx/templates/transitous.conf.j2
+++ b/ansible/roles/nginx/templates/transitous.conf.j2
@@ -90,6 +90,18 @@ server {
         add_header Cache-Control "public, max-age=36000";
     }
 
+    # OJP endpoint
+    location /ojp20 {
+        proxy_pass http://{{ item.vhost }}-backend/ojp20;
+
+        limit_req zone=api burst=40 delay=10;
+        
+        proxy_connect_timeout       2s;
+        proxy_send_timeout          60;
+        proxy_read_timeout          120;
+        send_timeout                60;
+    }
+
     # Rate limit plan API
     location ~ ^/api/(v1|v2|v3|v4|v5|v6|experimental)/(plan|one-to-all) {
         proxy_pass http://{{ item.vhost }}-backend$uri?$args;
@@ -114,7 +126,7 @@ server {
         send_timeout                60;
     }
 
-    # MOTIS
+    # other endpoints
     location /api/ {
         proxy_pass http://{{ item.vhost }}-backend/api/;
 

--- a/ansible/roles/nginx/templates/transitous.conf.j2
+++ b/ansible/roles/nginx/templates/transitous.conf.j2
@@ -82,6 +82,11 @@ server {
 
         limit_req zone=api_harmless burst=100 delay=50;
 
+        proxy_connect_timeout       2s;
+        proxy_send_timeout          60;
+        proxy_read_timeout          60;
+        send_timeout                60;
+
         proxy_cache            motis;
         proxy_cache_valid      200 302 1d;
         proxy_cache_valid      404 1s;


### PR DESCRIPTION
at least temporarily pass through OJP endpoint. moving to /api/ojp20 instead to be discussed.
already deployed.