### PR TITLE
Replace Porto SCTP source

### DIFF
--- a/feeds/pt.json
+++ b/feeds/pt.json
@@ -1,145 +1,145 @@
 {
-  "maintainers": [
-    {
-      "name": "Paul Brown",
-      "github": "Bro66666"
-    },
-    {
-      "name": "Marcus Lundblad",
-      "github": "mlundblad"
-    },
-    {
-      "name": "Patrick Steil",
-      "github": "SteilDev"
-    }
-  ],
-  "sources": [
-    {
-      "name": "Carris-Metropolitana",
-      "type": "http",
-      "url": "https://api.carrismetropolitana.pt/gtfs",
-      "license": {
-        "spdx-identifier": "CC-BY-4.0"
-      },
-      "fix": true,
-      "http-options": {
-        "fetch-interval-days": 1
-      }
-    },
-    {
-      "name": "Carris",
-      "type": "mobility-database",
-      "mdb-id": "mdb-2929",
-      "license": {
-        "spdx-identifier": "CC0-1.0"
-      }
-    },
-    {
-      "name": "Metro-Lisboa",
-      "type": "http",
-      "url": "https://www.metrolisboa.pt/google_transit/googleTransit.zip",
-      "license": {
-        "spdx-identifier": "CC0-1.0"
-      }
-    },
-    {
-      "name": "Cascais-Próxima",
-      "type": "transitland-atlas",
-      "transitland-atlas-id": "f-eyck-cascaispróximaemsa"
-    },
-    {
-      "name": "Comboios-de-Portugal(CP)",
-      "type": "transitland-atlas",
-      "transitland-atlas-id": "f-eyc-cp"
-    },
-    {
-      "name": "Comboios-de-Portugal(CP)",
-      "type": "url",
-      "spec": "gtfs-rt",
-      "url": "https://rt.gtfs.baguette.pirnet.si/gtfs-rt/cp/trip_updates.pb"
-    },
-    {
-      "name": "Fergatus",
-      "type": "transitland-atlas",
-      "transitland-atlas-id": "f-eyce-fertagus"
-    },
-    {
-      "name": "Barreiro",
-      "type": "transitland-atlas",
-      "transitland-atlas-id": "f-transportes~colectivos~do~barreiro~pt"
-    },
-    {
-      "name": "Funchal",
-      "type": "transitland-atlas",
-      "transitland-atlas-id": "f-etgc-hf~urbano~hf~interurbano"
-    },
-    {
-      "name": "Algarve-Vamus",
-      "type": "transitland-atlas",
-      "transitland-atlas-id": "f-ey-vizur"
-    },
-    {
-      "name": "Transportes-Urbanos-de-Braga",
-      "type": "transitland-atlas",
-      "transitland-atlas-id": "f-transportes~urbanos~de~braga"
-    },
-    {
-      "name": "Autna",
-      "type": "transitland-atlas",
-      "transitland-atlas-id": "f-ez-autnatransportes"
-    },
-    {
-      "name": "Porto-STCP",
-      "type": "http",
-      "url": "https://opendata.porto.digital/dataset/horarios-paragens-e-rotas-em-formato-gtfs-stcp",
-      "function": "data_stcp_latest_resource",
-      "license": {
-        "spdx-identifier": "CC0-1.0"
-      }
-    },
-    {
-      "name": "Tavira",
-      "type": "transitland-atlas",
-      "transitland-atlas-id": "f-eyd-sobeedesce"
-    },
-    {
-      "name": "Portimao",
-      "type": "transitland-atlas",
-      "transitland-atlas-id": "f-ey9-vaivem"
-    },
-    {
-      "name": "Faro",
-      "type": "transitland-atlas",
-      "transitland-atlas-id": "f-eyd-pxm"
-    },
-    {
-      "name": "Albufeira-Giro",
-      "type": "transitland-atlas",
-      "transitland-atlas-id": "f-eyd-giro"
-    },
-    {
-      "name": "Olhao",
-      "type": "transitland-atlas",
-      "transitland-atlas-id": "f-eyd-circuitoolhao"
-    },
-    {
-      "name": "Apanha-me",
-      "type": "transitland-atlas",
-      "transitland-atlas-id": "f-eyd-apanhame"
-    },
-    {
-      "name": "Lagos-Aonda",
-      "type": "transitland-atlas",
-      "transitland-atlas-id": "f-ey9-aonda"
-    },
-    {
-      "name": "Metro-Porto",
-      "type": "http",
-      "url": "https://www.metrodoporto.pt/pages/337",
-      "function": "data_metroporto_latest_resource",
-      "license": {
-        "spdx-identifier": "CC0-1.0"
-      }
-    }
-  ]
+    "maintainers": [
+        {
+            "name": "Paul Brown",
+            "github": "Bro66666"
+        },
+        {
+            "name": "Marcus Lundblad",
+            "github": "mlundblad"
+        },
+        {
+            "name": "Patrick Steil",
+            "github": "SteilDev"
+        }
+    ],
+    "sources": [
+        {
+            "name": "Carris-Metropolitana",
+            "type": "http",
+            "url": "https://api.carrismetropolitana.pt/gtfs",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            },
+            "fix": true,
+            "http-options": {
+                "fetch-interval-days": 1
+            }
+        },
+        {
+            "name": "Carris",
+            "type": "mobility-database",
+            "mdb-id": "mdb-2929",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            }
+        },
+        {
+            "name": "Metro-Lisboa",
+            "type": "http",
+            "url": "https://www.metrolisboa.pt/google_transit/googleTransit.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            }
+        },
+        {
+            "name": "Cascais-Próxima",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-eyck-cascaispróximaemsa"
+        },
+        {
+            "name": "Comboios-de-Portugal(CP)",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-eyc-cp"
+        },
+        {
+            "name": "Comboios-de-Portugal(CP)",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://rt.gtfs.baguette.pirnet.si/gtfs-rt/cp/trip_updates.pb"
+        },
+        {
+            "name": "Fergatus",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-eyce-fertagus"
+        },
+        {
+            "name": "Barreiro",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-transportes~colectivos~do~barreiro~pt"
+        },
+        {
+            "name": "Funchal",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-etgc-hf~urbano~hf~interurbano"
+        },
+        {
+            "name": "Algarve-Vamus",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ey-vizur"
+        },
+        {
+            "name": "Transportes-Urbanos-de-Braga",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-transportes~urbanos~de~braga"
+        },
+        {
+            "name": "Autna",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ez-autnatransportes"
+        },
+        {
+            "name": "Porto-STCP",
+            "type": "http",
+            "url": "https://opendata.porto.digital/dataset/horarios-paragens-e-rotas-em-formato-gtfs-stcp",
+            "function": "data_stcp_latest_resource",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            }
+        },
+        {
+            "name": "Tavira",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-eyd-sobeedesce"
+        },
+        {
+            "name": "Portimao",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ey9-vaivem"
+        },
+        {
+            "name": "Faro",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-eyd-pxm"
+        },
+        {
+            "name": "Albufeira-Giro",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-eyd-giro"
+        },
+        {
+            "name": "Olhao",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-eyd-circuitoolhao"
+        },
+        {
+            "name": "Apanha-me",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-eyd-apanhame"
+        },
+        {
+            "name": "Lagos-Aonda",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ey9-aonda"
+        },
+        {
+            "name": "Metro-Porto",
+            "type": "http",
+            "url": "https://www.metrodoporto.pt/pages/337",
+            "function": "data_metroporto_latest_resource",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            }
+        }
+    ]
 }

--- a/feeds/pt.json
+++ b/feeds/pt.json
@@ -1,142 +1,145 @@
 {
-    "maintainers": [
-        {
-            "name": "Paul Brown",
-            "github": "Bro66666"
-        },
-        {
-            "name": "Marcus Lundblad",
-            "github": "mlundblad"
-        },
-        {
-            "name": "Patrick Steil",
-            "github": "SteilDev"
-        }
-    ],
-    "sources": [
-        {
-            "name": "Carris-Metropolitana",
-            "type": "http",
-            "url": "https://api.carrismetropolitana.pt/gtfs",
-            "license": {
-                "spdx-identifier": "CC-BY-4.0"
-            },
-            "fix": true,
-            "http-options": {
-                "fetch-interval-days": 1
-            }
-        },
-        {
-            "name": "Carris",
-            "type": "mobility-database",
-            "mdb-id": "mdb-2929",
-            "license": {
-                "spdx-identifier": "CC0-1.0"
-            }
-        },
-        {
-            "name": "Metro-Lisboa",
-            "type": "http",
-            "url": "https://www.metrolisboa.pt/google_transit/googleTransit.zip",
-            "license": {
-                "spdx-identifier": "CC0-1.0"
-            }
-        },
-        {
-            "name": "Cascais-Próxima",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-eyck-cascaispróximaemsa"
-        },
-        {
-            "name": "Comboios-de-Portugal(CP)",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-eyc-cp"
-        },
-        {
-            "name": "Comboios-de-Portugal(CP)",
-            "type": "url",
-            "spec": "gtfs-rt",
-            "url": "https://rt.gtfs.baguette.pirnet.si/gtfs-rt/cp/trip_updates.pb"
-        },
-        {
-            "name": "Fergatus",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-eyce-fertagus"
-        },
-        {
-            "name": "Barreiro",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-transportes~colectivos~do~barreiro~pt"
-        },
-        {
-            "name": "Funchal",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-etgc-hf~urbano~hf~interurbano"
-        },
-        {
-            "name": "Algarve-Vamus",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-ey-vizur"
-        },
-        {
-            "name": "Transportes-Urbanos-de-Braga",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-transportes~urbanos~de~braga"
-        },
-        {
-            "name": "Autna",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-ez-autnatransportes"
-        },
-        {
-            "name": "Porto-STCP",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-stcp~porto~pt",
-            "url-override": "https://opendata.porto.digital/dataset/5275c986-592c-43f5-8f87-aabbd4e4f3a4/resource/1e0f4315-3694-42b0-a8ce-5218ad4742e5/download/horarios_gtfs_stcp_06_01_2025.zip"
-        },
-        {
-            "name": "Tavira",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-eyd-sobeedesce"
-        },
-        {
-            "name": "Portimao",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-ey9-vaivem"
-        },
-        {
-            "name": "Faro",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-eyd-pxm"
-        },
-        {
-            "name": "Albufeira-Giro",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-eyd-giro"
-        },
-        {
-            "name": "Olhao",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-eyd-circuitoolhao"
-        },
-        {
-            "name": "Apanha-me",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-eyd-apanhame"
-        },
-        {
-            "name": "Lagos-Aonda",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-ey9-aonda"
-        },
-        {
-            "name": "Metro-Porto",
-            "type": "http",
-            "url": "https://www.metrodoporto.pt/pages/337",
-            "function": "data_metroporto_latest_resource",
-            "license": {
-                "spdx-identifier": "CC0-1.0"
-            }
-        }
-    ]
+  "maintainers": [
+    {
+      "name": "Paul Brown",
+      "github": "Bro66666"
+    },
+    {
+      "name": "Marcus Lundblad",
+      "github": "mlundblad"
+    },
+    {
+      "name": "Patrick Steil",
+      "github": "SteilDev"
+    }
+  ],
+  "sources": [
+    {
+      "name": "Carris-Metropolitana",
+      "type": "http",
+      "url": "https://api.carrismetropolitana.pt/gtfs",
+      "license": {
+        "spdx-identifier": "CC-BY-4.0"
+      },
+      "fix": true,
+      "http-options": {
+        "fetch-interval-days": 1
+      }
+    },
+    {
+      "name": "Carris",
+      "type": "mobility-database",
+      "mdb-id": "mdb-2929",
+      "license": {
+        "spdx-identifier": "CC0-1.0"
+      }
+    },
+    {
+      "name": "Metro-Lisboa",
+      "type": "http",
+      "url": "https://www.metrolisboa.pt/google_transit/googleTransit.zip",
+      "license": {
+        "spdx-identifier": "CC0-1.0"
+      }
+    },
+    {
+      "name": "Cascais-Próxima",
+      "type": "transitland-atlas",
+      "transitland-atlas-id": "f-eyck-cascaispróximaemsa"
+    },
+    {
+      "name": "Comboios-de-Portugal(CP)",
+      "type": "transitland-atlas",
+      "transitland-atlas-id": "f-eyc-cp"
+    },
+    {
+      "name": "Comboios-de-Portugal(CP)",
+      "type": "url",
+      "spec": "gtfs-rt",
+      "url": "https://rt.gtfs.baguette.pirnet.si/gtfs-rt/cp/trip_updates.pb"
+    },
+    {
+      "name": "Fergatus",
+      "type": "transitland-atlas",
+      "transitland-atlas-id": "f-eyce-fertagus"
+    },
+    {
+      "name": "Barreiro",
+      "type": "transitland-atlas",
+      "transitland-atlas-id": "f-transportes~colectivos~do~barreiro~pt"
+    },
+    {
+      "name": "Funchal",
+      "type": "transitland-atlas",
+      "transitland-atlas-id": "f-etgc-hf~urbano~hf~interurbano"
+    },
+    {
+      "name": "Algarve-Vamus",
+      "type": "transitland-atlas",
+      "transitland-atlas-id": "f-ey-vizur"
+    },
+    {
+      "name": "Transportes-Urbanos-de-Braga",
+      "type": "transitland-atlas",
+      "transitland-atlas-id": "f-transportes~urbanos~de~braga"
+    },
+    {
+      "name": "Autna",
+      "type": "transitland-atlas",
+      "transitland-atlas-id": "f-ez-autnatransportes"
+    },
+    {
+      "name": "Porto-STCP",
+      "type": "http",
+      "url": "https://opendata.porto.digital/dataset/horarios-paragens-e-rotas-em-formato-gtfs-stcp",
+      "function": "data_stcp_latest_resource",
+      "license": {
+        "spdx-identifier": "CC0-1.0"
+      }
+    },
+    {
+      "name": "Tavira",
+      "type": "transitland-atlas",
+      "transitland-atlas-id": "f-eyd-sobeedesce"
+    },
+    {
+      "name": "Portimao",
+      "type": "transitland-atlas",
+      "transitland-atlas-id": "f-ey9-vaivem"
+    },
+    {
+      "name": "Faro",
+      "type": "transitland-atlas",
+      "transitland-atlas-id": "f-eyd-pxm"
+    },
+    {
+      "name": "Albufeira-Giro",
+      "type": "transitland-atlas",
+      "transitland-atlas-id": "f-eyd-giro"
+    },
+    {
+      "name": "Olhao",
+      "type": "transitland-atlas",
+      "transitland-atlas-id": "f-eyd-circuitoolhao"
+    },
+    {
+      "name": "Apanha-me",
+      "type": "transitland-atlas",
+      "transitland-atlas-id": "f-eyd-apanhame"
+    },
+    {
+      "name": "Lagos-Aonda",
+      "type": "transitland-atlas",
+      "transitland-atlas-id": "f-ey9-aonda"
+    },
+    {
+      "name": "Metro-Porto",
+      "type": "http",
+      "url": "https://www.metrodoporto.pt/pages/337",
+      "function": "data_metroporto_latest_resource",
+      "license": {
+        "spdx-identifier": "CC0-1.0"
+      }
+    }
+  ]
 }

--- a/src/region_helpers.py
+++ b/src/region_helpers.py
@@ -14,33 +14,38 @@ import requests
 
 
 def mvo_keycloak_token(source: HttpSource) -> HttpSource:
-    token = requests.post("https://user.mobilitaetsverbuende.at/auth/realms/dbp-public/protocol/openid-connect/token", data={
+    token = requests.post(
+        "https://user.mobilitaetsverbuende.at/auth/realms/dbp-public/protocol/openid-connect/token",
+        data={
             "client_id": "dbp-public-ui",
             "username": "5f7xgv6ilp@ro5wy.anonbox.net",
             "password": ")#E8qE'~CqND5b#",
             "grant_type": "password",
-            "scope": "openid"
-        }).json()["access_token"]
+            "scope": "openid",
+        },
+    ).json()["access_token"]
 
     source.options.headers["Authorization"] = f"Bearer {token}"
 
     return source
 
 
-def data_public_lu_latest_resource(
-        source: HttpSource) -> HttpSource:
+def data_public_lu_latest_resource(source: HttpSource) -> HttpSource:
     api = requests.get(source.url).json()
-    res = sorted(api["resources"],
-                 key=lambda res: datetime.fromisoformat(res["last_modified"]),
-                 reverse=True)
+    res = sorted(
+        api["resources"],
+        key=lambda res: datetime.fromisoformat(res["last_modified"]),
+        reverse=True,
+    )
     source.url = res[0]["latest"]
     return source
 
 
 def delhi_gov_in_csrf(source: HttpSource) -> HttpSource:
     from bs4 import BeautifulSoup
+
     html = requests.get(source.url).text
-    element = BeautifulSoup(html, "lxml").find(attrs = {"name": "csrfmiddlewaretoken"})
+    element = BeautifulSoup(html, "lxml").find(attrs={"name": "csrfmiddlewaretoken"})
     csrftoken = element["value"]
     source.options.headers["Cookie"] = f"csrftoken={csrftoken}"
     source.options.request_body = f"csrfmiddlewaretoken={csrftoken}"
@@ -51,10 +56,11 @@ def data_zielona_gora_latest_resource(source: HttpSource) -> HttpSource:
     from bs4 import BeautifulSoup
 
     html = requests.get(source.url).text
-    
 
     soup = BeautifulSoup(html, "lxml")
-    gtfs_link = next((a["href"] for a in soup.find_all("a") if "GTFS" in a.get_text()), None)
+    gtfs_link = next(
+        (a["href"] for a in soup.find_all("a") if "GTFS" in a.get_text()), None
+    )
 
     base_url = source.url.rsplit("/", 1)[0]
     source.url = f"{base_url}/{gtfs_link}"
@@ -67,7 +73,7 @@ def data_slupsk_latest_resource(source: HttpSource) -> HttpSource:
 
     headers = {
         "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
-    } # user-agent is necessary to avoid 403 Forbidden
+    }  # user-agent is necessary to avoid 403 Forbidden
 
     html = requests.get(source.url, headers=headers).text
 
@@ -82,7 +88,7 @@ def data_slupsk_latest_resource(source: HttpSource) -> HttpSource:
 
 def data_tasmania_latest_resource(source: HttpSource) -> HttpSource:
     from bs4 import BeautifulSoup
-    
+
     html = requests.get(source.url).text
 
     soup = BeautifulSoup(html, "lxml")
@@ -131,6 +137,7 @@ def data_hodmezovasarhely_latest_resource(source: HttpSource) -> HttpSource:
 def data_metroporto_latest_resource(source: HttpSource) -> HttpSource:
     from bs4 import BeautifulSoup
     from urllib.parse import urljoin
+    import requests
 
     headers = {
         "user-agent": (
@@ -140,21 +147,96 @@ def data_metroporto_latest_resource(source: HttpSource) -> HttpSource:
         )
     }
 
-    html = requests.get(source.url, headers=headers).text
+    html = requests.get(source.url, headers=headers, timeout=30).text
     soup = BeautifulSoup(html, "html.parser")
 
-    li = soup.find("li", class_=lambda c: c and "last zip" in c)
+    li = soup.select_one("li.last.zip")
     if li is None:
         raise ValueError("Could not find the latest GTFS link on Metro do Porto page")
 
-    a_tag = li.find("a")
-    if a_tag is None or "href" not in a_tag.attrs:
-        raise ValueError("No <a> tag with href found inside the <li>")
+    a_tag = li.find("a", href=True)
+    if a_tag is None:
+        raise ValueError("No <a> tag with href found")
 
     gtfs_url = urljoin(source.url, a_tag["href"])
-
     source.url = gtfs_url
     return source
+
+
+def data_stcp_latest_resource(source: HttpSource) -> HttpSource:
+    from bs4 import BeautifulSoup
+    from urllib.parse import urljoin
+    import requests
+    import re
+    from datetime import datetime
+
+    headers = {
+        "user-agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/138.0.0.0 Safari/537.36"
+        )
+    }
+
+    html = requests.get(source.url, headers=headers, timeout=30).text
+    soup = BeautifulSoup(html, "html.parser")
+
+    resources = soup.select("li.resource-item")
+    if not resources:
+        raise ValueError("No resources found on STCP page")
+
+    def _extract_download(li, base_url, source):
+        from urllib.parse import urljoin
+
+        for a in li.select("a[href]"):
+            href = a.get("href", "")
+            label = a.get_text(" ", strip=True).lower()
+
+            if "/download/" in href or "transferir" in label:
+                source.url = urljoin(base_url, href)
+                return source
+
+        raise ValueError("Download link not found in selected resource")
+
+    # look for Mas Recente
+    for li in resources:
+        heading = li.select_one("a.heading")
+        if not heading:
+            continue
+
+        title = heading.get("title", "")
+        text = heading.get_text(" ", strip=True)
+
+        if "Mais Recente" in title or "Mais Recente" in text:
+            return _extract_download(li, source.url, source)
+
+    # fallback: parse dates and pick latest
+    dated_resources = []
+
+    date_pattern = re.compile(r"(\d{2}-\d{2}-\d{4})")
+
+    for li in resources:
+        heading = li.select_one("a.heading")
+        if not heading:
+            continue
+
+        text = heading.get_text(" ", strip=True)
+
+        match = date_pattern.search(text)
+        if not match:
+            continue
+
+        try:
+            dt = datetime.strptime(match.group(1), "%d-%m-%Y")
+            dated_resources.append((dt, li))
+        except ValueError:
+            continue
+
+    if not dated_resources:
+        raise ValueError("No dated GTFS resources found")
+
+    latest_li = max(dated_resources, key=lambda x: x[0])[1]
+    return _extract_download(latest_li, source.url, source)
 
 
 def chile_dtp_downloader(source: HttpSource) -> HttpSource:


### PR DESCRIPTION
Sorry for the formatting issues in the JSON and Python files. If preferred, I can revert those changes and keep only the functional updates.

Changes:
Updated the data source for `Porto-STCP,` as the previous `Transitland` source was outdated.
Implemented logic to automatically scrape the latest GTFS feed URL in `src/region_helpers.py`.