### PR TITLE
Add Thessaloniki (OSETH) bus network

### DIFF
--- a/feeds/gr.json
+++ b/feeds/gr.json
@@ -3,6 +3,10 @@
         {
             "name": "Lach Anonym",
             "github": "Lach-anonym"
+        },
+        {
+            "name": "Martin Langbecker",
+            "github": "MartinLangbecker"
         }
     ],
     "sources": [
@@ -22,6 +26,16 @@
             "url": "https://www.gitlab.com/Lach-anonym/athens-gtfs/-/jobs/artifacts/main/raw/gtfs-rail.zip?job=download-republish-gtfs",
             "license": {
                 "spdx-identifier": "CC-BY-SA-4.0"
+            },
+            "fix": true,
+            "extend-calendar": true
+        },
+        {
+            "name": "Thessaloniki-OSETH",
+            "type": "http",
+            "url": "https://github.com/MartinLangbecker/thessaloniki-gtfs-mirror/releases/latest/download/oseth_gtfs.zip",
+            "license": {
+                "url": "https://data.gov.gr/pages/terms-of-use"
             },
             "fix": true,
             "extend-calendar": true

--- a/feeds/gr.json
+++ b/feeds/gr.json
@@ -33,9 +33,10 @@
         {
             "name": "Thessaloniki-OSETH",
             "type": "http",
-            "url": "https://github.com/MartinLangbecker/thessaloniki-gtfs-mirror/releases/latest/download/oseth_gtfs.zip",
+            "url": "https://data.gov.gr/api/3/action/package_show?id=dedomena-astikon-sygkoinonion-p-e-thessalonikis",
+            "function": "data_gov_gr_latest_resource",
             "license": {
-                "url": "https://data.gov.gr/pages/terms-of-use"
+                "spdx-identifier": "CC-BY-4.0"
             },
             "fix": true,
             "extend-calendar": true

--- a/src/region_helpers.py
+++ b/src/region_helpers.py
@@ -288,3 +288,21 @@ def chile_dtp_downloader(source: HttpSource) -> HttpSource:
 
     source.url = max(all_gtfs_feeds)
     return source
+
+
+def data_gov_gr_latest_resource(source: HttpSource) -> HttpSource:
+    resources = requests.get(source.url).json()["result"]["resources"]
+
+    gtfs_resources = [
+        r for r in resources
+        if r.get("last_modified")
+        and r.get("format") == "ZIP"
+        and not r.get("downloadall_datapackage_hash")
+    ]
+
+    source.url = max(
+        gtfs_resources,
+        key=lambda r: datetime.fromisoformat(r["last_modified"])
+    )["url"]
+
+    return source


### PR DESCRIPTION
Adds the Thessaloniki bus network (OSETH — Οργανισμός Συγκοινωνιακού Έργου Θεσσαλονίκης), covering ~381 routes and ~3,700 stops in the Thessaloniki regional unit.

Source: [data.gov.gr](https://data.gov.gr/dataset/dedomena-astikon-sygkoinonion-p-e-thessalonikis)

Mirror: [thessaloniki-gtfs-mirror](https://github.com/MartinLangbecker/thessaloniki-gtfs-mirror) (weekly GitHub Actions workflow, publishes latest GTFS at a stable URL)

Note on license: The OSETH dataset on data.gov.gr does not declare an explicit SPDX license in its metadata. The portal's Terms of Use (https://data.gov.gr/pages/terms-of-use) permit free reuse (including commercial) with no specific license type assigned to this dataset. I've linked the terms page as the license URL.