### PR TITLE
au-tas: switch to constant file URL to avoid Cloudflare

### DIFF
--- a/feeds/au-tas.json
+++ b/feeds/au-tas.json
@@ -10,8 +10,7 @@
             "name": "Tasmanian-Department-of-State-Growth",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://www.transport.tas.gov.au/public_transport/gtfs-data",
-            "function": "data_tasmania_latest_resource",
+            "url": "https://www.transport.tas.gov.au/__data/assets/file/0011/557615/tas_gtfs.zip",
             "license": {
                 "spdx-identifier": "CC-BY-4.0"
             },

--- a/src/region_helpers.py
+++ b/src/region_helpers.py
@@ -86,17 +86,6 @@ def data_slupsk_latest_resource(source: HttpSource) -> HttpSource:
     return source
 
 
-def data_tasmania_latest_resource(source: HttpSource) -> HttpSource:
-    from bs4 import BeautifulSoup
-
-    html = requests.get(source.url).text
-
-    soup = BeautifulSoup(html, "lxml")
-    source.url = soup.find("a", href=lambda x: x and x.endswith(".zip"))["href"]
-
-    return source
-
-
 def data_kaposvar_latest_resource(source: HttpSource) -> HttpSource:
     import re
     from bs4 import BeautifulSoup


### PR DESCRIPTION
looks like the Tasmanian state government installed Cloudflare sometime in June, fortunately the feed itself isn't under Cloudflare and the URL to the actual file hasn't actually changed