### PR TITLE
Add Tisseo subcontractors GTFSRT

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -216,7 +216,7 @@
         {
             "name": "tisseo-reseau-transport-urbain-toulousain",
             "type": "url",
-            "url": "https://gtfs.willbrooks.fr/trip_updates.json",
+            "url": "https://gtfs.willbrooks.fr/trip_updates.pb",
             "license": {
                 "url": "https://gtfs.willbrooks.fr/license.txt"
             },

--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -214,6 +214,15 @@
             "x-data-gov-fr-dataset-id": "56b0c2fba3a7294d39b88a86"
         },
         {
+            "name": "tisseo-reseau-transport-urbain-toulousain",
+            "type": "url",
+            "url": "https://gtfs.willbrooks.fr/trip_updates.json",
+            "license": {
+                "url": "https://gtfs.willbrooks.fr/license.txt"
+            },
+            "spec": "gtfs-rt"
+        },
+        {
             "name": "stations-velov-de-la-metropole-de-lyon-disponibilites-temps-reel",
             "type": "url",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/4cf2b946-9c2c-44a9-bbc7-4b5cb9e2c2fe",


### PR DESCRIPTION
Hello,

I created this feed to provide real-time data for subcontracted lines on the Tisséo network. These lines are not included in the main real-time feed for technical reasons, as the subcontracted operators use a different system.
This feed complements the existing one and does not duplicate any data from the main feed.

NB : there are many lines that should be added in the next days. I have to adapt for each operators. It shouldn't create any problems.