### PR TITLE
Italy/Sicilia: add intercity coaches GTFS + FCE Circumetnea

### DIFF
--- a/feeds/it.json
+++ b/feeds/it.json
@@ -290,6 +290,24 @@
             }
         },
         {
+            "name": "Sicilia-intercity-coaches",
+            "type": "http",
+            "url": "https://it.mangonese.dev/gtfs/sicily-coaches.gtfs.zip",
+            "spec": "gtfs",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            }
+        },
+        {
+            "name": "Sicilia-FCE-Circumetnea",
+            "type": "http",
+            "url": "https://it.mangonese.dev/gtfs/fce.gtfs.zip",
+            "spec": "gtfs",
+            "license": {
+                "url": "https://www.circumetnea.it/pubblicazione-orari-del-trasporto-pubblico-locale-in-formato-gtfs/"
+            }
+        },
+        {
             "name": "Toscana-Autolinee-LineeRegionali",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-s-lineeregionali"


### PR DESCRIPTION
Adds two Sicily sources to feeds/it.json:

**Sicilia-intercity-coaches** — a GTFS feed for Sicilian intercity (extraurban) coach service, which currently has no other machine-readable source. Generated from the operator timetables published by Regione Siciliana (Assessorato Infrastrutture e Mobilità, "Orari Autolinee" portal) plus TUA Agrigento's published urban timetables. Currently ~40 operators / ~490 routes (AST all provinces, Interbus, Etna Trasporti, Autotrasporti Cuffaro, Salvatore Lumia, Giuntabus and the long tail). Hosted at a stable URL, regenerated as source timetables change, license CC0. Pipeline + provenance (source snapshots, sha256 manifest, QA report): https://github.com/mangonese09/ManGO-IT — happy to adjust anything (naming, licensing declaration, feed shape) to fit project conventions, and to maintain this source going forward.

Caveats: schedule facts come from the operators' published PDF timetables. Sicilian intercity timetables are stable year-over-year but corrections are expected and the feed will be regenerated as fresher sheets are obtained. School-calendar-dependent services use the regional school year, approximated to ±a few days.

**Sicilia-FCE-Circumetnea** — Ferrovia Circumetnea's own official GTFS (Catania metro + Etna railway), published on their site with validity through 2028-02: https://www.circumetnea.it/pubblicazione-orari-del-trasporto-pubblico-locale-in-formato-gtfs/ (the download URL serves the zip directly).

With these two, Sicily coverage in Transitous becomes: Trenitalia rail + AMAT Palermo + AMTS Catania (already present) + intercity coaches + Catania metro/Circumetnea.
