### PR TITLE
refine usage policy

### DIFF
--- a/website/content/api.html
+++ b/website/content/api.html
@@ -32,11 +32,12 @@ there's also the option to <a href="/doc/#running-a-transitous-instance-locally"
 <p>If you want to use the API for your free and open-source application, please:<p>
 
 <ul>
-<li>Contact us <a href="https://matrix.to/#/%23transitous:matrix.spline.de">in our Matrix Channel</a> to make sure we can handle your
+<li>Make sure your source code is published under an appropriate open-source license (light prototype testing before that is of course fine).</li>
+<li>If you have any doubt about the load your requests will be causing (expensive requests, many users, etc.), please contact us <a href="https://matrix.to/#/%23transitous:matrix.spline.de">in our Matrix Channel</a> to make sure we can handle your
 expected resource usage and so we are aware of your usecases. This also allows us to contact you in case we want to coordinate breaking changes.</li>
 <li>
     <p>
-        Make sure your send HTTP <code>User-Agent</code> headers with every request, at least containing the following information:
+        Make sure you send HTTP <code>User-Agent</code> headers with every request, at least containing the following information:
         <ul>
             <li>Name of the application</li>
             <li>Version of the client implementation</li>
@@ -48,7 +49,8 @@ expected resource usage and so we are aware of your usecases. This also allows u
     However, please make sure to add contact information to your website in this case.
     </p>
 </li>
-<li>You may <a href="https://github.com/public-transport/transitous/blob/b2d184b51cb4cf20fb48d0b76420ba57f4d3fce0/website/content/_index.html#L30">add your application to the Transitous website</a></li>
+<li>Link to <a href="https://transitous.org/sources/">https://transitous.org/sources/</a> in a visible place in order to properly attribute the sources. Make sure to adhere to the conditions imposed by these sources. In particular, since Transitous uses OpenStreetMap data, you have to adhere to its <a href="https://www.openstreetmap.org/copyright">attribution guidelines</a>, too.</li>
+<li>You may <a href="https://github.com/public-transport/transitous/blob/b2d184b51cb4cf20fb48d0b76420ba57f4d3fce0/website/content/_index.html#L30">add your application to the Transitous website</a>.</li>
 </ul>
 
 <h3>Commercial Use</h3>

--- a/website/content/api.html
+++ b/website/content/api.html
@@ -34,7 +34,7 @@ there's also the option to <a href="/doc/#running-a-transitous-instance-locally"
 <ul>
 <li>Make sure your source code is published under an appropriate open-source license (light prototype testing before that is of course fine).</li>
 <li>If you have any doubt about the load your requests will be causing (expensive requests, many users, etc.), please contact us <a href="https://matrix.to/#/%23transitous:matrix.spline.de">in our Matrix Channel</a> to make sure we can handle your
-expected resource usage and so we are aware of your usecases. This also allows us to contact you in case we want to coordinate breaking changes.</li>
+expected resource usage. In general, we are always happy to hear about the projects using the API and their use cases. This also allows us to contact you in case we want to coordinate breaking changes.</li>
 <li>
     <p>
         Make sure you send HTTP <code>User-Agent</code> headers with every request, at least containing the following information:

--- a/website/content/api.html
+++ b/website/content/api.html
@@ -49,7 +49,7 @@ expected resource usage. In general, we are always happy to hear about the proje
     However, please make sure to add contact information to your website in this case.
     </p>
 </li>
-<li>Link to <a href="https://transitous.org/sources/">https://transitous.org/sources/</a> in a visible place in order to properly attribute the sources. Make sure to adhere to the conditions imposed by these sources. In particular, since Transitous uses OpenStreetMap data, you have to adhere to its <a href="https://www.openstreetmap.org/copyright">attribution guidelines</a>, too.</li>
+<li>Link to <a href="https://transitous.org/sources/">https://transitous.org/sources/</a> in a visible place in order to properly attribute the data sources. Make sure to adhere to the conditions imposed by these sources. In particular, since Transitous uses OpenStreetMap data, you have to adhere to its <a href="https://www.openstreetmap.org/copyright">attribution guidelines</a>, too.</li>
 <li>You may <a href="https://github.com/public-transport/transitous/blob/b2d184b51cb4cf20fb48d0b76420ba57f4d3fce0/website/content/_index.html#L30">add your application to the Transitous website</a>.</li>
 </ul>
 


### PR DESCRIPTION
I think we should apply some changes to the usage policy:
* make the main requirement, open source, clearer
* do not make it a hard requirement to contact us before. I think we should want to make the barrier for eligible use cases as low as possible. Having to contact us first may appear intimidating to some and may result in them using other closed APIs where supposedly they don't have to ask someone :clown_face: This is probably the most controversial proposition, open to discussion :)
* make it a hard requirement to link to the sources page. I think this is very important. To my understanding, every client also has to at least attribute OSM separately. We should probably check if our own/existing apps do that.