### PR TITLE
Fix urls for zbiorkom.live RT and add new feeds

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -1080,7 +1080,8 @@
             "url": "https://files.girlc.at/gtfs/tribus.zip",
             "license": {
                 "spdx-identifier": "CC0-1.0"
-            }
+            },
+            "fix":true
         },
         {
             "name": "PKS-Opoczno",
@@ -1453,7 +1454,9 @@
             "url": "https://github.com/pawlinski07/pawlinski-gtfs/raw/refs/heads/main/KolejPleszewska.zip",
             "license": {
                 "spdx-identifier": "CC-BY-4.0"
-            }
+            },
+            "skip": true,
+            "skip-reason":"Expired feed, see https://github.com/pawlinski07/pawlinski-gtfs/issues/1"
         },
         {
             "name": "Koszalin",

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -175,7 +175,18 @@
         {
             "name": "Toruń",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-u3mj-torun"
+            "transitland-atlas-id": "f-u3mj-torun",
+            "url-override": "https://api.zbiorkom.live/api6-open/torun/gtfs/default"
+        },
+        {
+            "name": "Toruń",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://api.zbiorkom.live/api6-open/torun/gtfsRealtime/default/tripUpdates,vehiclePositions",
+            "license": {
+                "spdx-identifier": "MIT"
+            },
+            "use-feed-proxy": true
         },
         {
             "name": "Kielce",
@@ -377,10 +388,20 @@
             "name": "Koleje-Małopolskie-ald",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://files.girlc.at/gtfs/malopolskie_linie_dowozowe.zip",
+            "url": "https://api.zbiorkom.live/api6-open/mld/gtfs/MLD",
             "license": {
-                "spdx-identifier": "CC0-1.0"
+                "spdx-identifier": "MIT"
             }
+        },
+        {
+            "name": "Koleje-Małopolskie-ald",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://api.zbiorkom.live/api6-open/mld/gtfsRealtime/MLD/tripUpdates,serviceAlerts",
+            "license": {
+                "spdx-identifier": "MIT"
+            },
+            "use-feed-proxy": true
         },
         {
             "name": "ZTP-Kraków-T",
@@ -460,6 +481,7 @@
             "type": "http",
             "spec": "gtfs",
             "url": "https://gtfs.kasznia.net/static/kalisz.zip",
+            "url-override": "https://api.zbiorkom.live/api6-open/kalisz/gtfs/default",
             "license": {
                 "spdx-identifier": "CC0-1.0"
             },
@@ -469,7 +491,7 @@
             "name": "KLA-Kalisz",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://api.zbiorkom.live/api6-open/kalisz/gtfsRealtime/tripUpdates",
+            "url": "https://api.zbiorkom.live/api6-open/kalisz/gtfsRealtime/default/tripUpdates,serviceAlerts",
             "license": {
                 "spdx-identifier": "MIT"
             },
@@ -498,6 +520,16 @@
                 "spdx-identifier": "MIT"
             },
             "fix": true
+        },
+        {
+            "name": "MPK-Wrocław",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://api.zbiorkom.live/api6-open/wroclaw/gtfsRealtime/default/tripUpdates,serviceAlerts",
+            "license": {
+                "spdx-identifier": "MIT"
+            },
+            "use-feed-proxy": true
         },
         {
             "name": "Łódź",
@@ -533,6 +565,7 @@
             "type": "http",
             "spec": "gtfs",
             "url": "https://files.girlc.at/gtfs/wschod_express.zip",
+            "url-override": "https://api.zbiorkom.live/api6-open/bialystok/gtfs/WSCHODEXPRESS",
             "license": {
                 "spdx-identifier": "CC0-1.0"
             },
@@ -572,9 +605,10 @@
             "name": "Sochaczew",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/SOCHACZEW",
+            "url": "https://files.girlc.at/gtfs/sochaczew.zip",
+            "url-override": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/SOCHACZEW",
             "license": {
-                "spdx-identifier": "MIT"
+                "spdx-identifier": "CC0-1.0"
             },
             "fix": true
         },
@@ -592,9 +626,10 @@
             "name": "Otwock",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/OTWOCK",
+            "url": "https://files.girlc.at/gtfs/otwock.zip",
+            "url-override": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/OTWOCK",
             "license": {
-                "spdx-identifier": "MIT"
+                "spdx-identifier": "CC0-1.0"
             },
             "fix": true
         },
@@ -612,9 +647,10 @@
             "name": "Opole",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://api.zbiorkom.live/api6-open/opole/gtfs/default",
+            "url": "https://files.girlc.at/gtfs/opole.zip",
+            "url-override": "https://api.zbiorkom.live/api6-open/opole/gtfs/default",
             "license": {
-                "spdx-identifier": "MIT"
+                "spdx-identifier": "CC0-1.0"
             },
             "fix": true
         },
@@ -742,6 +778,7 @@
             "type": "http",
             "spec": "gtfs",
             "url": "https://kasmar00.github.io/gtfs-warsaw-custom/feeds/warsaw-ferries/latest.zip",
+            "url-override": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/FERRIES/",
             "license": {
                 "spdx-identifier": "CC-BY-4.0"
             }
@@ -760,9 +797,10 @@
             "name": "Ząbki",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/ZABKI",
+            "url": "https://files.girlc.at/gtfs/zabki.zip",
+            "url-override": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/ZABKI",
             "license": {
-                "spdx-identifier": "MIT"
+                "spdx-identifier": "CC0-1.0"
             }
         },
         {
@@ -1169,9 +1207,10 @@
             "name": "Radzymin",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/RADZYMIN",
+            "url": "https://files.girlc.at/gtfs/radzymin.zip",
+            "url-override": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/RADZYMIN",
             "license": {
-                "spdx-identifier": "MIT"
+                "spdx-identifier": "CC0-1.0"
             }
         },
         {
@@ -1188,9 +1227,10 @@
             "name": "Łomianki",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/LOMIANKI",
+            "url": "https://files.girlc.at/gtfs/lomianki.zip",
+            "url-override": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/LOMIANKI",
             "license": {
-                "spdx-identifier": "MIT"
+                "spdx-identifier": "CC0-1.0"
             }
         },
         {

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -375,8 +375,12 @@
         },
         {
             "name": "Koleje-Małopolskie-ald",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-u2y-koleje~małopolskie~ald"
+            "type": "http",
+            "spec": "gtfs",
+            "url": "https://files.girlc.at/gtfs/malopolskie_linie_dowozowe.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            }
         },
         {
             "name": "ZTP-Kraków-T",
@@ -746,7 +750,7 @@
             "name": "Warsaw-Ferries",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://api.zbiorkom.live/api6-open/warsaw/gtfsRealtime/FERRIES/tripUpdates,serviceAlerts+json",
+            "url": "https://api.zbiorkom.live/api6-open/warsaw/gtfsRealtime/FERRIES/tripUpdates,serviceAlerts",
             "license": {
                 "spdx-identifier": "MIT"
             },
@@ -1437,6 +1441,42 @@
             "spec": "gtfs",
             "url": "https://files.girlc.at/gtfs/halinow.zip",
             "fix": true,
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            }
+        },
+        {
+            "name": "Powiat-Wodzisławski",
+            "type": "http",
+            "spec": "gtfs",
+            "url": "https://files.girlc.at/gtfs/powiat_wodzislawski.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            }
+        },
+        {
+            "name": "Wieliszew",
+            "type": "http",
+            "spec": "gtfs",
+            "url": "https://files.girlc.at/gtfs/wieliszew.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            }
+        },
+        {
+            "name": "Zamość",
+            "type": "http",
+            "spec": "gtfs",
+            "url": "https://files.girlc.at/gtfs/zamosc.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            }
+        },
+        {
+            "name": "Zamość",
+            "type": "http",
+            "spec": "gtfs",
+            "url": "https://files.girlc.at/gtfs/zyrardow.zip",
             "license": {
                 "spdx-identifier": "CC0-1.0"
             }

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -1513,7 +1513,7 @@
             }
         },
         {
-            "name": "Zamość",
+            "name": "Żyrardów",
             "type": "http",
             "spec": "gtfs",
             "url": "https://files.girlc.at/gtfs/zyrardow.zip",

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -1516,15 +1516,6 @@
             }
         },
         {
-            "name": "Żyrardów",
-            "type": "http",
-            "spec": "gtfs",
-            "url": "https://files.girlc.at/gtfs/zyrardow.zip",
-            "license": {
-                "spdx-identifier": "CC0-1.0"
-            }
-        },
-        {
             "name": "Chełmski-Rower",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-chełmski~rower~gbfs"

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -72,10 +72,10 @@
             }
         },
         {
-            "name": "Koleje-Mazowieckie-ZL",
+            "name": "Kolejki-Wąskotorowe",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://gtfs.kasznia.net/static/km-zl.zip",
+            "url": "https://gtfs.kasznia.net/static/narrow-gauge.zip",
             "license": {
                 "spdx-identifier": "CC-BY-4.0"
             }

--- a/src/region_helpers.py
+++ b/src/region_helpers.py
@@ -63,7 +63,7 @@ def data_zielona_gora_latest_resource(source: HttpSource) -> HttpSource:
     )
 
     base_url = source.url.rsplit("/", 1)[0]
-    source.url = f"{base_url}/{gtfs_link}"
+    source.url = f"{base_url}{gtfs_link}"
 
     return source
 
@@ -81,7 +81,7 @@ def data_slupsk_latest_resource(source: HttpSource) -> HttpSource:
     gtfs_link = soup.find("a", href=lambda x: x and x.endswith(".zip"))["href"]
 
     base_url = source.url.rsplit("/", 1)[0]
-    source.url = f"{base_url}{gtfs_link}"
+    source.url = f"{base_url}/{gtfs_link}"
 
     return source
 

--- a/src/region_helpers.py
+++ b/src/region_helpers.py
@@ -81,7 +81,7 @@ def data_slupsk_latest_resource(source: HttpSource) -> HttpSource:
     gtfs_link = soup.find("a", href=lambda x: x and x.endswith(".zip"))["href"]
 
     base_url = source.url.rsplit("/", 1)[0]
-    source.url = f"{base_url}/{gtfs_link}"
+    source.url = f"{base_url}{gtfs_link}"
 
     return source
 


### PR DESCRIPTION
Unfortunately zbiorkom.live introduced a _breaking_ change to their gtfs-rt processing, which makes their gtfs-rt feeds incompatible with original static feeds (they mangle trip_id's). So, their reprocessed gtfs feeds will be used and where available a link to the original feed is also included.

Additionally:
- adding new feeds for: Powiat-Wodzisławski, Wieliszew, Zamość, Żyrardów
- fix RT url for Kalisz and Warsaw Ferries
- add RT for Toruń, Koleje Małopolskie Buses and Wrocław.
- removed temporary KM-ZL feed
- added feed for narrow gauge railways in Poland
- added "fix" to tribus and "skip" to Kolej Pleszewska