### PR TITLE
Add static GTFS for TEP - Parma

### DIFF
--- a/feeds/it.json
+++ b/feeds/it.json
@@ -50,6 +50,11 @@
             "transitland-atlas-id": "f-eave~wimob~it"
         },
         {
+            "name": "Emilia-Romagna-TEP-Parma",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-spz3-tepparma"
+        },
+        {
             "name": "Emilia-Romagna-TPER-Bologna",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-srb-tperspa~bologna"


### PR DESCRIPTION
I added the static feed for TEP in Parma, Italy, using the source available in transitland. The static feed works fine (which is all I added in this PR), however, the RT feed doesn't seem to work well with MOTIS, as I discussed in the Matrix channel, so I'd appreciate any help there. The feeds (both static and RT) are available at https://temporeale.cl.tep.pr.it/.