### PR TITLE
Initial GBFS attribution

### DIFF
--- a/src/generate-attribution.py
+++ b/src/generate-attribution.py
@@ -169,6 +169,42 @@ def add_rt_attribution(attribution: dict, source: UrlSource) -> None:
 
     attribution["rt"].append(rt_attribution)
 
+def gbfs_source_attribution(source: UrlSource, source_id: str, region_data: dict):
+    attribution = region_data
+
+    if source.license.spdx_identifier:
+        attribution["spdx_license_identifier"] = \
+            source.license.spdx_identifier
+    if source.license.url:
+        attribution["license_url"] = source.license.url
+    if source.license.attribution_text:
+        attribution["attribution_text"] = source.license.attribution_text
+
+    attribution["operators"] = []
+    attribution["source"] = source.url
+
+    human_name: str = (
+        source_id.split("_")[1].replace("-", " ")
+    )
+    human_name = " ".join(
+        map(lambda w: w[0].upper() + w[1:] if len(w) > 0 else w, human_name.split(" "))
+    )
+    attribution["human_name"] = human_name
+
+    if source.license.publisher:
+        attribution["publisher"] = {}
+        attribution["publisher"]["name"] = source.license.publisher
+        attribution["publisher"]["url"] = source.license.publisher_url
+
+    if (
+            "operators" in attribution
+            and len(attribution["operators"]) == 1
+            and len(attribution["operators"][0]) > 1
+    ):
+        attribution["human_name"] = attribution["operators"][0]
+
+    return attribution
+
 
 def get_region_data(code: str) -> dict:
     code = code.upper()
@@ -234,12 +270,19 @@ if __name__ == "__main__":
 
             for source in resolved_sources:
                 match source:
-                    case UrlSource() if source.spec == "gtfs-rt":
-                        if source_id not in attributions:
-                            print(f"Warning: Stray gtfs-rt source for {source_id} without a (locally available) static timetable")
-                            continue
-                        else:
-                            add_rt_attribution(attributions[source_id], source)
+                    case UrlSource():
+                        if source.spec == "gtfs-rt":
+                            if source_id not in attributions:
+                                print(f"Warning: Stray gtfs-rt source for {source_id} without a (locally available) static timetable")
+                                continue
+                            else:
+                                add_rt_attribution(attributions[source_id], source)
+                        elif source.spec == "gbfs":
+                            gbfs_attribution = gbfs_source_attribution(source, source_id, region_data.copy())
+                            if not http_attribution:
+                                continue
+                            if source_id not in attributions:
+                                attributions[source_id] = gbfs_attribution
                     case HttpSource():
                         http_attribution = http_source_attribution(source, source_id, region_data.copy())
                         if not http_attribution:

--- a/src/generate-attribution.py
+++ b/src/generate-attribution.py
@@ -279,7 +279,7 @@ if __name__ == "__main__":
                                 add_rt_attribution(attributions[source_id], source)
                         elif source.spec == "gbfs":
                             gbfs_attribution = gbfs_source_attribution(source, source_id, region_data.copy())
-                            if not http_attribution:
+                            if not gbfs_attribution:
                                 continue
                             if source_id not in attributions:
                                 attributions[source_id] = gbfs_attribution

--- a/website/layouts/shortcodes/source-table.html
+++ b/website/layouts/shortcodes/source-table.html
@@ -110,8 +110,10 @@ summary h3 {
     </p>
   {{ end }}
 
+  {{ if $source.filename }}
   <a class="btn btn-outline-secondary" href="{{ $source.source }}">Original File</a>
   <a class="btn btn-outline-secondary" href="https://api.transitous.org/gtfs/{{ $source.filename }}">Processed File</a>
+  {{ end }}
 
   {{ if or $source.rt }}
     {{ range $rt_source := $source.rt }}


### PR DESCRIPTION
This provides initial listings for the GBFS feeds in the attribution page. What we currently lack, is the licensing information, as  this is not provided by transitland-atlas.

As discussed in #1060 we could retrieve the information from the feed itself, but I'm not sure whether it makes sense to do these requests in the generate-attribution.py script, as we would redo this every time the attribution is updated. Ideally the license would be provided in the mobilitydatabase or transitland-atlas, but afaik, this is currently not the case. Therefore we could add in on our own to the feeds, but this might be double effort, as Mobilitydatabase already have the license available, but not in the CSV export we are currently using.

Also should we merge the current state to improve the situation or first fix the licensing issue (which lead to over a year of missing attribution at all)?

Any comments on how to proceed appreciated :)

Would resolve #2274 