### PR TITLE
Add license information to Piemonte-Bus entry

### DIFF
--- a/feeds/it.json
+++ b/feeds/it.json
@@ -144,7 +144,10 @@
             "name": "Piemonte-Bus",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u0j-piemonte~autobus",
-            "fix": true
+            "fix": true,
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            }
         },
         {
             "name": "Piemonte-Gruppo-Torinese-Trasporti",


### PR DESCRIPTION
License is specified on https://www.dati.piemonte.it/#/catalogodetail/regpie_ckan_ckan2_yucca_sdp_smartdatanet.it_Servizioprogrammatodeltrasportopubblicoregionepiemonteautobus_22942
