### PR TITLE
Remove ignore_errors from motis config

### DIFF
--- a/configs/motis/config.yml
+++ b/configs/motis/config.yml
@@ -25,7 +25,6 @@ timetable:
   num_days: 365
   railviz: true
   with_shapes: true
-  ignore_errors: true
   adjust_footpaths: true
   merge_dupes_intra_src: true
   merge_dupes_inter_src: true


### PR DESCRIPTION
timetable.ignore_errors doesn't exist
it never worked properly and was removed long time ago