### PR TITLE
Feed proxy: proxy chain for upstream rate limiting and error caching

### DIFF
--- a/ansible/roles/feed-proxy/templates/feed-proxy.conf.j2
+++ b/ansible/roles/feed-proxy/templates/feed-proxy.conf.j2
@@ -4,8 +4,17 @@
 #
 
 proxy_cache_path /var/cache/nginx/feed-proxy max_size=10g keys_zone=feed-proxy:10m inactive=1h;
+proxy_cache_path /var/cache/nginx/feed-proxy-error max_size=1g keys_zone=feed-proxy-error:10m inactive=1h;
+
+
+map $request_uri $feed_region {
+    default                 "$http_host";
+    "~^/feed/([a-z]{2}-.)"  "$1";
+}
 
 limit_req_zone $binary_remote_addr zone=feed-proxy-quota:10m rate=10000r/m;
+limit_req_zone $feed_region zone=feed-proxy-upstream-quota:10m rate=4r/s;
+limit_req_zone $feed_region zone=feed-proxy-upstream-gbfs-quota:10m rate=9r/s;
 limit_req_status 429;
 
 
@@ -13,6 +22,110 @@ limit_req_status 429;
 geo $dollar {
     default "$";
 }
+
+
+server {
+    listen 127.0.0.1:8081 http2;
+    listen [::1]:8081 http2;
+    
+    server_name localhost;
+
+    include ./conf.d/feed-proxy-http-default;
+
+    proxy_pass_header Server;
+    proxy_set_header User-Agent transitous.org;
+
+    proxy_cache            feed-proxy-error;
+    proxy_cache_key   "$request_uri";
+    proxy_buffering on;
+    proxy_ignore_headers Set-Cookie;
+    proxy_ignore_headers X-Accel-Expires;
+    proxy_ignore_headers Expires;
+    proxy_ignore_headers Cache-Control;
+    proxy_http_version 1.1;
+    proxy_intercept_errors on;
+    error_page 301 302 307 308 = @handle_redirects;
+    proxy_cache_valid      400 401 403 404 429 500 502 503 504 200s;
+    proxy_ignore_client_abort on;
+    proxy_cache_use_stale  updating;
+
+    limit_req zone=feed-proxy-upstream-quota burst=40;
+
+    {% for item in feed_vars | dict2items %}   
+        location "/feed/{{item.key}}" {
+            set $feed_upstream "{{ item.value.url | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$dollar') }}";
+            set $original_host "{{ item.value.url | urlsplit('scheme') }}://{{ item.value.url | urlsplit('hostname') }}";
+            proxy_pass $feed_upstream; 
+
+            {% if "headers" in item.value %}
+                {% for header in item.value.headers | dict2items -%}
+                    proxy_set_header "{{ header.key }}" "{{ header.value | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$dollar') }}";
+                {% endfor %}
+            {% endif %}            
+        }
+    {% endfor %}
+
+    location @handle_redirects {
+       set $original_uri "$request_uri";
+       set $orig_loc "$upstream_http_location";
+
+       proxy_cache       feed-proxy-error;
+       proxy_cache_key $original_uri;
+       proxy_cache_valid 400 401 403 404 429 500 502 503 504 200s;
+
+       if ($orig_loc ~* "://") {
+         proxy_pass $orig_loc;
+         break;
+       }
+       # handle relative redirect
+       if ($orig_loc !~* "://") {
+         proxy_pass $original_host$orig_loc;
+         break;
+       }
+    }
+}
+
+
+{% for item in feed_vars | dict2items -%}   
+{% if "gbfs" in item.value -%}
+
+server {
+    listen 127.0.0.1:8081 http2;
+    listen [::1]:8081 http2;
+
+    server_name "{{ item.value.url | urlsplit('hostname') }}";
+
+    include ./conf.d/feed-proxy-http-default;
+
+    proxy_pass_header Server;
+    proxy_set_header User-Agent transitous.org;
+
+    proxy_cache            feed-proxy-error;
+    proxy_ignore_headers Set-Cookie;
+    proxy_ignore_headers X-Accel-Expires;
+    proxy_ignore_headers Expires;
+    proxy_ignore_headers Cache-Control;
+    proxy_http_version 1.1;
+    proxy_cache_valid      400 401 403 404 429 500 502 503 504 200s;
+    proxy_ignore_client_abort on;
+    proxy_cache_use_stale  updating;
+
+    limit_req zone=feed-proxy-upstream-gbfs-quota burst=90;
+
+    location / {
+        set $feed_upstream "{{ item.value.url | urlsplit('scheme') }}://{{ item.value.url | urlsplit('hostname') }}";
+        proxy_pass $feed_upstream;
+
+        {% if "headers" in item.value -%}
+            {% for header in item.value.headers | dict2items -%}
+                proxy_set_header "{{ header.key }}" "{{ header.value | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$dollar') }}";
+            {% endfor %}
+        {% endif %} 
+    }  
+}
+
+{% endfor %}
+{% endif %}
 
 {% for proto in ['http', 'https'] %}
 
@@ -31,7 +144,6 @@ server {
     include ./conf.d/feed-proxy-{{ proto }}-default;
 
     proxy_pass_header Server;
-    proxy_set_header User-Agent transitous.org;
     add_header X-Cache $upstream_cache_status;
     add_header Link '<https://transitous.org/sources/>; rel="license"';
 
@@ -43,49 +155,18 @@ server {
     proxy_ignore_headers Expires;
     proxy_ignore_headers Cache-Control;
     proxy_http_version 1.1;
-    proxy_intercept_errors on;
-    error_page 301 302 307 308 = @handle_redirects;
     proxy_cache_valid      200 40s;
-    proxy_cache_valid      400 401 403 404 200s;
     proxy_ignore_client_abort on;
     proxy_cache_use_stale  error timeout invalid_header updating
-                            http_500 http_502 http_503 http_504 http_429;
+                            http_401 http_403 http_404 http_429 http_500 http_502 http_503 http_504 http_400;
 
     limit_req zone=feed-proxy-quota burst=10000 nodelay;
 
     {% for item in feed_vars | dict2items %}   
         location "/feed/{{item.key}}" {
-            set $feed_upstream "{{ item.value.url | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$dollar') }}";
-            set $original_host "{{ item.value.url | urlsplit('hostname') }}";
-            proxy_pass $feed_upstream; 
-
-            {% if "headers" in item.value %}
-                {% for header in item.value.headers | dict2items -%}
-                    proxy_set_header "{{ header.key }}" "{{ header.value | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$dollar') }}";
-                {% endfor %}
-            {% endif %}            
+            proxy_pass http://127.0.0.1:8081; 
         }
     {% endfor %}
-
-    location @handle_redirects {
-       set $original_uri "$request_uri";
-       set $orig_loc "$upstream_http_location";
-
-       proxy_cache       feed-proxy;
-       proxy_cache_key $original_uri;
-       proxy_cache_valid 200 40s;
-       proxy_cache_valid 400 401 403 404 200s;
-
-       if ($orig_loc ~* "://") {
-         proxy_pass $orig_loc;
-         break;
-       }
-       # handle relative redirect
-       if ($orig_loc !~* "://") {
-         proxy_pass $scheme://$original_host$orig_loc;
-         break;
-       }
-    }
 }
 
 {% endfor %}
@@ -108,12 +189,11 @@ server {
 
     include ./conf.d/feed-proxy-{{ proto }}-default;
 
-    proxy_ssl_server_name on;
-
     proxy_pass_header Server;
-    proxy_set_header User-Agent transitous.org;
     add_header X-Cache $upstream_cache_status;
     add_header Link '<https://transitous.org/sources/>; rel="license"';
+
+    proxy_set_header Host "{{ item.value.url | urlsplit('hostname') }}";
 
     proxy_cache            feed-proxy;
     proxy_buffering on;
@@ -123,22 +203,15 @@ server {
     proxy_ignore_headers Cache-Control;
     proxy_http_version 1.1;
     proxy_cache_valid      200 80s;
-    proxy_cache_valid      400 401 403 404 200s;
+    proxy_cache_valid      301 302 307 308 200s;
     proxy_ignore_client_abort on;
     proxy_cache_use_stale  error timeout invalid_header updating
-                            http_500 http_502 http_503 http_504 http_429;
+                            http_401 http_403 http_404 http_429 http_500 http_502 http_503 http_504 http_400;
 
     limit_req zone=feed-proxy-quota burst=10000 nodelay;
 
     location / {
-        set $feed_upstream "{{ item.value.url | urlsplit('scheme') }}://{{ item.value.url | urlsplit('hostname') }}";
-        proxy_pass $feed_upstream;
-
-        {% if "headers" in item.value -%}
-            {% for header in item.value.headers | dict2items -%}
-                proxy_set_header "{{ header.key }}" "{{ header.value | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$dollar') }}";
-            {% endfor %}
-        {% endif %} 
+        proxy_pass http://127.0.0.1:8081;
     }  
 }
 

--- a/ansible/roles/feed-proxy/templates/feed-proxy.conf.j2
+++ b/ansible/roles/feed-proxy/templates/feed-proxy.conf.j2
@@ -14,14 +14,21 @@ geo $dollar {
     default "$";
 }
 
+{% for proto in ['http', 'https'] %}
+
 server {
+    {% if proto == 'https' %}
+    listen 443 http2 ssl;
+    listen [::]:443 http2 ssl;
+    proxy_ssl_server_name on;
+    {% else %}
     listen 80;
     listen [::]:80;
+    {% endif %}
+
     server_name {{ feed_proxy_host }};
 
-    include ./conf.d/feed-proxy-http-default;
-
-    proxy_ssl_server_name on;
+    include ./conf.d/feed-proxy-{{ proto }}-default;
 
     proxy_pass_header Server;
     proxy_set_header User-Agent transitous.org;
@@ -81,84 +88,25 @@ server {
     }
 }
 
-server {
-    listen 443 http2 ssl;
-    listen [::]:443 http2 ssl;
-
-    server_name {{ feed_proxy_host }};
-
-    include ./conf.d/feed-proxy-https-default;
-
-    proxy_ssl_server_name on;
-    
-    proxy_pass_header Server;
-    proxy_set_header User-Agent transitous.org;
-    add_header X-Cache $upstream_cache_status;
-    add_header Link '<https://transitous.org/sources/>; rel="license"';
-
-    proxy_cache            feed-proxy;
-    proxy_cache_key   "$request_uri";
-    proxy_buffering on;
-    proxy_ignore_headers Set-Cookie;
-    proxy_ignore_headers X-Accel-Expires;
-    proxy_ignore_headers Expires;
-    proxy_ignore_headers Cache-Control;
-    proxy_http_version 1.1;
-    proxy_intercept_errors on;
-    error_page 301 302 307 308 = @handle_redirects;
-    proxy_cache_valid      200 40s;
-    proxy_cache_valid      400 401 403 404 200s;
-    proxy_ignore_client_abort on;
-    proxy_cache_use_stale  error timeout invalid_header updating
-                            http_500 http_502 http_503 http_504 http_429;
-
-    limit_req zone=feed-proxy-quota burst=10000 nodelay;
-
-    {% for item in feed_vars | dict2items %}   
-        location "/feed/{{item.key}}" {
-            set $feed_upstream "{{ item.value.url | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$dollar') }}";
-            set $original_host "{{ item.value.url | urlsplit('hostname') }}";
-            proxy_pass $feed_upstream;  
-
-            {% if "headers" in item.value %}
-                {% for header in item.value.headers | dict2items -%}
-                    proxy_set_header "{{ header.key }}" "{{ header.value | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$dollar') }}";
-                {% endfor %}
-            {% endif %}            
-        }
-    {% endfor %}
-    
-    location @handle_redirects {
-       set $original_uri "$request_uri";
-       set $orig_loc "$upstream_http_location";
-
-       proxy_cache       feed-proxy;
-       proxy_cache_key $original_uri;
-       proxy_cache_valid 200 40s;
-       proxy_cache_valid 400 401 403 404 200s;
-
-       if ($orig_loc ~* "://") {
-         proxy_pass $orig_loc;
-         break;
-       }
-       # handle relative redirect
-       if ($orig_loc !~* "://") {
-         proxy_pass $scheme://$original_host$orig_loc;
-         break;
-       }
-    }
-}
-
+{% endfor %}
 
 {% for item in feed_vars | dict2items -%}   
 {% if "gbfs" in item.value -%}
+{% for proto in ['http', 'https'] %}
 
 server {
+    {% if proto == 'https' %}
+    listen 443 http2 ssl;
+    listen [::]:443 http2 ssl;
+    proxy_ssl_server_name on;
+    {% else %}
     listen 80;
     listen [::]:80;
+    {% endif %}
+
     server_name "{{ item.value.url | urlsplit('hostname') }}";
 
-    include ./conf.d/feed-proxy-http-default;
+    include ./conf.d/feed-proxy-{{ proto }}-default;
 
     proxy_ssl_server_name on;
 
@@ -194,47 +142,6 @@ server {
     }  
 }
 
-server {
-    listen 443 http2 ssl;
-    listen [::]:443 http2 ssl;
-
-    server_name "{{ item.value.url | urlsplit('hostname') }}";
-
-    include ./conf.d/feed-proxy-https-default;
-
-    proxy_ssl_server_name on;
-
-    proxy_pass_header Server;
-    proxy_set_header User-Agent transitous.org;
-    add_header X-Cache $upstream_cache_status;
-    add_header Link '<https://transitous.org/sources/>; rel="license"';
-
-    proxy_cache            feed-proxy;
-    proxy_buffering on;
-    proxy_ignore_headers Set-Cookie;
-    proxy_ignore_headers X-Accel-Expires;
-    proxy_ignore_headers Expires;
-    proxy_ignore_headers Cache-Control;
-    proxy_http_version 1.1;
-    proxy_cache_valid      200 80s;
-    proxy_cache_valid      400 401 403 404 200s;
-    proxy_ignore_client_abort on;
-    proxy_cache_use_stale  error timeout invalid_header updating
-                            http_500 http_502 http_503 http_504 http_429;
-
-    limit_req zone=feed-proxy-quota burst=10000 nodelay;
-
-    location / {
-        set $feed_upstream "{{ item.value.url | urlsplit('scheme') }}://{{ item.value.url | urlsplit('hostname') }}";
-        proxy_pass $feed_upstream;        
-
-        {% if "headers" in item.value -%}
-            {% for header in item.value.headers | dict2items -%}
-                proxy_set_header "{{ header.key }}" "{{ header.value | replace('\\', '\\\\') | replace('"', '\\"') | replace('$', '$dollar') }}";
-            {% endfor %}
-        {% endif %} 
-    }           
-}
-
+{% endfor %}
 {% endif %}
 {% endfor %}

--- a/ansible/roles/feed-proxy/templates/feed-proxy.conf.j2
+++ b/ansible/roles/feed-proxy/templates/feed-proxy.conf.j2
@@ -43,6 +43,7 @@ server {
     proxy_ignore_headers Expires;
     proxy_ignore_headers Cache-Control;
     proxy_http_version 1.1;
+    proxy_ssl_server_name on;
     proxy_intercept_errors on;
     error_page 301 302 307 308 = @handle_redirects;
     proxy_cache_valid      400 401 403 404 429 500 502 503 504 200s;
@@ -106,6 +107,7 @@ server {
     proxy_ignore_headers Expires;
     proxy_ignore_headers Cache-Control;
     proxy_http_version 1.1;
+    proxy_ssl_server_name on;
     proxy_cache_valid      400 401 403 404 429 500 502 503 504 200s;
     proxy_ignore_client_abort on;
     proxy_cache_use_stale  updating;
@@ -124,8 +126,8 @@ server {
     }  
 }
 
-{% endfor %}
 {% endif %}
+{% endfor %}
 
 {% for proto in ['http', 'https'] %}
 
@@ -133,7 +135,6 @@ server {
     {% if proto == 'https' %}
     listen 443 http2 ssl;
     listen [::]:443 http2 ssl;
-    proxy_ssl_server_name on;
     {% else %}
     listen 80;
     listen [::]:80;
@@ -158,7 +159,7 @@ server {
     proxy_cache_valid      200 40s;
     proxy_ignore_client_abort on;
     proxy_cache_use_stale  error timeout invalid_header updating
-                            http_401 http_403 http_404 http_429 http_500 http_502 http_503 http_504 http_400;
+                            http_403 http_404 http_429 http_500 http_502 http_503 http_504;
 
     limit_req zone=feed-proxy-quota burst=10000 nodelay;
 
@@ -179,7 +180,6 @@ server {
     {% if proto == 'https' %}
     listen 443 http2 ssl;
     listen [::]:443 http2 ssl;
-    proxy_ssl_server_name on;
     {% else %}
     listen 80;
     listen [::]:80;
@@ -206,7 +206,7 @@ server {
     proxy_cache_valid      301 302 307 308 200s;
     proxy_ignore_client_abort on;
     proxy_cache_use_stale  error timeout invalid_header updating
-                            http_401 http_403 http_404 http_429 http_500 http_502 http_503 http_504 http_400;
+                            http_403 http_404 http_429 http_500 http_502 http_503 http_504;
 
     limit_req zone=feed-proxy-quota burst=10000 nodelay;
 


### PR DESCRIPTION
These are all just workarounds because Nginx doesn't allow you to:
* Apply rate limiting to upstream requests rather than incoming (cached) requests, and
* Deliver stale responses in case of an error without Nginx then DoS-ing the upstream (because it doesn't cache the error).

That’s why a proxy chain is used, where the upper proxy handles error caching and rate limiting, and the lower proxy handles the 200 (OK) caching.