### PR TITLE
us-fl: add Gainesville RTS

### DIFF
--- a/feeds/us-fl.json
+++ b/feeds/us-fl.json
@@ -76,6 +76,11 @@
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-djn-centralfloridaregionaltransitauthority~rt",
             "skip": true
+        },
+        {
+            "name": "Gainesville-RTS",
+            "type": "http",
+            "url": "https://go-rts.com/wp-content/uploads/2026/01/RTSGTFS_Spring2026_V6.zip"
         }
     ]
 }


### PR DESCRIPTION
GTFS file is not dynamically updated (valid for Spring 2026 only), so may need to be updated seasonally.