### PR TITLE
Fix the import of pt-Carris by applying gtfsclean fix

### DIFF
--- a/feeds/pt.json
+++ b/feeds/pt.json
@@ -32,7 +32,8 @@
             "mdb-id": "mdb-2929",
             "license": {
                 "spdx-identifier": "CC0-1.0"
-            }
+            },
+            "fix": true
         },
         {
             "name": "Metro-Lisboa",


### PR DESCRIPTION
Related issue: https://github.com/public-transport/transitous/issues/2109
The error seems to persist since a few weeks: https://mobilitydatabase.org/feeds/gtfs/mdb-2929

Resolves #2109 