### PR TITLE
Update GTFS source URL for Île-de-France Mobilités

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -7269,14 +7269,14 @@
         {
             "name": "reseau-urbain-et-interurbain-dile-de-france-mobilites",
             "type": "http",
-            "url": "https://www.data.gouv.fr/api/1/datasets/r/413988ed-d340-467b-8be2-7b999fcd207a",
+            "url": "http://gtfsidfm.clarifygdps.com/gtfs",
             "fix": true,
             "license": {
-                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-et-interurbain-dile-de-france-mobilites",
+                "url": "https://github.com/Jouca/IDFM_GTFS-RT/blob/main/LICENSE",
                 "spdx-identifier": null
             },
             "x-data-gov-fr-res-id": 80921,
-            "managed-by-script": true,
+            "managed-by-script": false,
             "skip": false,
             "x-data-gov-fr-res-title": "Horaires au format GTFS",
             "x-data-gov-fr-dataset-id": "6449c52caeceb71273a42dd3"

--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -7276,8 +7276,8 @@
                 "spdx-identifier": null
             },
             "x-data-gov-fr-res-id": 80921,
-            "managed-by-script": false,
-            "skip": false,
+            "managed-by-script": true,
+            "skip": true,
             "x-data-gov-fr-res-title": "Horaires au format GTFS",
             "x-data-gov-fr-dataset-id": "6449c52caeceb71273a42dd3"
         },

--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -7269,16 +7269,27 @@
         {
             "name": "reseau-urbain-et-interurbain-dile-de-france-mobilites",
             "type": "http",
-            "url": "http://gtfsidfm.clarifygdps.com/gtfs",
+            "url": "https://www.data.gouv.fr/api/1/datasets/r/413988ed-d340-467b-8be2-7b999fcd207a",
             "fix": true,
             "license": {
-                "url": "https://github.com/Jouca/IDFM_GTFS-RT/blob/main/LICENSE",
+                "url": "https://transport.data.gouv.fr/datasets/reseau-urbain-et-interurbain-dile-de-france-mobilites",
                 "spdx-identifier": null
             },
             "x-data-gov-fr-res-id": 80921,
             "managed-by-script": true,
             "skip": true,
+            "skip-reason": "Replaced by postprocessed community feed",
             "x-data-gov-fr-res-title": "Horaires au format GTFS",
+            "x-data-gov-fr-dataset-id": "6449c52caeceb71273a42dd3"
+        },
+        {
+            "name": "reseau-urbain-et-interurbain-dile-de-france-mobilites",
+            "type": "http",
+            "url": "http://gtfsidfm.clarifygdps.com/gtfs",
+            "fix": true,
+            "license": {
+                "url": "https://github.com/Jouca/IDFM_GTFS-RT/blob/main/LICENSE"
+            },
             "x-data-gov-fr-dataset-id": "6449c52caeceb71273a42dd3"
         },
         {


### PR DESCRIPTION
This PR aims to propose a **new GTFS feed** (in addition to the GTFS-RT feed) of the Île-de-France Mobilités network to **include elements currently missing from the official GTFS that are essential** for the proposed GTFS-RT.

Here is what this new GTFS is expected to include in the future:
- Platforms (with real-time linked)
- Fares (still under development; may also be an extension for GTFS Fares V2)
- Pathways for elevators (including alerts with real-time data)

You can get the feed here: http://gtfsidfm.clarifygdps.com/gtfs