### PR TITLE
set GBFS ttl defaults/overrides

### DIFF
--- a/configs/motis/config.yml
+++ b/configs/motis/config.yml
@@ -39,6 +39,21 @@ timetable:
   datasets:
 
 gbfs:
+  ttl:
+    # static information - 6h
+    overwrite:
+      gbfs: 21600
+      manifest: 21600
+      system_information: 21600
+      vehicle_types: 21600
+      station_information: 21600
+      geofencing_zones: 21600
+
+    # dynamic information - 3min
+    default:
+      station_status: 180
+      vehicle_status: 180
+      free_bike_status: 180
   feeds:
 
 limits:


### PR DESCRIPTION
apparently MOTIS already supports setting ttl defaults and overrides for different types of GBFS resources, just nobody knew about it :D

for https://github.com/public-transport/transitous/issues/2279 we still need to properly adhere to the TTL sent by the feed (next MOTIS release) and even then the multi-instances-with-feed-proxy issue persists. But in general this should already much reduce our DDoS attack against GBFS providers (and our own feed proxy)