### PR TITLE
add feed for Southland

### DIFF
--- a/feeds/nz-stl.json
+++ b/feeds/nz-stl.json
@@ -1,0 +1,20 @@
+{
+    "maintainers": [
+        {
+            "name": "Thomas Dickson",
+            "github": "Hoverth"
+        },
+        {
+            "name": "applecuckoo",
+            "github": "applecuckoo"
+        }
+    ],
+    "sources": [
+        {
+            "name": "BusSmart",
+            "type": "http",
+            "spec": "gtfs",
+            "url": "https://codeberg.org/applecuckoo/gtfs-mirror/raw/branch/main/icc-nz.zip"
+        }
+    ]
+}


### PR DESCRIPTION
surprisingly this leaves only one major area in NZ (Gisborne) without its GTFS feed in Transitous