### PR TITLE
Fix URL for warsaw ferries and add override for Powiat Miński

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -778,7 +778,7 @@
             "type": "http",
             "spec": "gtfs",
             "url": "https://kasmar00.github.io/gtfs-warsaw-custom/feeds/warsaw-ferries/latest.zip",
-            "url-override": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/FERRIES/",
+            "url-override": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/FERRIES",
             "license": {
                 "spdx-identifier": "CC-BY-4.0"
             }

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -1423,6 +1423,7 @@
             "type": "http",
             "spec": "gtfs",
             "url": "https://files.girlc.at/gtfs/powiat_minski.zip",
+            "url-override": "https://api.zbiorkom.live/api6-open/bialystok/gtfs/MINSKI",
             "fix": true,
             "license": {
                 "spdx-identifier": "CC0-1.0"

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -993,9 +993,20 @@
             "type": "http",
             "spec": "gtfs",
             "url": "https://files.girlc.at/gtfs/nowy_dwor_mazowiecki.zip",
+            "url-override": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/NDM",
             "license": {
                 "spdx-identifier": "CC0-1.0"
             }
+        },
+        {
+            "name": "Nowy-Dwór-Mazowiecki",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://api.zbiorkom.live/api6-open/warsaw/gtfsRealtime/NDM/tripUpdates,serviceAlerts",
+            "license": {
+                "spdx-identifier": "MIT"
+            },
+            "use-feed-proxy": true
         },
         {
             "name": "Ciechanów",

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -1423,7 +1423,7 @@
             "type": "http",
             "spec": "gtfs",
             "url": "https://files.girlc.at/gtfs/powiat_minski.zip",
-            "url-override": "https://api.zbiorkom.live/api6-open/bialystok/gtfs/MINSKI",
+            "url-override": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/MINSKI",
             "fix": true,
             "license": {
                 "spdx-identifier": "CC0-1.0"


### PR DESCRIPTION
Apparently the trailing `/` causes a 500 error on zbiorkom side and original url was used instead of the url-override.

Add override for Powiat Miński - to make static compatible with RT
Add RT for Nowy dwór mazowiecki