### PR TITLE
Fix typo in spdx-identifier field

### DIFF
--- a/feeds/be.json
+++ b/feeds/be.json
@@ -29,7 +29,7 @@
                 }
             },
             "license": {
-                "spdx-idenfifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             }
         },
         {
@@ -42,7 +42,7 @@
                 }
             },
             "license": {
-                "spdx-idenfifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             }
         },
         {
@@ -55,7 +55,7 @@
             },
             "use-feed-proxy": true,
             "license": {
-                "spdx-idenfifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             }
         },
         {
@@ -68,7 +68,7 @@
             },
             "use-feed-proxy": true,
             "license": {
-                "spdx-idenfifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             }
         },
         {
@@ -88,7 +88,7 @@
                 }
             },
             "license": {
-                "spdx-idenfifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             }
         },
         {
@@ -101,7 +101,7 @@
             },
             "use-feed-proxy": true,
             "license": {
-                "spdx-idenfifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             }
         },
         {
@@ -114,7 +114,7 @@
             },
             "use-feed-proxy": true,
             "license": {
-                "spdx-idenfifier": "CC-BY-4.0"
+                "spdx-identifier": "CC-BY-4.0"
             }
         },
         {


### PR DESCRIPTION
Replace `spdx-idenfifier` by `spdx-identifier`

Also checked, be.json is the only file with this typo