### PR TITLE
fix(france): skip Pays de la Loire feed exposing flights as buses (#1646)

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -5267,7 +5267,8 @@
             ],
             "x-data-gov-fr-res-id": 79818,
             "managed-by-script": true,
-            "skip": false,
+            "skip": true,
+            "skip-reason": "Aéroport Nantes Atlantique flights are exposed as bus journeys with unrealistic times. See #1646.",
             "x-data-gov-fr-res-title": "GTFS Destineo Pays de la Loire",
             "x-data-gov-fr-dataset-id": "632b2a8a8bf5b436bed4f8df"
         },


### PR DESCRIPTION
## Summary

Marks the Pays de la Loire / Destineo / Réseaux AOM Aleop GTFS feed as `skip: true` so it no longer produces routes where flights from Aéroport Nantes Atlantique render as bus journeys.

## Why this matters

#1646 ships a concrete example trip (Nantes airport → some bus stop) where the journey planner returns a bus with unrealistic timing because the upstream feed labels flight legs as bus services. The feed name in the trip ID maps to `feeds/fr.json:5256-5273`:

```json
{
  "name": "arrets-horaires-et-circuits-des-lignes-de-transports-en-commun-en-pays-de-la-loire-gtfs-destineo-reseaux-aom-aleop-1",
  ...
  "drop-agency-names": ["Aéroport Nantes Atlantique"],
  "skip": false,
  ...
}
```

The existing `drop-agency-names` workaround targets that same airport agency, but the misclassified-bus output the reporter saw is still leaking through. The reporter's suggested fix in the issue is "we should probably just ignore the feed."

## Changes

`feeds/fr.json` — flip `"skip": false` to `"skip": true` and add a `"skip-reason"` describing the issue. Mirrors the field shape used by other already-skipped feeds in the same file (e.g. `transports-a-la-demande-en-pays-de-la-loire-gtfs-flex-aleop` lower in the file).

`src/update-france.py:97` updates existing entries via `id_map[resource["id"]].update(source)`. The script-built `source` dict does not include a `skip` or `skip-reason` key, so the next run of `update-france.py` will preserve these fields.

## Testing

- `python3 -c "import json; json.load(open('feeds/fr.json'))"` — file still parses.

Fixes #1646
