### PR TITLE
Reactivate warsaw ferries for 2026 season

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -859,9 +859,7 @@
             "url": "https://kasmar00.github.io/gtfs-warsaw-custom/feeds/warsaw-ferries/latest.zip",
             "license": {
                 "spdx-identifier": "CC-BY-4.0"
-            },
-            "skip": true,
-            "skip-reason": "Outdated feed"
+            }
         },
         {
             "name": "Ząbki",


### PR DESCRIPTION
Feed has been updated with data for 2026 summer season.