### PR TITLE
fr: skip destineo feed mixing flights with bus journeys

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -5267,7 +5267,8 @@
             ],
             "x-data-gov-fr-res-id": 79818,
             "managed-by-script": true,
-            "skip": false,
+            "skip": true,
+            "skip-reason": "Feed contains flights from Nantes Atlantique airport mapped as bus journeys with unrealistic travel times. drop-agency-names did not fully filter them.",
             "x-data-gov-fr-res-title": "GTFS Destineo Pays de la Loire",
             "x-data-gov-fr-dataset-id": "632b2a8a8bf5b436bed4f8df"
         },


### PR DESCRIPTION
The destineo (Pays de la Loire) feed at https://www.data.gouv.fr/api/1/datasets/r/c0bd9ff1-97f9-43f8-aca4-8e80d7728324 maps flights departing Nantes Atlantique airport as scheduled bus journeys with travel times that don't match ground transport. The existing `drop-agency-names: ["Aéroport Nantes Atlantique"]` doesn't fully filter them - the example trip in #1646 still surfaces:

https://api.transitous.org/?tripId=20251028_14%3A00_fr-arrets-horaires-et-circuits-des-lignes-de-transports-en-commun-en-pays-de-la-loire-gtfs-destineo-reseaux-aom-aleop-1_AEROPORT_NANTES%3AVehicleJourney%3AV72237_PMO_20250902102000%3AA

This sets `skip: true` with a skip-reason, matching how other problematic French feeds are handled (e.g. the Aix-Marseille aggregation at line 5256). `drop-agency-names` is left in place so a future contributor can revisit a more targeted fix if the feed gets cleaned up upstream.

Closes #1646
