### PR TITLE
Actually use script in NL feed

### DIFF
--- a/feeds/nl.json
+++ b/feeds/nl.json
@@ -18,7 +18,8 @@
             "license": {
                 "spdx-identifier": "CC0-1.0",
                 "url": "https://gtfs.openov.nl/LICENSE.TXT"
-            }
+            },
+            "script": "nl-OpenOV.lua"
         },
         {
             "name": "OpenOV",


### PR DESCRIPTION
When #1864 was reverted, that included removing the `script` part from the json file. When I reintroduced the script in #2267, I forgot to also reference the `script`. This fixes that.