### PR TITLE
reverse proxy: refine limits, extend logging

### DIFF
--- a/ansible/roles/nginx/files/nginx.conf
+++ b/ansible/roles/nginx/files/nginx.conf
@@ -42,8 +42,10 @@ http {
 	##
 	# Logging Settings
 	##
-
-	access_log /var/log/nginx/access.log;
+	log_format combined_with_response_time '$remote_addr - $remote_user [$time_local] '
+                    '"$request" $status $body_bytes_sent urt=$upstream_response_time '
+                    '"$http_referer" "$http_user_agent"';
+    access_log /var/log/nginx/access.log combined_with_response_time;
 	log_format metrics '[$time_local] $host rl=$request_length urt=$upstream_response_time rt=$request_time bbs=$body_bytes_sent s=$status ph=$proxy_host uri=$uri ua=$http_user_agent';
 	access_log /var/log/nginx/metrics.log metrics;
 

--- a/ansible/roles/nginx/templates/transitous.conf.j2
+++ b/ansible/roles/nginx/templates/transitous.conf.j2
@@ -99,7 +99,7 @@ server {
     location /ojp20 {
         proxy_pass http://{{ item.vhost }}-backend/ojp20;
 
-        limit_req zone=api burst=40 delay=10;
+        limit_req zone=api burst=20 delay=10;
         
         proxy_connect_timeout       2s;
         proxy_send_timeout          60;
@@ -111,7 +111,7 @@ server {
     location ~ ^/api/(v1|v2|v3|v4|v5|v6|experimental)/(plan|one-to-all) {
         proxy_pass http://{{ item.vhost }}-backend$uri?$args;
 
-        limit_req zone=api_plan burst=20 delay=10;
+        limit_req zone=api_plan burst=17 delay=7;
 
         proxy_connect_timeout       2s;
         proxy_send_timeout          60;


### PR DESCRIPTION
extend logging to contain response time to more easily find long running queries
slightly lower limits

(already deployed)