### PR TITLE
website: add dark mode via head-additions partial

### DIFF
--- a/website/layouts/partials/head-additions.html
+++ b/website/layouts/partials/head-additions.html
@@ -1,0 +1,41 @@
+<!--
+SPDX-FileCopyrightText: 2026 Kristjan Esperanto
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+{{/* Dark mode: apply stored/OS preference before first paint */}}
+<script>
+  (function () {
+    var stored = null;
+    try { stored = localStorage.getItem('bs-theme'); } catch (e) {}
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var theme = stored || (prefersDark ? 'dark' : 'light');
+    document.documentElement.setAttribute('data-bs-theme', theme);
+  })();
+</script>
+
+{{/* Dark mode toggle button — injected into nav via JS, no template override needed */}}
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var nav = document.querySelector('nav .flex-l.justify-between > .flex-l.items-center');
+    if (!nav) return;
+    var btn = document.createElement('button');
+    btn.className = 'theme-toggle-btn';
+    btn.title = 'Toggle dark/light mode';
+    btn.innerHTML = '<i id="theme-icon" class="bi bi-moon-fill"></i>';
+    btn.addEventListener('click', function () {
+      var html = document.documentElement;
+      var next = html.getAttribute('data-bs-theme') === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-bs-theme', next);
+      try { localStorage.setItem('bs-theme', next); } catch (e) {}
+      updateIcon(next);
+    });
+    nav.appendChild(btn);
+    function updateIcon(theme) {
+      var icon = document.getElementById('theme-icon');
+      if (icon) icon.className = theme === 'dark' ? 'bi bi-sun-fill' : 'bi bi-moon-fill';
+    }
+    updateIcon(document.documentElement.getAttribute('data-bs-theme'));
+  });
+</script>

--- a/website/static/custom.css
+++ b/website/static/custom.css
@@ -66,3 +66,45 @@ h3 {
 h2 {
   margin-top: 60px;
 }
+
+/* ---- Dark mode toggle button ---- */
+.theme-toggle-btn {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  color: rgba(255, 255, 255, 0.9);
+  border-radius: 4px;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  margin-left: 8px;
+  transition: background-color 0.15s, border-color 0.15s;
+}
+
+.theme-toggle-btn:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.65);
+}
+
+/* ---- Dark mode overrides for Tachyons classes Bootstrap doesn't control ---- */
+
+/* Smooth theme transition */
+body, .card, .table {
+  transition: background-color 0.2s, color 0.2s, border-color 0.2s;
+}
+
+/* Body background (Tachyons bg-near-white → Bootstrap body bg) */
+[data-bs-theme="dark"] body {
+  background-color: var(--bs-body-bg) !important;
+}
+
+/* Content text (Tachyons mid-gray / dark-gray → Bootstrap body color) */
+[data-bs-theme="dark"] .mid-gray,
+[data-bs-theme="dark"] .dark-gray {
+  color: var(--bs-body-color) !important;
+}
+
+/* App card shadow for dark mode */
+[data-bs-theme="dark"] .app-card:hover {
+  box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.5), 0 2px 12px 0 rgba(0, 0, 0, 0.4);
+}


### PR DESCRIPTION
I think dark mode for the website would be nice.

Functionality:

- detect OS color scheme preference
- a sun/moon toggle button is injected into the navbar via JS
- persist user choice in localStorage

Live preview: https://kristjanesperanto.github.io/transitous/

What do you think?
