### PR TITLE
Add Nuup Bussii (Nuuk, Greenland)

### DIFF
--- a/feeds/gl.json
+++ b/feeds/gl.json
@@ -1,0 +1,18 @@
+{
+    "maintainers": [
+        {
+            "name": "Thomas Ryde",
+            "github": "thomasryde"
+        }
+    ],
+    "sources": [
+        {
+            "name": "nuup-bussii",
+            "type": "http",
+            "url": "https://github.com/thomasryde/nuup-bussii-gtfs/releases/latest/download/nuup-bussii-gtfs.zip",
+            "license": {
+                "url": "https://bus.gl"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- First GTFS feed for Greenland (`gl.json`)
- Covers **Nuup Bussii A/S**, the public bus system in Nuuk
- 5 routes, 240 trips, 77 stops
- Data source: https://github.com/thomasryde/nuup-bussii-gtfs

## Details
Timetable data extracted from official PDF schedules at [bus.gl](https://bus.gl). Stop coordinates sourced from OpenStreetMap and verified against the [Ridango real-time API](https://pilet.ee/viipe/ajax/gotlandpublicrealtime?org_id=968).

The GTFS feed is hosted as a GitHub release with a stable `latest` URL so it stays current as the feed is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)