### PR TITLE
Add Realtime to Kalisz, Ząbki, Powiat Miński, Sulejówek, Legnica & ŁKA Buses

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -1487,6 +1487,16 @@
             }
         },
         {
+            "name": "Sulejówek",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://api.zbiorkom.live/api6-open/czestochowa/gtfsRealtime/SULEJOWEK/tripUpdates",
+            "license": {
+                "spdx-identifier": "MIT"
+            },
+            "use-feed-proxy": true
+        },
+        {
             "name": "Powiat-Miński",
             "type": "http",
             "spec": "gtfs",
@@ -1494,6 +1504,16 @@
             "license": {
                 "spdx-identifier": "CC0-1.0"
             }
+        },
+        {
+            "name": "Powiat-Miński",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://api.zbiorkom.live/api6-open/warsaw/gtfsRealtime/MINSKI/tripUpdates",
+            "license": {
+                "spdx-identifier": "MIT"
+            },
+            "use-feed-proxy": true
         },
         {
             "name": "Pleszew",

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -548,8 +548,9 @@
             "spec": "gtfs",
             "url": "https://gtfs.kasznia.net/static/kalisz.zip",
             "license": {
-                "spdx-identifier": "CC-BY-4.0"
-            }
+                "spdx-identifier": "CC0-1.0"
+            },
+            "fix": true
         },
         {
             "name": "KLA-Kalisz",

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -534,6 +534,16 @@
             }
         },
         {
+            "name": "Łódzka-Kolej-Aglomeracyjna-bus",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": " https://cdn.zbiorkom.live/gtfs-rt/lodz-lka.pb",
+            "license": {
+                "spdx-identifier": "MIT"
+            },
+            "use-feed-proxy": true
+        },
+        {
             "name": "PKS-Kalisz",
             "type": "http",
             "spec": "gtfs",
@@ -1025,6 +1035,16 @@
             "license": {
                 "spdx-identifier": "MIT"
             }
+        },
+        {
+            "name": "Legnica",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://cdn.zbiorkom.live/gtfs-rt/legnica.pb",
+            "license": {
+                "spdx-identifier": "MIT"
+            },
+            "use-feed-proxy": true
         },
         {
             "name": "Grodziskie-Przewozy-Autobusowe",

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -546,9 +546,9 @@
             "name": "KLA-Kalisz",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://api.zbiorkom.live/api6-open/kalisz/gtfs/default",
+            "url": "https://gtfs.kasznia.net/static/kalisz.zip",
             "license": {
-                "spdx-identifier": "MIT"
+                "spdx-identifier": "CC-BY-4.0"
             }
         },
         {

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -546,11 +546,19 @@
             "name": "KLA-Kalisz",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://gtfs.kasznia.net/static/kalisz.zip",
+            "url": "https://api.zbiorkom.live/api6-open/kalisz/gtfs/default",
             "license": {
-                "spdx-identifier": "CC0-1.0"
-            },
-            "fix": true
+                "spdx-identifier": "MIT"
+            }
+        },
+        {
+            "name": "KLA-Kalisz",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://api.zbiorkom.live/api6-open/kalisz/gtfsRealtime/tripUpdates",
+            "license": {
+                "spdx-identifier": "MIT"
+            }
         },
         {
             "name": "Kalisz-LocalBuses",

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -558,7 +558,8 @@
             "url": "https://api.zbiorkom.live/api6-open/kalisz/gtfsRealtime/tripUpdates",
             "license": {
                 "spdx-identifier": "MIT"
-            }
+            },
+            "use-feed-proxy": true
         },
         {
             "name": "Kalisz-LocalBuses",

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -874,10 +874,20 @@
             "name": "Ząbki",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://kasmar00.github.io/gtfs-warsaw-custom/feeds/zabki/latest.zip",
+            "url": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/ZABKI",
             "license": {
-                "spdx-identifier": "CC-BY-4.0"
+                "spdx-identifier": "MIT"
             }
+        },
+        {
+            "name": "Mińsk-Mazowiecki",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://api.zbiorkom.live/api6-open/warsaw/gtfsRealtime/ZABKI/tripUpdates",
+            "license": {
+                "spdx-identifier": "MIT"
+            },
+            "use-feed-proxy": true
         },
         {
             "name": "Mińsk-Mazowiecki",


### PR DESCRIPTION
- Add RT for Kalisz
- Add RT for Ząbki and move static feed (it is now generated _live_ by zbiorkom, the previous one relied on manually updated csv files exported pdfs on the operators website)
- Add RT for Powiat Miński
- Add RT for Sulejówek
- Add RT for Legnica
- Add RT for ŁKA Buses