### PR TITLE
Add Turkish State Railways

### DIFF
--- a/feeds/tr.json
+++ b/feeds/tr.json
@@ -213,6 +213,12 @@
             "type": "http",
             "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/tokat.zip",
             "fix": true
+        },
+        {
+            "name": "tcdd",
+            "type": "http",
+            "url": "https://github.com/yasinkaraaslan/tcdd-gtfs/raw/main/output/tcdd.zip",
+            "fix": true
         }
     ]
 }


### PR DESCRIPTION
I was able to generate a GTFS feed for Turkish State Railways using their API. I hope people find it useful.
fix is set to true because a newly opened station (Neşetiye) appears in trip data but hasn't been added to the API I get stations from, causing error.

https://github.com/yasinkaraaslan/tcdd-gtfs