### PR TITLE
add license information

### DIFF
--- a/feeds/es.json
+++ b/feeds/es.json
@@ -845,7 +845,10 @@
         {
             "name": "Ferrocarriles-de-la-Generalitat-de-Cataluña",
             "type": "mobility-database",
-            "mdb-id": "mdb-1856"
+            "mdb-id": "mdb-1856",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            }
         },
         {
             "name": "Ferrocarriles-de-la-Generalitat-de-Cataluña",

--- a/feeds/ro.json
+++ b/feeds/ro.json
@@ -15,6 +15,7 @@
             "type": "http",
             "url": "https://jbb.ghsq.de/gtfs/ro-railway.gtfs.zip",
             "license": {
+                "spdx-identifier": "OGL-ROU-1.0",
                 "url": "https://data.gov.ro/base/images/logoinst/OGL-ROU-1.0.pdf"
             }
         },


### PR DESCRIPTION
1. In [traewelling/transitous-licenses](https://github.com/Traewelling/transitous-licenses/blob/main/licenses.json) we've collected a few licenses for feeds. Primarily those that can't be defined using standard SPDX identifiers. However, over time, some generic licenses have also ended up there, and I'd prefer to see them here in the repo instead. :)

~~2. For transitland feeds where a liense is specified in [their DMFR specifications](https://github.com/transitland/transitland-atlas/tree/main/feeds), I've copied the identifier here, so it can be processed here as well.~~