### PR TITLE
bg: Use official BDZ feeds

### DIFF
--- a/feeds/bg.json
+++ b/feeds/bg.json
@@ -81,13 +81,16 @@
         {
             "name": "bdz",
             "type": "http",
-            "url": "https://jbb.ghsq.de/gtfs/bg-bdz.gtfs.zip"
+            "url": "https://gtfs.livetransport.eu/gtfs/bdz.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            }
         },
         {
             "name": "bdz",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://rt.gtfs.baguette.pirnet.si/gtfs-rt/bdz/trip_updates.pb"
+            "url": "https://sipbg.gov.bg/bgnap/portal/api/catalog/subsets/cc43fe99-141e-4eb8-bef1-cae144870a0f/realtime-download"
         },
         {
             "name": "pleven",


### PR DESCRIPTION
Adds the official BDZ static and realtime feeds from the National Access Point. The static feed is processed as the official one is filled with various mistakes and missing things, and I also decided to add translations as a bonus.