### PR TITLE
Update Sharing entries for Germany

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -172,11 +172,6 @@
             "transitland-atlas-id": "f-lime~frankfurt~gbfs"
         },
         {
-            "name": "NextbikeFrankfurt",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-nextbike~frankfurt~gbfs"
-        },
-        {
             "name": "DottFrankfurt",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-dott~frankfurt~gbfs"
@@ -184,7 +179,14 @@
         {
             "name": "Deer",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-deer~germany~gbfs"
+            "transitland-atlas-id": "f-deer~germany~gbfs",
+            "skip": true,
+            "skip-reason": "Unavailable since Deer migrated to a new system"
+        },
+        {
+            "name": "Mikar",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-mikar~germany~gbfs"
         },
         {
             "name": "StadtmobilStuttgart",
@@ -220,6 +222,82 @@
             "name": "TeilAutoSchwäbischHall",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-teilauto~schwäbisch~hall~gbfs"
+        },
+        {
+            "name": "CarSharingRenningen",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-carsharing~renningen~gbfs"
+        },
+        {
+            "name": "DieGrüneFlotte",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-die~grüne~flotte~freiburg~im~breisgau~gbfs"
+        },
+        {
+            "name": "swu2go",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-swu2go~carsharing~ulm~gbfs",
+            "url-override": "https://api.mobidata-bw.de/sharing/gbfs/v2/swu2go/gbfs"
+        },
+        {
+            "name": "Conficars",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-conficars~ulm~gbfs"
+        },
+        {
+            "name": "StadtwerkTauberfranken",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-stadtwerk~tauberfranken~germany~gbfs"
+        },
+        {
+            "name": "Flinkster",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-flinkster~germany~gbfs"
+        },
+        {
+            "name": "OberSchwabenMobil",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-oberschwabenmobil~carsharing~halle~saale~~gbfs"
+        },
+        {
+            "name": "FordCarsharingAutohausBaur",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ford~carsharing~autohaus~baur~germany~gbfs"
+        },
+        {
+            "name": "FordCarharingAutohausKauderer",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ford~carsharing~autohaus~kauderer~eislingen~gbfs"
+        },
+        {
+            "name": "EinfachUnterwegs",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-einfach~unterwegs~germany~gbfs"
+        },
+        {
+            "name": "Seefahrer",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-seefahrer~e~carsharing~radolfzell~gbfs"
+        },
+        {
+            "name": "StadtwerkeWertheim",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-carsharing~in~wertheim~gbfs"
+        },
+        {
+            "name": "Hertlein,",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-hertlein~carsharing~weikersheim~gbfs"
+        },
+        {
+            "name": "LaRaToGo",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-lara~to~go~waiblingen~gbfs"
+        },
+        {
+            "name": "Car-ship",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-car~ship~constance~gbfs"
         },
         {
             "name": "MOBIBikeDresden",


### PR DESCRIPTION
- added new Carsharing feeds from Baden-Württemberg
- Remove Nextbike Frankfurt as the feed is dead and Nextbike stopped their offer in Frankfurt at 01.04.2026
- skip deer feed, as the feed is not available, due to a system migration. There are plans to reintroduce it.
- For swu2go the original feed was unavailable when I tested the changes locally. Therefore, the url-override