### PR TITLE
GB: remove fares for the time being

### DIFF
--- a/feeds/gb.json
+++ b/feeds/gb.json
@@ -21,7 +21,8 @@
             "drop-agency-names": [
                 "FlixBus"
             ],
-            "script": "gb-great-britain.lua"
+            "script": "gb-great-britain.lua",
+            "keep-additional-fields": false
         },
         {
             "name": "great-britain",


### PR DESCRIPTION
The fares are humongous and are causing extremely slow queries right now in GB. I think disabling `keep-additional-fields` should remove the fare files without causing any other harm. Since the GB feed seems to be updated daily, this should be applied directly with the next import.

Not tested.