### PR TITLE
fix(ee): classify domestic coaches as coach instead of bus

### DIFF
--- a/feeds/ee.json
+++ b/feeds/ee.json
@@ -184,7 +184,8 @@
             "url": "https://eu-gtfs.remix.com/kaugliinid.zip",
             "license": {
                 "spdx-identifier": "CC0-1.0"
-            }
+            },
+            "script": "generic-bus-to-coach.lua"
         },
         {
             "name": "kaugliinid-rahvusvaheline",


### PR DESCRIPTION
## Summary

- Adds `generic-bus-to-coach.lua` override to the `kaugliinid` (domestic long-distance) feed
- This matches the override already applied to `kaugliinid-rahvusvaheline` (international long-distance)
- Estonian domestic long-distance services are coaches, not regular city buses

Closes #1947

## Test plan

- [ ] After rebuild, Estonian domestic long-distance routes appear with coach icon/type instead of bus
- [ ] International routes remain unchanged (already had the override)