### PR TITLE
migrate MTA BusTime/AT/Metro APIs to new proxy system

### DIFF
--- a/feeds/nz.json
+++ b/feeds/nz.json
@@ -123,29 +123,9 @@
         },
         {
             "name": "Metro-Christchurch",
-            "type": "url",
-            "url": "https://apis.metroinfo.co.nz/rti/gtfsrt/v1/service-alerts.pb",
-            "headers": {
-                "Ocp-Apim-Subscription-Key": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArRDhISEtWYTJwYms5UVdXY3IyTzBudWdldHQ3Tjg3SVhYdHdENjlQUWxJClpPKzZVTG5VM2cvVENWZ1J2Qlpndm5qNDdZdXFobHJoVTdNVGVsamlic0UKLS0tIFF6RjdTaFlGMnM3QkJyVjFNdER4RWd6czVjRHNHL3lSU3ZpQ1p1dHRwQkEKuLrshIcb3nCoRsQ4ETXEgitAURwB4QJCaj66kI2VbeOOjr3bKSWiAvo3i0UentTimUCJhW5z+0S0B861sJovZQ=="
-            },
-            "use-feed-proxy": true
-        },
-        {
-            "name": "Metro-Christchurch",
-            "type": "url",
-            "url": "https://apis.metroinfo.co.nz/rti/gtfsrt/v1/trip-updates.pb",
-            "headers": {
-                "Ocp-Apim-Subscription-Key": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArRDhISEtWYTJwYms5UVdXY3IyTzBudWdldHQ3Tjg3SVhYdHdENjlQUWxJClpPKzZVTG5VM2cvVENWZ1J2Qlpndm5qNDdZdXFobHJoVTdNVGVsamlic0UKLS0tIFF6RjdTaFlGMnM3QkJyVjFNdER4RWd6czVjRHNHL3lSU3ZpQ1p1dHRwQkEKuLrshIcb3nCoRsQ4ETXEgitAURwB4QJCaj66kI2VbeOOjr3bKSWiAvo3i0UentTimUCJhW5z+0S0B861sJovZQ=="
-            },
-            "use-feed-proxy": true
-        },
-        {
-            "name": "Metro-Christchurch",
-            "type": "url",
-            "url": "https://apis.metroinfo.co.nz/rti/gtfsrt/v1/vehicle-positions.pb",
-            "headers": {
-                "Ocp-Apim-Subscription-Key": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArRDhISEtWYTJwYms5UVdXY3IyTzBudWdldHQ3Tjg3SVhYdHdENjlQUWxJClpPKzZVTG5VM2cvVENWZ1J2Qlpndm5qNDdZdXFobHJoVTdNVGVsamlic0UKLS0tIFF6RjdTaFlGMnM3QkJyVjFNdER4RWd6czVjRHNHL3lSU3ZpQ1p1dHRwQkEKuLrshIcb3nCoRsQ4ETXEgitAURwB4QJCaj66kI2VbeOOjr3bKSWiAvo3i0UentTimUCJhW5z+0S0B861sJovZQ=="
-            },
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-rb6b-metrochristchurch~rt",
+            "api-key": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArRDhISEtWYTJwYms5UVdXY3IyTzBudWdldHQ3Tjg3SVhYdHdENjlQUWxJClpPKzZVTG5VM2cvVENWZ1J2Qlpndm5qNDdZdXFobHJoVTdNVGVsamlic0UKLS0tIFF6RjdTaFlGMnM3QkJyVjFNdER4RWd6czVjRHNHL3lSU3ZpQ1p1dHRwQkEKuLrshIcb3nCoRsQ4ETXEgitAURwB4QJCaj66kI2VbeOOjr3bKSWiAvo3i0UentTimUCJhW5z+0S0B861sJovZQ==",
             "use-feed-proxy": true
         },
         {

--- a/feeds/nz.json
+++ b/feeds/nz.json
@@ -117,8 +117,10 @@
             "type": "http",
             "url": "https://apis.metroinfo.co.nz/rti/gtfs/v1/gtfs.zip",
             "fix": true,
-            "headers": {
-                "Ocp-Apim-Subscription-Key": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArRDhISEtWYTJwYms5UVdXY3IyTzBudWdldHQ3Tjg3SVhYdHdENjlQUWxJClpPKzZVTG5VM2cvVENWZ1J2Qlpndm5qNDdZdXFobHJoVTdNVGVsamlic0UKLS0tIFF6RjdTaFlGMnM3QkJyVjFNdER4RWd6czVjRHNHL3lSU3ZpQ1p1dHRwQkEKuLrshIcb3nCoRsQ4ETXEgitAURwB4QJCaj66kI2VbeOOjr3bKSWiAvo3i0UentTimUCJhW5z+0S0B861sJovZQ=="
+            "http-options": {
+                "headers": {
+                    "Ocp-Apim-Subscription-Key": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArRDhISEtWYTJwYms5UVdXY3IyTzBudWdldHQ3Tjg3SVhYdHdENjlQUWxJClpPKzZVTG5VM2cvVENWZ1J2Qlpndm5qNDdZdXFobHJoVTdNVGVsamlic0UKLS0tIFF6RjdTaFlGMnM3QkJyVjFNdER4RWd6czVjRHNHL3lSU3ZpQ1p1dHRwQkEKuLrshIcb3nCoRsQ4ETXEgitAURwB4QJCaj66kI2VbeOOjr3bKSWiAvo3i0UentTimUCJhW5z+0S0B861sJovZQ=="
+                }
             }
         },
         {

--- a/feeds/nz.json
+++ b/feeds/nz.json
@@ -20,7 +20,12 @@
             "name": "AT",
             "spec": "gtfs-rt",
             "type": "url",
-            "url": "https://jbb.ghsq.de/gtfs/at/legacy"
+            "url": "https://api.at.govt.nz/realtime/legacy/",
+            "headers": {
+                "Accept": "application/x-protobuf",
+                "Ocp-Apim-Subscription-Key": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyVG5pcGdhQnFpOE9jTlV6RVpQVWFlNVh5MzdNOExsWkFVaE5CbFd4THpjCjE0QkRzZVJrZExjSkRhYmM2MDZQNWt1ZWJIbUs3SndvM1lMeExvd09IZjQKLS0tIFJJUk9pMHVLelBvSi9uZjBSM3lqZy80VmZTRHowRWxqWlM1ZXVMSVV4RWcKKeqXFv7A+cJ5xNUharR0hvB+GmKdNWue8TQocekK4XraGNEM/mEk4anoSgKrv7BTIMMEl2iaCvAUa6dJfCRc3g=="
+            },
+            "use-feed-proxy": true
         },
         {
             "name": "Flamingo-Auckland",
@@ -110,14 +115,37 @@
         {
             "name": "Metro-Christchurch",
             "type": "http",
-            "url": "https://gitlab.com/applecuckoo/gtfs-fixes/-/jobs/artifacts/main/raw/chc-gtfs.zip?job=gtfs-mirror",
-            "fix": true
+            "url": "https://apis.metroinfo.co.nz/rti/gtfs/v1/gtfs.zip",
+            "fix": true,
+            "headers": {
+                "Ocp-Apim-Subscription-Key": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArRDhISEtWYTJwYms5UVdXY3IyTzBudWdldHQ3Tjg3SVhYdHdENjlQUWxJClpPKzZVTG5VM2cvVENWZ1J2Qlpndm5qNDdZdXFobHJoVTdNVGVsamlic0UKLS0tIFF6RjdTaFlGMnM3QkJyVjFNdER4RWd6czVjRHNHL3lSU3ZpQ1p1dHRwQkEKuLrshIcb3nCoRsQ4ETXEgitAURwB4QJCaj66kI2VbeOOjr3bKSWiAvo3i0UentTimUCJhW5z+0S0B861sJovZQ=="
+            }
         },
         {
             "name": "Metro-Christchurch",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-rb6b-metrochristchurch~rt",
-            "api-key": "key-from-secrets",
+            "type": "url",
+            "url": "https://apis.metroinfo.co.nz/rti/gtfsrt/v1/service-alerts.pb",
+            "headers": {
+                "Ocp-Apim-Subscription-Key": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArRDhISEtWYTJwYms5UVdXY3IyTzBudWdldHQ3Tjg3SVhYdHdENjlQUWxJClpPKzZVTG5VM2cvVENWZ1J2Qlpndm5qNDdZdXFobHJoVTdNVGVsamlic0UKLS0tIFF6RjdTaFlGMnM3QkJyVjFNdER4RWd6czVjRHNHL3lSU3ZpQ1p1dHRwQkEKuLrshIcb3nCoRsQ4ETXEgitAURwB4QJCaj66kI2VbeOOjr3bKSWiAvo3i0UentTimUCJhW5z+0S0B861sJovZQ=="
+            },
+            "use-feed-proxy": true
+        },
+        {
+            "name": "Metro-Christchurch",
+            "type": "url",
+            "url": "https://apis.metroinfo.co.nz/rti/gtfsrt/v1/trip-updates.pb",
+            "headers": {
+                "Ocp-Apim-Subscription-Key": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArRDhISEtWYTJwYms5UVdXY3IyTzBudWdldHQ3Tjg3SVhYdHdENjlQUWxJClpPKzZVTG5VM2cvVENWZ1J2Qlpndm5qNDdZdXFobHJoVTdNVGVsamlic0UKLS0tIFF6RjdTaFlGMnM3QkJyVjFNdER4RWd6czVjRHNHL3lSU3ZpQ1p1dHRwQkEKuLrshIcb3nCoRsQ4ETXEgitAURwB4QJCaj66kI2VbeOOjr3bKSWiAvo3i0UentTimUCJhW5z+0S0B861sJovZQ=="
+            },
+            "use-feed-proxy": true
+        },
+        {
+            "name": "Metro-Christchurch",
+            "type": "url",
+            "url": "https://apis.metroinfo.co.nz/rti/gtfsrt/v1/vehicle-positions.pb",
+            "headers": {
+                "Ocp-Apim-Subscription-Key": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArRDhISEtWYTJwYms5UVdXY3IyTzBudWdldHQ3Tjg3SVhYdHdENjlQUWxJClpPKzZVTG5VM2cvVENWZ1J2Qlpndm5qNDdZdXFobHJoVTdNVGVsamlic0UKLS0tIFF6RjdTaFlGMnM3QkJyVjFNdER4RWd6czVjRHNHL3lSU3ZpQ1p1dHRwQkEKuLrshIcb3nCoRsQ4ETXEgitAURwB4QJCaj66kI2VbeOOjr3bKSWiAvo3i0UentTimUCJhW5z+0S0B861sJovZQ=="
+            },
             "use-feed-proxy": true
         },
         {

--- a/feeds/us-ny.json
+++ b/feeds/us-ny.json
@@ -7,6 +7,10 @@
         {
             "name": "Marcus Lundblad",
             "github": "mlundblad"
+        },
+        {
+            "name": "applecuckoo",
+            "github": "applecuckoo"
         }
     ],
     "sources": [
@@ -90,14 +94,14 @@
             "name": "MTA-BusManhattan",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfsrt.prod.obanyc.com/tripUpdates?key=e6a24daf-8207-4e14-8795-b612ea66878f",
+            "url": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHdGVtMXBwckpWWHhQenlhOHlISXhJZEZ2aENPN3JmNDZqVnJubjRvVmc0CjllUVdCbXcvNndFWlo0VlBCY1M3Tnk2Y2hEYXcybDkvbGU5R096VDNjMmMKLS0tIGd4UE9tUU9wZGtRMlIyaHJINlJ6WWU5bkNlMnd0Nmw5WFh4SGtmYTVGcncKo4LWEYLhPQo9nsae+waYSYEjCE4S4EmZrDa9P3zk9r8Ix5oqDbQCXaqVAQZZV3cBMIU7cyhB+6eld1Xct6osLVUJ+78X6ES0BCXslUJUa7sqG5HfgrVEKecF2OJ1VX5aTzAILxZiMlLyrdHq757FfsXqlg==",
             "use-feed-proxy": true
         },
         {
             "name": "MTA-BusManhattan",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfsrt.prod.obanyc.com/alerts?key=e6a24daf-8207-4e14-8795-b612ea66878f",
+            "url": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQTG1YMVdpWS8rdThiMmR4eUZIRk9vNkh5a0dyTmxZM3hmWmtUTmF0VlVrCk1tMmQ3R05XRGQ5VkRRVXIvT05oYTc2ZERKaXNaeTF3V2xxUktuRWxYYmsKLS0tIFFuRkw4TE1mQkNZeFVOaWg5bDNzbVlIM1BzRTlPeFd5WFNsVWVBKzB4Tk0KkPo9eCWlYT+fXuoYV9T83A946l2t2eBsw+FRh8aUyVK6duRpYv7zuUYxqcKf5Ci+xd5RYPGLESF6j5HqgQH1R8/m5GAwYpQ6FsCvR+nluGxZPWSFqBpH52qv6tyKBJvT2LCN+K79Q4a+nCHWsww=",
             "use-feed-proxy": true
         },
         {
@@ -109,14 +113,14 @@
             "name": "MTA-BusQueens",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfsrt.prod.obanyc.com/tripUpdates?key=e6a24daf-8207-4e14-8795-b612ea66878f",
+            "url": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHdGVtMXBwckpWWHhQenlhOHlISXhJZEZ2aENPN3JmNDZqVnJubjRvVmc0CjllUVdCbXcvNndFWlo0VlBCY1M3Tnk2Y2hEYXcybDkvbGU5R096VDNjMmMKLS0tIGd4UE9tUU9wZGtRMlIyaHJINlJ6WWU5bkNlMnd0Nmw5WFh4SGtmYTVGcncKo4LWEYLhPQo9nsae+waYSYEjCE4S4EmZrDa9P3zk9r8Ix5oqDbQCXaqVAQZZV3cBMIU7cyhB+6eld1Xct6osLVUJ+78X6ES0BCXslUJUa7sqG5HfgrVEKecF2OJ1VX5aTzAILxZiMlLyrdHq757FfsXqlg==",
             "use-feed-proxy": true
         },
         {
             "name": "MTA-BusQueens",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfsrt.prod.obanyc.com/alerts?key=e6a24daf-8207-4e14-8795-b612ea66878f",
+            "url": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQTG1YMVdpWS8rdThiMmR4eUZIRk9vNkh5a0dyTmxZM3hmWmtUTmF0VlVrCk1tMmQ3R05XRGQ5VkRRVXIvT05oYTc2ZERKaXNaeTF3V2xxUktuRWxYYmsKLS0tIFFuRkw4TE1mQkNZeFVOaWg5bDNzbVlIM1BzRTlPeFd5WFNsVWVBKzB4Tk0KkPo9eCWlYT+fXuoYV9T83A946l2t2eBsw+FRh8aUyVK6duRpYv7zuUYxqcKf5Ci+xd5RYPGLESF6j5HqgQH1R8/m5GAwYpQ6FsCvR+nluGxZPWSFqBpH52qv6tyKBJvT2LCN+K79Q4a+nCHWsww=",
             "use-feed-proxy": true
         },
         {
@@ -128,14 +132,14 @@
             "name": "MTA-BusStatenIsland",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfsrt.prod.obanyc.com/tripUpdates?key=e6a24daf-8207-4e14-8795-b612ea66878f",
+            "url": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHdGVtMXBwckpWWHhQenlhOHlISXhJZEZ2aENPN3JmNDZqVnJubjRvVmc0CjllUVdCbXcvNndFWlo0VlBCY1M3Tnk2Y2hEYXcybDkvbGU5R096VDNjMmMKLS0tIGd4UE9tUU9wZGtRMlIyaHJINlJ6WWU5bkNlMnd0Nmw5WFh4SGtmYTVGcncKo4LWEYLhPQo9nsae+waYSYEjCE4S4EmZrDa9P3zk9r8Ix5oqDbQCXaqVAQZZV3cBMIU7cyhB+6eld1Xct6osLVUJ+78X6ES0BCXslUJUa7sqG5HfgrVEKecF2OJ1VX5aTzAILxZiMlLyrdHq757FfsXqlg==",
             "use-feed-proxy": true
         },
         {
             "name": "MTA-BusStatenIsland",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfsrt.prod.obanyc.com/alerts?key=e6a24daf-8207-4e14-8795-b612ea66878f",
+            "url": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQTG1YMVdpWS8rdThiMmR4eUZIRk9vNkh5a0dyTmxZM3hmWmtUTmF0VlVrCk1tMmQ3R05XRGQ5VkRRVXIvT05oYTc2ZERKaXNaeTF3V2xxUktuRWxYYmsKLS0tIFFuRkw4TE1mQkNZeFVOaWg5bDNzbVlIM1BzRTlPeFd5WFNsVWVBKzB4Tk0KkPo9eCWlYT+fXuoYV9T83A946l2t2eBsw+FRh8aUyVK6duRpYv7zuUYxqcKf5Ci+xd5RYPGLESF6j5HqgQH1R8/m5GAwYpQ6FsCvR+nluGxZPWSFqBpH52qv6tyKBJvT2LCN+K79Q4a+nCHWsww=",
             "use-feed-proxy": true
         },
         {
@@ -147,14 +151,14 @@
             "name": "MTA-BusBrooklyn",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfsrt.prod.obanyc.com/tripUpdates?key=e6a24daf-8207-4e14-8795-b612ea66878f",
+            "url": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHdGVtMXBwckpWWHhQenlhOHlISXhJZEZ2aENPN3JmNDZqVnJubjRvVmc0CjllUVdCbXcvNndFWlo0VlBCY1M3Tnk2Y2hEYXcybDkvbGU5R096VDNjMmMKLS0tIGd4UE9tUU9wZGtRMlIyaHJINlJ6WWU5bkNlMnd0Nmw5WFh4SGtmYTVGcncKo4LWEYLhPQo9nsae+waYSYEjCE4S4EmZrDa9P3zk9r8Ix5oqDbQCXaqVAQZZV3cBMIU7cyhB+6eld1Xct6osLVUJ+78X6ES0BCXslUJUa7sqG5HfgrVEKecF2OJ1VX5aTzAILxZiMlLyrdHq757FfsXqlg==",
             "use-feed-proxy": true
         },
         {
             "name": "MTA-BusBrooklyn",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfsrt.prod.obanyc.com/alerts?key=e6a24daf-8207-4e14-8795-b612ea66878f",
+            "url": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQTG1YMVdpWS8rdThiMmR4eUZIRk9vNkh5a0dyTmxZM3hmWmtUTmF0VlVrCk1tMmQ3R05XRGQ5VkRRVXIvT05oYTc2ZERKaXNaeTF3V2xxUktuRWxYYmsKLS0tIFFuRkw4TE1mQkNZeFVOaWg5bDNzbVlIM1BzRTlPeFd5WFNsVWVBKzB4Tk0KkPo9eCWlYT+fXuoYV9T83A946l2t2eBsw+FRh8aUyVK6duRpYv7zuUYxqcKf5Ci+xd5RYPGLESF6j5HqgQH1R8/m5GAwYpQ6FsCvR+nluGxZPWSFqBpH52qv6tyKBJvT2LCN+K79Q4a+nCHWsww=",
             "use-feed-proxy": true
         },
         {
@@ -166,14 +170,14 @@
             "name": "MTA-BusBronx",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfsrt.prod.obanyc.com/tripUpdates?key=e6a24daf-8207-4e14-8795-b612ea66878f",
+            "url": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHdGVtMXBwckpWWHhQenlhOHlISXhJZEZ2aENPN3JmNDZqVnJubjRvVmc0CjllUVdCbXcvNndFWlo0VlBCY1M3Tnk2Y2hEYXcybDkvbGU5R096VDNjMmMKLS0tIGd4UE9tUU9wZGtRMlIyaHJINlJ6WWU5bkNlMnd0Nmw5WFh4SGtmYTVGcncKo4LWEYLhPQo9nsae+waYSYEjCE4S4EmZrDa9P3zk9r8Ix5oqDbQCXaqVAQZZV3cBMIU7cyhB+6eld1Xct6osLVUJ+78X6ES0BCXslUJUa7sqG5HfgrVEKecF2OJ1VX5aTzAILxZiMlLyrdHq757FfsXqlg==",
             "use-feed-proxy": true
         },
         {
             "name": "MTA-BusBronx",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfsrt.prod.obanyc.com/alerts?key=e6a24daf-8207-4e14-8795-b612ea66878f",
+            "url": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQTG1YMVdpWS8rdThiMmR4eUZIRk9vNkh5a0dyTmxZM3hmWmtUTmF0VlVrCk1tMmQ3R05XRGQ5VkRRVXIvT05oYTc2ZERKaXNaeTF3V2xxUktuRWxYYmsKLS0tIFFuRkw4TE1mQkNZeFVOaWg5bDNzbVlIM1BzRTlPeFd5WFNsVWVBKzB4Tk0KkPo9eCWlYT+fXuoYV9T83A946l2t2eBsw+FRh8aUyVK6duRpYv7zuUYxqcKf5Ci+xd5RYPGLESF6j5HqgQH1R8/m5GAwYpQ6FsCvR+nluGxZPWSFqBpH52qv6tyKBJvT2LCN+K79Q4a+nCHWsww=",
             "use-feed-proxy": true
         },
         {
@@ -185,14 +189,14 @@
             "name": "MTA-BusCompany",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfsrt.prod.obanyc.com/tripUpdates?key=e6a24daf-8207-4e14-8795-b612ea66878f",
+            "url": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHdGVtMXBwckpWWHhQenlhOHlISXhJZEZ2aENPN3JmNDZqVnJubjRvVmc0CjllUVdCbXcvNndFWlo0VlBCY1M3Tnk2Y2hEYXcybDkvbGU5R096VDNjMmMKLS0tIGd4UE9tUU9wZGtRMlIyaHJINlJ6WWU5bkNlMnd0Nmw5WFh4SGtmYTVGcncKo4LWEYLhPQo9nsae+waYSYEjCE4S4EmZrDa9P3zk9r8Ix5oqDbQCXaqVAQZZV3cBMIU7cyhB+6eld1Xct6osLVUJ+78X6ES0BCXslUJUa7sqG5HfgrVEKecF2OJ1VX5aTzAILxZiMlLyrdHq757FfsXqlg==",
             "use-feed-proxy": true
         },
         {
             "name": "MTA-BusCompany",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfsrt.prod.obanyc.com/alerts?key=e6a24daf-8207-4e14-8795-b612ea66878f",
+            "url": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQTG1YMVdpWS8rdThiMmR4eUZIRk9vNkh5a0dyTmxZM3hmWmtUTmF0VlVrCk1tMmQ3R05XRGQ5VkRRVXIvT05oYTc2ZERKaXNaeTF3V2xxUktuRWxYYmsKLS0tIFFuRkw4TE1mQkNZeFVOaWg5bDNzbVlIM1BzRTlPeFd5WFNsVWVBKzB4Tk0KkPo9eCWlYT+fXuoYV9T83A946l2t2eBsw+FRh8aUyVK6duRpYv7zuUYxqcKf5Ci+xd5RYPGLESF6j5HqgQH1R8/m5GAwYpQ6FsCvR+nluGxZPWSFqBpH52qv6tyKBJvT2LCN+K79Q4a+nCHWsww=",
             "use-feed-proxy": true
         },
         {

--- a/feeds/us-ny.json
+++ b/feeds/us-ny.json
@@ -225,7 +225,7 @@
             "name": "SuffolkCountyTransit",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-drk-ny~suffolkcountytransit~rt",
-            "api-key": "key-from-secrets",
+            "api-key": "AGE-ENCRYPTED:YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCSDBQa1VaYmlZb2lEd09ncHZ5YmYyMmsrbFNxN0tES1NHUkxYa0hDMXpFCjNhSDN4cWtZL3Qrc3FVNXJxbnpjZlRBcEJqK3Rnbld0a3p2UXhscW5pZkUKLS0tIDFwUzFya2JrcENyaVYySGtoM3Bjek5WeEFRK0NneTlIUDBYRjU5V0RNMlkKBY8R3FtbmSVnQlG8d7Mdsj2CfMbto2vfDXhks9+vYYTES5Ni1nlCSbA/Kv65Ap4GM06VEKfE4BbJT18N0NsuJg==",
             "use-feed-proxy": true
         },
         {


### PR DESCRIPTION
also worth mentioning that the NYC BusTime URLs had my API key in them so I encrypted them, looks to be the first instance of that as far as I can find?