### PR TITLE
Drop SNCB from DE-DELFI feed

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -34,7 +34,8 @@
                 "FlixBus-de",
                 "EUROSTAR",
                 "Bremer Straßenbahn AG",
-                "Verkehrsgemeinschaft Osnabrück"
+                "Verkehrsgemeinschaft Osnabrück",
+                "SNCB"
             ],
             "http-options": {
                 "fetch-interval-days": 2


### PR DESCRIPTION
As far as I can tell, the SNCB agency in DELFI only contains the S41 train between Aachen and Liège, which is already contained in the SNCB feed from Belgium (with generally better realtime data).