### PR TITLE
Fix Kolej Pleszewska

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -1404,8 +1404,7 @@
             "url": "https://github.com/pawlinski07/pawlinski-gtfs/raw/refs/heads/main/KolejPleszewska.zip",
             "license": {
                 "spdx-identifier": "CC-BY-4.0"
-            },
-            "script": "pl-Koleje-Wielkopolskie.lua"
+            }
         },
         {
             "name": "Chełmski-Rower",


### PR DESCRIPTION
#2199 removed script `pl-Koleje-Wielkopolskie.lua` which happened to be used by `Kolej-Pleszewska` and broke import (https://routing-import.spline.de/repos/1/pipeline/1891/4). I'm removing the usage of this script, as it only set the mode to `REGIONAL_RAIL`, which is no longer necessary (as it is now the default for imported trains).