### PR TITLE
Fix Malaysian feed and add extend-calendar to the docs

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -305,6 +305,7 @@ Option Name            | Description
 `script`               | A Lua script applied by MOTIS to GTFS data during import, see [the MOTIS documentation](https://github.com/motis-project/motis/blob/master/docs/scripting.md) for details.
 `use-gtfsclean`        | Preprocess GTFS feeds with `gtfsclean`, default is `true`.
 `enable-crowd-sourced-realtime` | Whether users should be able to submit gps positions for trips from this source.
+`extend-calendar`      | Extend the calendar beyond the specified end date, although the feed is expired, default is `false`.
 
 #### License Options
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -305,7 +305,7 @@ Option Name            | Description
 `script`               | A Lua script applied by MOTIS to GTFS data during import, see [the MOTIS documentation](https://github.com/motis-project/motis/blob/master/docs/scripting.md) for details.
 `use-gtfsclean`        | Preprocess GTFS feeds with `gtfsclean`, default is `true`.
 `enable-crowd-sourced-realtime` | Whether users should be able to submit gps positions for trips from this source.
-`extend-calendar`      | Extend the calendar beyond the specified end date, although the feed is expired, default is `false`.
+`extend-calendar`      | Extend the calendar beyond the specified end date, although the feed is expired, default is `false`. Only works for feeds that use `calendar.txt`.
 
 #### License Options
 

--- a/feeds/my.json
+++ b/feeds/my.json
@@ -35,7 +35,8 @@
             "name": "ktmb",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-ktmb",
-            "fix": true
+            "fix": true,
+            "extend-calendar": true
         },
         {
             "name": "ktmb",


### PR DESCRIPTION
The KTMB feed from Malaysia had the issue that the feed was only valid till today at midnight, but gets regular updates (as seen here: https://www.transit.land/feeds/f-ktmb) This leads to the feed recognized as expired. To fix it, the extend-calendar option seems sufficient. As this was not yet available in the docs, I added a row in the table as well.
Resolves #1025 