### PR TITLE
Add Air France/KLM flight schedule

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -13983,6 +13983,15 @@
             "managed-by-script": true,
             "skip": true,
             "skip-reason": "Invalid GTFS, not zipped"
+        },
+        {
+            "name": "airfrance-klm",
+            "type": "http",
+            "url": "https://public-transport.github.io/ssim-converter/AF-KL-TO-HV-S26-W26.zip",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/programme-des-vols-air-france",
+                "spdx-identifier": null
+            }
         }
     ]
 }


### PR DESCRIPTION
Converted from the SSIM schedule on transport.data.gouv.fr and airport/ airline data from Wikidata, using https://github.com/public-transport/ssim-converter/.

Depends on https://github.com/public-transport/gtfsclean/pull/18.

Implements #619.