### PR TITLE
Fix vahrplan icon

### DIFF
--- a/website/static/images/apps/vahrplan.svg
+++ b/website/static/images/apps/vahrplan.svg
@@ -1,10 +1,13 @@
 <svg width='512px' height='512px' viewBox="-3 -3 32 32" xmlns='http://www.w3.org/2000/svg'>
     <style>
+        svg {
+            background: oklch(0.99 0.002 170);
+        }
         .regular-lines {
-            stroke: light-dark(oklch(0.25 0.02 170), oklch(0.95 0.002 170));
+            stroke: oklch(0.25 0.02 170);
         }
         .accent-lines {
-            stroke: light-dark(oklch(0.5 0.09 170), oklch(0.8 0.1 170));
+            stroke: oklch(0.5 0.09 170);
         }
     </style>
     <mask id="line-mask">

--- a/website/static/images/apps/vahrplan.svg
+++ b/website/static/images/apps/vahrplan.svg
@@ -1,4 +1,4 @@
-<svg width='512px' height='512px' viewBox="-3 -3 32 32" xmlns='http://www.w3.org/2000/svg'>
+<svg width='512px' height='512px' viewBox="-7 -7 40 40" xmlns='http://www.w3.org/2000/svg'>
     <style>
         svg {
             background: oklch(0.99 0.002 170);


### PR DESCRIPTION
Turns out using `light-dark()` in an svg that is not inlined is a bad idea...

Sorry about the noise