### PR TITLE
fix(gb): use HTTPS for FlixBus GTFS URL

### DIFF
--- a/feeds/gb.json
+++ b/feeds/gb.json
@@ -45,7 +45,7 @@
         {
             "name": "flixbus",
             "type": "http",
-            "url": "http://gtfs.gis.flix.tech/gtfs_generic_gb.zip",
+            "url": "https://gtfs.gis.flix.tech/gtfs_generic_gb.zip",
             "script": "generic-bus-to-coach.lua"
         },
         {


### PR DESCRIPTION
## Summary

The FlixBus GB GTFS source in `feeds/gb.json` uses an `http://` URL:

```
http://gtfs.gis.flix.tech/gtfs_generic_gb.zip
```

This redirects 301 to HTTPS. This PR updates it to use HTTPS directly, eliminating the unnecessary redirect and ensuring the connection is encrypted from the first request.

All other URLs in `gb.json` already use HTTPS.

## Test plan

- [x] Confirmed `https://gtfs.gis.flix.tech/gtfs_generic_gb.zip` returns HTTP 200