### PR TITLE
Update sharing feed for de

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -173,11 +173,6 @@
             "transitland-atlas-id": "f-lime~frankfurt~gbfs"
         },
         {
-            "name": "DottFrankfurt",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-dott~frankfurt~gbfs"
-        },
-        {
             "name": "Deer",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-deer~germany~gbfs",
@@ -261,9 +256,19 @@
             "transitland-atlas-id": "f-oberschwabenmobil~carsharing~halle~saale~~gbfs"
         },
         {
+            "name": "FordCarsharingAutohausAlbert",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ford~carsharing~autohaus~albert~donaueschingen~gbfs"
+        },
+        {
             "name": "FordCarsharingAutohausBaur",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-ford~carsharing~autohaus~baur~germany~gbfs"
+        },
+        {
+            "name": "FordCarsharingAutohausBölz",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-ford~carsharing~autohaus~bölz~sinsheim~gbfs"
         },
         {
             "name": "FordCarharingAutohausKauderer",
@@ -299,8 +304,7 @@
             "name": "Car-ship",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-car~ship~constance~gbfs",
-            "skip": true,
-            "skip-reason": "Server overloaded by our requests, MOTIS ttl handling and our proxy need investigation (https://github.com/public-transport/transitous/issues/2279)"
+            "url-override": "https://api.mobidata-bw.de/sharing/gbfs/v2/car_ship/gbfs"
         },
         {
             "name": "Stella",
@@ -387,11 +391,6 @@
             "name": "DottSaarbrücken",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-dott~saarbrücken~gbfs"
-        },
-        {
-            "name": "DottFrankfurt",
-            "type": "transitland-atlas",
-            "transitland-atlas-id": "f-dott~frankfurt~gbfs"
         },
         {
             "name": "DottDarmstadt",


### PR DESCRIPTION
- remove Dott Frankfurt as it does not exist anymore (resolves #2334)
- add new feeds for Ford Carsharing
- re-enable Car-Ship feed with URL override (see also #2279)