### PR TITLE
Add correct GoVolta category to Lua script

### DIFF
--- a/scripts/nl-OpenOV.lua
+++ b/scripts/nl-OpenOV.lua
@@ -13,6 +13,7 @@ local route_type_map = {
     { 2, "EuroCity", 102, "ECC" },
     { 2, "ICE", 101, "ICE" },
     { 2, "Eurostar", 101, "EST" },
+    { 2, "GoVolta", 102, "GV" },
 }
 
 function process_route(route)


### PR DESCRIPTION
GoVolta is a long distance train, so this sets the proper category, and also makes it show up as `GV 123` instead of `GoVolta`.