### PR TITLE
Show number for Belgian EC trains

### DIFF
--- a/scripts/be-sncb.lua
+++ b/scripts/be-sncb.lua
@@ -26,7 +26,8 @@ end
 local use_trip_short_name = {
     ["IC"] = true,
     ["L"] = true,
-    ["P"] = true
+    ["P"] = true,
+    ["EC"] = true,
 }
 
 function process_trip(trip)


### PR DESCRIPTION
This is in line with the IC, P and L trains, as the EC trains are operated by SNCB/NMBS as well.