### PR TITLE
si.json: additional city transport feeds

### DIFF
--- a/feeds/si.json
+++ b/feeds/si.json
@@ -191,19 +191,19 @@
             "url": "https://gbfs.derp.si/gbfs/scbikes_kulu/gbfs.json"
         },
         {
-            "name": "scbikes_gonm",
+            "name": "scbikes-gonm",
             "type": "url",
             "spec": "gbfs",
             "url": "https://gbfs.derp.si/gbfs/scbikes_gonm/gbfs.json"
         },
         {
-            "name": "scbikes_biciklanc",
+            "name": "scbikes-biciklanc",
             "type": "url",
             "spec": "gbfs",
             "url": "https://gbfs.derp.si/gbfs/scbikes_biciklanc/gbfs.json"
         },
         {
-            "name": "scbikes_pokolo",
+            "name": "scbikes-pokolo",
             "type": "url",
             "spec": "gbfs",
             "url": "https://gbfs.derp.si/gbfs/scbikes_pokolo/gbfs.json"
@@ -215,7 +215,7 @@
             "url": "https://gbfs.derp.si/gbfs/jcdecaux_maribor/gbfs.json"
         },
         {
-            "name": "jcdecaux_ljubljana",
+            "name": "jcdecaux-ljubljana",
             "type": "url",
             "spec": "gbfs",
             "url": "https://gbfs.derp.si/gbfs/jcdecaux_ljubljana/gbfs.json"
@@ -227,19 +227,19 @@
             "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_cc/gbfs.json"
         },
         {
-            "name": "nextbike_cd",
+            "name": "nextbike-cd",
             "type": "url",
             "spec": "gbfs",
             "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_cd/gbfs.json"
         },
         {
-            "name": "nextbike_ce",
+            "name": "nextbike-ce",
             "type": "url",
             "spec": "gbfs",
             "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_ce/gbfs.json"
         },
         {
-            "name": "nextbike_cf",
+            "name": "nextbike-cf",
             "type": "url",
             "spec": "gbfs",
             "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_cf/gbfs.json"
@@ -275,13 +275,13 @@
             "url": "https://gbfs.derp.si/gbfs/kvik/gbfs.json"
         },
         {
-            "name": "greengo_544",
+            "name": "greengo-544",
             "type": "url",
             "spec": "gbfs",
             "url": "https://greengo.rideatom.com/gbfs/v2_2/en/gbfs?id=544"
         },
         {
-            "name": "greengo_1451",
+            "name": "greengo-1451",
             "type": "url",
             "spec": "gbfs",
             "url": "https://greengo.rideatom.com/gbfs/v2_2/en/gbfs?id=1451"

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -48,16 +48,6 @@
             "url": "https://rt.gtfs.derp.si/sources/lpp/all"
         },
         {
-            "name": "jesenice",
-            "type": "http",
-            "url": "https://b2b.nap.si/data/b2b.gtfs.jesenice",
-            "url-override": "https://jbb.ghsq.de/gtfs/si-jesenice.gtfs.zip",
-            "license": {
-                "spdx-identifier": "CC-BY-SA-4.0",
-                "url": "https://nap.si/en/datasets_details?id=36cf8092-f234-4796-9cc9-d63830003ff9"
-            }
-        },
-        {
             "name": "kranjska-gora",
             "type": "http",
             "url": "https://b2b.nap.si/data/b2b.gtfs.kranjska-gora",
@@ -65,26 +55,6 @@
             "license": {
                 "spdx-identifier": "CC-BY-SA-4.0",
                 "url": "https://nap.si/en/datasets_details?id=b1f8aacc-e144-490c-a1d7-d0b07c2e8ac3"
-            }
-        },
-        {
-            "name": "nova-gorica",
-            "type": "http",
-            "url": "https://b2b.nap.si/data/b2b.gtfs.nova-gorica",
-            "url-override": "https://jbb.ghsq.de/gtfs/si-nova-gorica.gtfs.zip",
-            "license": {
-                "spdx-identifier": "CC-BY-SA-4.0",
-                "url": "https://nap.si/en/datasets_details?id=c41d24aa-3609-4beb-818c-22980f1fa1b8"
-            }
-        },
-        {
-            "name": "brežice",
-            "type": "http",
-            "url": "https://b2b.nap.si/data/b2b.gtfs.brezice",
-            "url-override": "https://jbb.ghsq.de/gtfs/si-bre%C5%BEice.gtfs.zip",
-            "license": {
-                "spdx-identifier": "CC-BY-SA-4.0",
-                "url": "https://nap.si/en/datasets_details?id=7110f4c4-3581-4b91-a826-6843ee4d7201"
             }
         },
         {

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -143,7 +143,7 @@
             "url": "http://gtfs.derp.si/ptuj_gtfs.zip"
         },
         {
-            "name": "avant2go_si",
+            "name": "avant2go-si",
             "type": "url",
             "spec": "gbfs",
             "url": "https://gbfs.derp.si/gbfs/avant2go_si/gbfs.json"

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -92,7 +92,7 @@
             "url": "https://rt.gtfs.derp.si/sources/kranj/trip_updates"
         },
         {
-            "name": "murska_sobota",
+            "name": "murska-sobota",
             "type": "http",
             "url": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/extract_moms_gtfs/latest/moms_gtfs.zip"
         },

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -293,7 +293,7 @@
             "url": "https://gbfs.derp.si/gbfs/micikel/gbfs.json"
         },
         {
-            "name": "bolt_359",
+            "name": "bolt-359",
             "type": "url",
             "spec": "gbfs",
             "url": "https://gbfs.derp.si/bolt_proxy/2/359/gbfs"

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -120,7 +120,8 @@
         {
             "name": "brežice",
             "type": "http",
-            "url": "http://gtfs.derp.si/brezice_manual.zip"
+            "url": "http://gtfs.derp.si/brezice_manual.zip",
+            "fix": true
         },
         {
             "name": "postojna",
@@ -161,31 +162,31 @@
             "url": "https://gbfs.derp.si/gbfs/scbikes_posbikes/gbfs.json"
         },
         {
-            "name": "scbikes_kras",
+            "name": "scbikes-kras",
             "type": "url",
             "spec": "gbfs",
             "url": "https://gbfs.derp.si/gbfs/scbikes_kras/gbfs.json"
         },
         {
-            "name": "scbikes_pors",
+            "name": "scbikes-pors",
             "type": "url",
             "spec": "gbfs",
             "url": "https://gbfs.derp.si/gbfs/scbikes_pors/gbfs.json"
         },
         {
-            "name": "scbikes_gbike",
+            "name": "scbikes-gbike",
             "type": "url",
             "spec": "gbfs",
             "url": "https://gbfs.derp.si/gbfs/scbikes_gbike/gbfs.json"
         },
         {
-            "name": "scbikes_sobota",
+            "name": "scbikes-sobota",
             "type": "url",
             "spec": "gbfs",
             "url": "https://gbfs.derp.si/gbfs/scbikes_sobota/gbfs.json"
         },
         {
-            "name": "scbikes_kulu",
+            "name": "scbikes-kulu",
             "type": "url",
             "spec": "gbfs",
             "url": "https://gbfs.derp.si/gbfs/scbikes_kulu/gbfs.json"
@@ -221,7 +222,7 @@
             "url": "https://gbfs.derp.si/gbfs/jcdecaux_ljubljana/gbfs.json"
         },
         {
-            "name": "nextbike_cc",
+            "name": "nextbike-cc",
             "type": "url",
             "spec": "gbfs",
             "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_cc/gbfs.json"
@@ -245,13 +246,13 @@
             "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_cf/gbfs.json"
         },
         {
-            "name": "nextbike_ck",
+            "name": "nextbike-ck",
             "type": "url",
             "spec": "gbfs",
             "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_ck/gbfs.json"
         },
         {
-            "name": "nextbike_cl",
+            "name": "nextbike-cl",
             "type": "url",
             "spec": "gbfs",
             "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_cl/gbfs.json"
@@ -263,7 +264,7 @@
             "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_cn/gbfs.json"
         },
         {
-            "name": "nextbike_cx",
+            "name": "nextbike-cx",
             "type": "url",
             "spec": "gbfs",
             "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_cx/gbfs.json"

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -133,7 +133,7 @@
             "url": "http://gtfs.derp.si/koper_gtfs.zip"
         },
         {
-            "name": "nova_gorica",
+            "name": "nova-gorica",
             "type": "http",
             "url": "http://gtfs.derp.si/mong_gtfs.zip"
         },

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -209,7 +209,7 @@
             "url": "https://gbfs.derp.si/gbfs/scbikes_pokolo/gbfs.json"
         },
         {
-            "name": "jcdecaux_maribor",
+            "name": "jcdecaux-maribor",
             "type": "url",
             "spec": "gbfs",
             "url": "https://gbfs.derp.si/gbfs/jcdecaux_maribor/gbfs.json"

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -28,6 +28,12 @@
             "url": "https://rt.gtfs.derp.si/sources/ijpp/trip_updates"
         },
         {
+            "name": "nap",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://rt.gtfs.derp.si/sources/ijpp/service_alerts"
+        },
+        {
             "name": "lpp",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u24q-ljubljanskipotniškipromet",
@@ -103,6 +109,68 @@
             "type": "url",
             "spec": "gtfs-rt",
             "url": "https://rt.gtfs.derp.si/sources/celje/trip_updates"
+        },
+        {
+            "name": "kranj",
+            "type": "http",
+            "url": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/kranj/latest/kranj_gtfs.zip"
+        },
+        {
+            "name": "kranj",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://rt.gtfs.derp.si/sources/kranj/trip_updates"
+        },
+        {
+            "name": "murska_sobota",
+            "type": "http",
+            "url": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/extract_moms_gtfs/latest/moms_gtfs.zip"
+        },
+        {
+            "name": "murska_sobota",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://rt.gtfs.derp.si/sources/moms/trip_updates"
+        },
+        {
+            "name": "sevnica",
+            "type": "http",
+            "url": "http://gtfs.derp.si/sevnica_manual.zip"
+        },
+        {
+            "name": "novo_mesto",
+            "type": "http",
+            "url": "http://gtfs.derp.si/monm_manual.zip"
+        },
+        {
+            "name": "velenje",
+            "type": "http",
+            "url": "http://gtfs.derp.si/velenje_manual.zip"
+        },
+        {
+            "name": "brežice",
+            "type": "http",
+            "url": "http://gtfs.derp.si/brezice_manual.zip"
+        },
+        {
+            "name": "postojna",
+            "type": "http",
+            "url": "http://gtfs.derp.si/postojna_gtfs.zip"
+        },
+        {
+            "name": "koper",
+            "type": "http",
+            "url": "http://gtfs.derp.si/koper_gtfs.zip"
+        },
+        {
+            "name": "nova_gorica",
+            "type": "http",
+            "url": "http://gtfs.derp.si/mong_gtfs.zip"
+        },
+        {
+            "name": "ptuj",
+            "type": "http",
+            "url": "http://gtfs.derp.si/ptuj_gtfs.zip"
         }
     ]
 }

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -179,12 +179,6 @@
             "url": "https://gbfs.derp.si/gbfs/avant2go_si/gbfs.json"
         },
         {
-            "name": "avant2go_hr",
-            "type": "url",
-            "spec": "gbfs",
-            "url": "https://gbfs.derp.si/gbfs/avant2go_hr/gbfs.json"
-        },
-        {
             "name": "sharengo",
             "type": "url",
             "spec": "gbfs",

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -97,7 +97,7 @@
             "url": "https://gitlab.com/api/v4/projects/derp-si%2Fgtfs-generators/packages/generic/extract_moms_gtfs/latest/moms_gtfs.zip"
         },
         {
-            "name": "murska_sobota",
+            "name": "murska-sobota",
             "type": "url",
             "spec": "gtfs-rt",
             "url": "https://rt.gtfs.derp.si/sources/moms/trip_updates"

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -257,7 +257,7 @@
             "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_cl/gbfs.json"
         },
         {
-            "name": "nextbike_cn",
+            "name": "nextbike-cn",
             "type": "url",
             "spec": "gbfs",
             "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_cn/gbfs.json"

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -155,7 +155,7 @@
             "url": "https://gbfs.derp.si/gbfs/sharengo/gbfs.json"
         },
         {
-            "name": "scbikes_posbikes",
+            "name": "scbikes-posbikes",
             "type": "url",
             "spec": "gbfs",
             "url": "https://gbfs.derp.si/gbfs/scbikes_posbikes/gbfs.json"

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -108,7 +108,7 @@
             "url": "http://gtfs.derp.si/sevnica_manual.zip"
         },
         {
-            "name": "novo_mesto",
+            "name": "novo-mesto",
             "type": "http",
             "url": "http://gtfs.derp.si/monm_manual.zip"
         },

--- a/feeds/si.json
+++ b/feeds/si.json
@@ -171,6 +171,168 @@
             "name": "ptuj",
             "type": "http",
             "url": "http://gtfs.derp.si/ptuj_gtfs.zip"
+        },
+        {
+            "name": "avant2go_si",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/gbfs/avant2go_si/gbfs.json"
+        },
+        {
+            "name": "avant2go_hr",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/gbfs/avant2go_hr/gbfs.json"
+        },
+        {
+            "name": "sharengo",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/gbfs/sharengo/gbfs.json"
+        },
+        {
+            "name": "scbikes_posbikes",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/gbfs/scbikes_posbikes/gbfs.json"
+        },
+        {
+            "name": "scbikes_kras",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/gbfs/scbikes_kras/gbfs.json"
+        },
+        {
+            "name": "scbikes_pors",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/gbfs/scbikes_pors/gbfs.json"
+        },
+        {
+            "name": "scbikes_gbike",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/gbfs/scbikes_gbike/gbfs.json"
+        },
+        {
+            "name": "scbikes_sobota",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/gbfs/scbikes_sobota/gbfs.json"
+        },
+        {
+            "name": "scbikes_kulu",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/gbfs/scbikes_kulu/gbfs.json"
+        },
+        {
+            "name": "scbikes_gonm",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/gbfs/scbikes_gonm/gbfs.json"
+        },
+        {
+            "name": "scbikes_biciklanc",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/gbfs/scbikes_biciklanc/gbfs.json"
+        },
+        {
+            "name": "scbikes_pokolo",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/gbfs/scbikes_pokolo/gbfs.json"
+        },
+        {
+            "name": "jcdecaux_maribor",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/gbfs/jcdecaux_maribor/gbfs.json"
+        },
+        {
+            "name": "jcdecaux_ljubljana",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/gbfs/jcdecaux_ljubljana/gbfs.json"
+        },
+        {
+            "name": "nextbike_cc",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_cc/gbfs.json"
+        },
+        {
+            "name": "nextbike_cd",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_cd/gbfs.json"
+        },
+        {
+            "name": "nextbike_ce",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_ce/gbfs.json"
+        },
+        {
+            "name": "nextbike_cf",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_cf/gbfs.json"
+        },
+        {
+            "name": "nextbike_ck",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_ck/gbfs.json"
+        },
+        {
+            "name": "nextbike_cl",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_cl/gbfs.json"
+        },
+        {
+            "name": "nextbike_cn",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_cn/gbfs.json"
+        },
+        {
+            "name": "nextbike_cx",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://api.nextbike.net/maps/gbfs/v2/nextbike_cx/gbfs.json"
+        },
+        {
+            "name": "kvik",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/gbfs/kvik/gbfs.json"
+        },
+        {
+            "name": "greengo_544",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://greengo.rideatom.com/gbfs/v2_2/en/gbfs?id=544"
+        },
+        {
+            "name": "greengo_1451",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://greengo.rideatom.com/gbfs/v2_2/en/gbfs?id=1451"
+        },
+        {
+            "name": "micikel",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/gbfs/micikel/gbfs.json"
+        },
+        {
+            "name": "bolt_359",
+            "type": "url",
+            "spec": "gbfs",
+            "url": "https://gbfs.derp.si/bolt_proxy/2/359/gbfs"
         }
     ]
 }


### PR DESCRIPTION
Brings up Slovenia to (almost) complete city transport coverage. Also adds GBFS feeds for Slovenia.