### PR TITLE
sk: zsr

### DIFF
--- a/feeds/sk.json
+++ b/feeds/sk.json
@@ -15,14 +15,13 @@
     ],
     "sources": [
         {
-            "name": "zssk",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-eo0-zssk",
-            "url-override": "https://jbb.ghsq.de/gtfs/sk-zssk.gtfs.zip",
+            "name": "zsr",
+            "type": "http",
+            "fix": true,
             "display-name-options": {
                 "copy-trip-names-matching": "((EC|Os|Zr|Ex|REX|RJX|IC|RRR|R|EN|NJ)) +\\d+ +.*"
             },
-            "fix": true
+            "url": "https://data.slovensko.sk/download?id=c5a63281-3c44-4dba-82c9-7b7ad603db5d"
         },
         {
             "name": "Bratislava",


### PR DESCRIPTION
replaces broken ZSSK (Železničná spoločnosť Slovenská) feed with ŽSR (Železnice Slovenskej Republiky) feed, including also other agencies such as RegioJet a.s.; Leo Express s.r.o.; Leo Express Slovensko s.r.o.; LTE Logistik a Transport Slovakia, s.r.o.; Trenčianska elektrická železnica, n.o.