### PR TITLE
Change drop_shapes default to True

### DIFF
--- a/src/metadata.py
+++ b/src/metadata.py
@@ -50,7 +50,7 @@ class Source:
     skip_reason: str = ""
     function: Optional[str] = None
     drop_too_fast_trips: bool = True
-    drop_shapes: bool = False
+    drop_shapes: bool = True
     drop_agency_names: List[str] = []
     keep_agency_names: List[str] = []
     display_name_options: Optional[DisplayNameOptions] = None


### PR DESCRIPTION
Most shapes contained in datasets have very low quality or are also routed on OSM like we do (= no improvement).

Therefore the default should be not to use them, and if we find a dataset with better quality shapes than those we automatically compute via map matching on OSM data, it should be easy to keep the original shapes.

Just looking at Germany, we get low quality shapes for FlixTrain, from Austrian datasets that have partial shapes (only routed in Austria), in Berlin there are buses flying through buildings, etc.

I agree that there might be cases where a dataset has better shapes than what MOTIS would compute. However, the default is that I browse through the debug view to find bugs in our map matching and almost every shape that looks bad turns out to have `TIMETABLE` as source. So we would definitely benefit from dropping them by default in order to improve average shape quality.

Edit: another option would be to drop a lot of shapes (manually going through a lot of datasets and setting the flag) and monitor this for all new datasets. Since nobody is willing to do this, the better option is to drop the shapes by default and for the rare cases where we know that the dataset has better shapes, we can put an effort to disable `drop_shapes`.