### PR TITLE
naive conn limit

### DIFF
--- a/ansible/roles/nginx/files/nginx.conf
+++ b/ansible/roles/nginx/files/nginx.conf
@@ -68,6 +68,7 @@ http {
 
 	# Limit for routing requests
 	limit_req_zone $binary_remote_addr zone=api_plan:10m rate=20r/m;
+	limit_conn_zone $binary_remote_addr zone=api_plan_conn:10m;
 
 	# Limit for harmless APIs
 	limit_req_zone $binary_remote_addr zone=api_harmless:10m rate=1000r/m;
@@ -76,6 +77,7 @@ http {
 	limit_req_zone $binary_remote_addr zone=api:10m rate=100r/m;
 
 	limit_req_status 429;
+	limit_conn_status 429;
 
 	proxy_next_upstream error timeout; # needed for no-downtime during MOTIS restart, hopefully doesn't pass segfaults
 	proxy_next_upstream_tries 2; # try the potentially dangerous request at most on one other upstream

--- a/ansible/roles/nginx/templates/transitous.conf.j2
+++ b/ansible/roles/nginx/templates/transitous.conf.j2
@@ -86,9 +86,9 @@ server {
         limit_req zone=api_harmless burst=200 delay=50;
 
         proxy_connect_timeout       2s;
-        proxy_send_timeout          60;
-        proxy_read_timeout          60;
-        send_timeout                60;
+        proxy_send_timeout          10s;
+        proxy_read_timeout          10s;
+        send_timeout                60s;
 
         proxy_cache            motis;
         proxy_cache_valid      200 302 1d;
@@ -134,6 +134,7 @@ server {
         proxy_pass http://{{ item.vhost }}-backend$uri?$args;
 
         limit_req zone=api_plan burst=20 delay=10;
+        limit_conn api_plan_conn 10;
 
         proxy_connect_timeout       2s;
         proxy_send_timeout          60;
@@ -148,9 +149,9 @@ server {
         limit_req zone=api_harmless burst=150 delay=20;
 
         proxy_connect_timeout       2s;
-        proxy_send_timeout          60;
-        proxy_read_timeout          120;
-        send_timeout                60;
+        proxy_send_timeout          10s;
+        proxy_read_timeout          10s;
+        send_timeout                60s;
     }
 
     # other endpoints


### PR DESCRIPTION
evolving towards 
* penalizing 10 1s requests roughly the same as 1 10s request
* penalizing concurrent requests and not so much multiple sequential batch requests
* don't encouraging distributed client-side requests over server-side requests for an app
