### PR TITLE
allow querying all long distance stops globally

### DIFF
--- a/configs/motis/config.yml
+++ b/configs/motis/config.yml
@@ -45,7 +45,7 @@ limits:
   stoptimes_max_results: 16384
   plan_max_results: 256
   plan_max_search_window_minutes: 5760
-  stops_max_results: 2048
+  stops_max_results: 16384
   onetoall_max_results: 524288
   onetoall_max_travel_minutes: 2880
   routing_max_timeout_seconds: 90


### PR DESCRIPTION
preparation for stops view
still would only take ~200ms max at less then 1 MB response size