### PR TITLE
Make use of transitland entries if available for GBFS feeds

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -178,9 +178,8 @@
         },
         {
             "name": "DottFrankfurt",
-            "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/frankfurt/gbfs.json",
-            "spec": "gbfs"
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-dott~frankfurt~gbfs"
         },
         {
             "name": "Deer",
@@ -234,27 +233,23 @@
         },
         {
             "name": "NextbikeBerlin",
-            "type": "url",
-            "url": "https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_bn/gbfs.json",
-            "spec": "gbfs"
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-nextbike~berlin~gbfs"
         },
         {
             "name": "DottBerlin",
-            "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/berlin/gbfs.json",
-            "spec": "gbfs"
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-dott~berlin~gbfs"
         },
         {
             "name": "esel.ac",
-            "type": "url",
-            "url": "https://di.esel.ac/gbfs/gbfs.json",
-            "spec": "gbfs"
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-esel~ac~aachen~gbfs"
         },
         {
             "name": "DottRostock",
-            "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/rostock/gbfs.json",
-            "spec": "gbfs"
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-dott~rostock~gbfs"
         },
         {
             "name": "amarillo-bw",
@@ -279,9 +274,8 @@
         },
         {
             "name": "DottMunich",
-            "type": "url",
-            "url": "https://gbfs.api.ridedott.com/public/v2/munich/gbfs.json",
-            "spec": "gbfs"
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-dott~munich~gbfs"
         },
         {
             "name": "MyRadlMunich",

--- a/feeds/nz.json
+++ b/feeds/nz.json
@@ -34,9 +34,8 @@
         },
         {
             "name": "Flamingo-Christchurch",
-            "type": "url",
-            "spec": "gbfs",
-            "url": "https://data.rideflamingo.com/gbfs/3/christchurch/gbfs.json"
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-flamingo~christchurch~gbfs"
         },
         {
             "name": "Flamingo-Dunedin",


### PR DESCRIPTION
Where available, it makes sense to use the upstream feeds to benefit from fixes and updates at transit land and reduce the redundancy