### PR TITLE
Fix Gdynia and Koszalin RT

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -1299,7 +1299,8 @@
             "url": "https://api.zbiorkom.live/api6-open/zielonaGora/gtfs/default",
             "license": {
                 "spdx-identifier": "MIT"
-            }
+            },
+            "fix": true
         },
         {
             "name": "Zielona-Góra",
@@ -1360,8 +1361,7 @@
             "name": "Pruszków",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/pruszkow",
-            "url-override": "https://cdn.zbiorkom.live/gtfs/warsaw-pruszkow.zip",
+            "url": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/PRUSZKOW",
             "license": {
                 "spdx-identifier": "MIT"
             }
@@ -1411,7 +1411,9 @@
             "url": "https://files.girlc.at/gtfs/szczytno.zip",
             "license": {
                 "spdx-identifier": "CC0-1.0"
-            }
+            },
+            "skip": true,
+            "skip-reason": "Feed expired"
         },
         {
             "name": "Sulejówek",
@@ -1588,19 +1590,28 @@
             "name": "RPK-Bochnia",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://api.odt.org.pl/static/media/public_transport_data/RPKBochnia_bgLAcxp.zip",
+            "url": "https://api.odt.org.pl/feed/21/GTFS_RPKBochnia.zip",
             "license": {
                 "spdx-identifier": "MIT"
             },
             "fix": true
         },
         {
-            "name": "Wałbrzych",
+            "name": "Wałbrzych-SKA",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://api.odt.org.pl/static/media/public_transport_data/GTFS-SKA.zip",
+            "url": "https://api.odt.org.pl/feed/20/SKA.zip",
             "license": {
-                "spdx-identifier": "MIT"
+                "spdx-identifier": "CC0-1.0"
+            }
+        },
+        {
+            "name": "Wałbrzych-MUZK",
+            "type": "http",
+            "spec": "gtfs",
+            "url": "https://api.odt.org.pl/feed/19/MUZK.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
             }
         },
         {

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -1656,13 +1656,15 @@
             "name": "Krosno",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://mks.ekrosno.pl/GTFS-ST/GTFS.zip"
+            "url": "https://mks.ekrosno.pl/GTFS-ST/GTFS.zip",
+            "url-override": "https://api.zbiorkom.live/api6-open/krosno/gtfs/default"
         },
         {
             "name": "Krosno",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://mks.ekrosno.pl/GTFS-RT/trip_updates.bin"
+            "url": "https://mks.ekrosno.pl/GTFS-RT/trip_updates.bin",
+            "url-override": "https://api.zbiorkom.live/api6-open/krosno/gtfsRealtime/default/tripUpdates,serviceAlerts"
         }
     ]
 }

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -1296,11 +1296,20 @@
             "name": "Zielona-Góra",
             "type": "http",
             "spec": "gtfs",
-            "url": "https://www.mzk.zgora.pl/dla-deweloperow",
-            "function": "data_zielona_gora_latest_resource",
+            "url": "https://api.zbiorkom.live/api6-open/zielonaGora/gtfs/default",
             "license": {
-                "spdx-identifier": "CC0-1.0"
+                "spdx-identifier": "MIT"
             }
+        },
+        {
+            "name": "Zielona-Góra",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://api.zbiorkom.live/api6-open/zielonaGora/gtfsRealtime/default/tripUpdates,serviceAlerts",
+            "license": {
+                "spdx-identifier": "MIT"
+            },
+            "use-feed-proxy": true
         },
         {
             "name": "Zakroczym",

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -279,15 +279,17 @@
         },
         {
             "name": "Gdynia",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-ztm~gdynia",
-            "fix": true
+            "type": "http",
+            "url": "https://api.zbiorkom.live/api6-open/tricity/gtfs/GDYNIA",
+            "license":{
+                "spdx-identifier": "MIT"
+            }
         },
         {
             "name": "Gdynia",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://api.zbiorkom.live/api6-open/tricity/gtfsRealtime/default/tripUpdates,serviceAlerts",
+            "url": "https://api.zbiorkom.live/api6-open/tricity/gtfsRealtime/GDYNIA/tripUpdates,serviceAlerts",
             "license": {
                 "spdx-identifier": "MIT"
             },
@@ -1161,10 +1163,21 @@
             "type": "http",
             "spec": "gtfs",
             "url": "https://files.girlc.at/gtfs/tczew.zip",
+            "url-override": "https://api.zbiorkom.live/api6-open/tczew/gtfs/default",
             "license": {
                 "spdx-identifier": "CC0-1.0"
             },
             "fix": true
+        },
+        {
+            "name": "Tczew",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://api.zbiorkom.live/api6-open/tczew/gtfsRealtime/default/tripUpdates,serviceAlerts",
+            "license": {
+                "spdx-identifier": "MIT"
+            },
+            "use-feed-proxy": true
         },
         {
             "name": "Plusbus",
@@ -1404,6 +1417,7 @@
             "type": "http",
             "spec": "gtfs",
             "url": "https://files.girlc.at/gtfs/sulejowek.zip",
+            "url-override": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/SULEJOWEK",
             "license": {
                 "spdx-identifier": "CC0-1.0"
             }
@@ -1412,7 +1426,7 @@
             "name": "Sulejówek",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://api.zbiorkom.live/api6-open/czestochowa/gtfsRealtime/SULEJOWEK/tripUpdates,serviceAlerts",
+            "url": "https://api.zbiorkom.live/api6-open/warsaw/gtfsRealtime/SULEJOWEK/tripUpdates,serviceAlerts",
             "license": {
                 "spdx-identifier": "MIT"
             },
@@ -1423,6 +1437,7 @@
             "type": "http",
             "spec": "gtfs",
             "url": "https://files.girlc.at/gtfs/powiat_minski.zip",
+            "url-override": "https://api.zbiorkom.live/api6-open/warsaw/gtfs/MINSKI",
             "fix": true,
             "license": {
                 "spdx-identifier": "CC0-1.0"
@@ -1463,6 +1478,7 @@
             "type": "http",
             "spec": "gtfs",
             "url": "https://files.girlc.at/gtfs/koszalin.zip",
+            "url-override": "https://api.zbiorkom.live/api6-open/koszalin/gtfs/default",
             "fix": true,
             "license": {
                 "spdx-identifier": "CC0-1.0"

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -1664,7 +1664,8 @@
             "type": "url",
             "spec": "gtfs-rt",
             "url": "https://mks.ekrosno.pl/GTFS-RT/trip_updates.bin",
-            "url-override": "https://api.zbiorkom.live/api6-open/krosno/gtfsRealtime/default/tripUpdates,serviceAlerts"
+            "url-override": "https://api.zbiorkom.live/api6-open/krosno/gtfsRealtime/default/tripUpdates,serviceAlerts",
+            "use-feed-proxy": true
         }
     ]
 }

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -988,7 +988,9 @@
             "fix": true,
             "license": {
                 "spdx-identifier": "CC0-1.0"
-            }
+            },
+            "skip" :true,
+            "skip-reason": "Feed expired"
         },
         {
             "name": "Nowy-Dwór-Mazowiecki",
@@ -1356,16 +1358,6 @@
             }
         },
         {
-            "name": "Siechnice",
-            "type": "http",
-            "spec": "gtfs",
-            "url": "https://api.zbiorkom.live/api6-open/wroclaw/gtfs/siechnice",
-            "url-override": "https://cdn.zbiorkom.live/gtfs/wroclaw-siechnice.zip",
-            "license": {
-                "spdx-identifier": "MIT"
-            }
-        },
-        {
             "name": "Goleniów",
             "type": "http",
             "spec": "gtfs",
@@ -1550,11 +1542,6 @@
             "name": "KRM-Koszalin",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-koszaliński~rower~miejski~poland~koszalin~gbfs"
-        },
-        {
-            "name": "ŁRP-Łódź",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-łódzki~rower~publiczny~łódź~pl~gbfs"
         },
         {
             "name": "Metrorower",

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -1657,7 +1657,11 @@
             "type": "http",
             "spec": "gtfs",
             "url": "https://mks.ekrosno.pl/GTFS-ST/GTFS.zip",
-            "url-override": "https://api.zbiorkom.live/api6-open/krosno/gtfs/default"
+            "url-override": "https://api.zbiorkom.live/api6-open/krosno/gtfs/default",
+            "license": {
+                "spdx-identifier": "MIT"
+            },
+            "fix": true
         },
         {
             "name": "Krosno",
@@ -1665,7 +1669,10 @@
             "spec": "gtfs-rt",
             "url": "https://mks.ekrosno.pl/GTFS-RT/trip_updates.bin",
             "url-override": "https://api.zbiorkom.live/api6-open/krosno/gtfsRealtime/default/tripUpdates,serviceAlerts",
-            "use-feed-proxy": true
+            "use-feed-proxy": true,
+            "license": {
+                "spdx-identifier": "MIT"
+            }
         }
     ]
 }

--- a/src/region_helpers.py
+++ b/src/region_helpers.py
@@ -52,22 +52,6 @@ def delhi_gov_in_csrf(source: HttpSource) -> HttpSource:
     return source
 
 
-def data_zielona_gora_latest_resource(source: HttpSource) -> HttpSource:
-    from bs4 import BeautifulSoup
-
-    html = requests.get(source.url).text
-
-    soup = BeautifulSoup(html, "lxml")
-    gtfs_link = next(
-        (a["href"] for a in soup.find_all("a") if "GTFS" in a.get_text()), None
-    )
-
-    base_url = source.url.rsplit("/", 1)[0]
-    source.url = f"{base_url}{gtfs_link}"
-
-    return source
-
-
 def data_slupsk_latest_resource(source: HttpSource) -> HttpSource:
     from bs4 import BeautifulSoup
 


### PR DESCRIPTION
- Fix Gdynia RT - zbiorkom exposes cities in Tricity properly now, so we can use Gdynia RT and static
- override static to be compatible with RT for: Koszalin, Sulejówek, Powiat Miński, Koszalin
- Fix Zielona góra - feed is available with RT on zbiorkom.live and the original website was problematic (failing requests and python helper function)
- Fix urls of feeds from ODT