### PR TITLE
Add WienMobil Rad (Nextbike Vienna)

### DIFF
--- a/feeds/at.json
+++ b/feeds/at.json
@@ -158,6 +158,11 @@
             },
             "managed-by-script": true,
             "x-mvo-id": "57-2026"
+        },
+        {
+            "name": "WienMobil-Rad",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-wienmobil~rad~vienna~gbfs"
         }
     ]
 }


### PR DESCRIPTION
The feed is on Transitland, and the same feed exists and works on citybik.es

Fixes #2001 