### PR TITLE
add static feed for KVV; drop agencies in DELFI feed

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -35,7 +35,28 @@
                 "EUROSTAR",
                 "Bremer Straßenbahn AG",
                 "Verkehrsgemeinschaft Osnabrück",
-                "SNCB"
+                "SNCB",
+                "Tram VBK",
+                "Bus VBK",
+                "Albtal-Verkehrs-Gesellschaft",
+                "Stadtbahn Karlsruhe SEV",
+                "Bus VERA",
+                "Bus RVS",
+                "Bus SWEG",
+                "Taxiverkehre",
+                "Bus Engel",
+                "Bus Faller",
+                "Bus Hassis",
+                "Bus Wöhrle",
+                "Bus Richard Eberhardt GmbH",
+                "Bus Stadtwerke Baden-Baden",
+                "Friedrich Müller Omnibus GmbH",
+                "Kraichtal Bus GbR",
+                "Bus NVW (Walz)",
+                "Busverkehr Nordschwarzwald GmbH",
+                "SEV T+B (Tram + Sonstige Busse)",
+                "Nachtverkehr",
+                "Nachtverkehr Ausstieg"
             ],
             "http-options": {
                 "fetch-interval-days": 2
@@ -125,6 +146,14 @@
             "license": {
                 "spdx-identifier": "ODbL-1.0",
                 "url": "https://opendata.avv.de/current_GTFS/lizenz_und_readme.txt"
+            }
+        },
+        {
+            "name": "KVV",
+            "type": "http",
+            "url": "https://projekte.kvv-efa.de/GTFS/google_transit.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
             }
         },
         {

--- a/feeds/de.json
+++ b/feeds/de.json
@@ -157,6 +157,17 @@
             }
         },
         {
+            "name": "KVV",
+            "type": "url",
+            "spec": "siri",
+            "url": "https://cdn.k118.de/siri-et/bw-kvv/latest.xml",
+            "url-contact": "github.com/MrKrisKrisu",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0",
+                "url": "https://mobilithek.info/offers/832218391386144768"
+            }
+        },
+        {
             "name": "RegioRadStuttgart",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-regioradstuttgart~stuttgart~gbfs"


### PR DESCRIPTION
I've checked that the [SIRI ET from Baden Württemberg](https://mobilithek.info/offers/832218391386144768) is matching this static feed.

Matched / Dropped Agencies:

| KVV Agency                                   | DELFI Agency                                                     |
|----------------------------------------------|------------------------------------------------------------------|
| Verkehrsbetriebe Karlsruhe GmbH              | Tram VBK, Bus VBK, SEV T+B (Tram + Sonstige Busse), Nachtverkehr |
| Albtal-Verkehrs-Gesellschaft mbH             | Albtal-Verkehrs-Gesellschaft, Stadtbahn Karlsruhe SEV            |
| Friedrich Müller Omnibusunternehmen GmbH     | Friedrich Müller Omnibus GmbH                                    |
| Stadtwerke Baden-Baden                       | Bus Stadtwerke Baden-Baden                                       |
| Richard Eberhardt GmbH                       | Bus Richard Eberhardt GmbH                                       |
| Reisebüro Wöhrle GmbH                        | Bus Wöhrle                                                       |
| Engel Mühlacker                              | Bus Engel                                                        |
| Hassis Reisen GmbH                           | Bus Hassis                                                       |
| Verkehrsgesellschaft Rastatt mbH             | Bus VERA                                                         |
| Kraichtal Bus GbR                            | Kraichtal Bus GbR                                                |
| Taxi-Funk-Zentrale Karlsruhe eG              | Taxiverkehre, Nachtverkehr Ausstieg                              |
| Taxi-Holl                                    | Taxiverkehre                                                     |
| DB ZugBus Regionalverkehr Alb-Bodensee       | Busverkehr Nordschwarzwald GmbH                                  |
| Nahverkehr Mittelbaden Walz GmbH             | Bus NVW (Walz)                                                   |
| SWEG Südwestdeutsche Landesverkehrs-AG       | Bus SWEG                                                         |
| Zeller Bus, Taxi- und Krankentransporte GmbH | Bus SWEG, Taxiverkehre                                           |
| Stadtbus Bruchsal                            | Bus RVS                                                          |
| Faller Reisen GmbH                           | Bus Faller                                                       |
| Taxi Bitterwolf                              | Taxiverkehre                                                     |
| Regionalbusverkehr Südwest GmbH              | Bus RVS                                                          |
