### PR TITLE
fix ca-qc St Laurent

### DIFF
--- a/feeds/ca-qc.json
+++ b/feeds/ca-qc.json
@@ -81,13 +81,15 @@
         {
             "name": "Exo-citduhaut-saint-laurent",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-f259-exo~citduhaut~saint~laurent"
+            "transitland-atlas-id": "o-zenbus~mrc~haut~saint~laurent"
         },
         {
             "name": "Exo-citduhaut-saint-laurent",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-f259-exo~citduhaut~saint~laurent~rt",
-            "url-override": "https://birch.catenarymaps.org/gtfs_rt?feed_id=f-f259-exo~citduhaut~saint~laurent~rt&feed_type=trip"
+            "url-override": "https://birch.catenarymaps.org/gtfs_rt?feed_id=f-f259-exo~citduhaut~saint~laurent~rt&feed_type=trip",
+            "skip": true,
+            "skip-reason": "f-f259-exo~citduhaut~saint~laurent~rt does not exist anymore?"
         },
         {
             "name": "Exo-richelain-roussillon",

--- a/feeds/ca-qc.json
+++ b/feeds/ca-qc.json
@@ -81,7 +81,7 @@
         {
             "name": "Exo-citduhaut-saint-laurent",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "o-zenbus~mrc~haut~saint~laurent"
+            "transitland-atlas-id": "f-hubup~mrc~haut~saint~laurent"
         },
         {
             "name": "Exo-citduhaut-saint-laurent",

--- a/feeds/ca-qc.json
+++ b/feeds/ca-qc.json
@@ -160,12 +160,16 @@
         {
             "name": "STS-Sherbrooke",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-f2hf-sociétédetransportdesherbrooke"
+            "transitland-atlas-id": "f-f2hf-sociétédetransportdesherbrooke",
+            "skip": true,
+            "skip-reason": "api-key is missing"
         },
         {
             "name": "STS-Sherbrooke",
             "type": "transitland-atlas",
-            "transitland-atlas-id": "f-f2hf-sociétédetransportdesherbrooke~rt"
+            "transitland-atlas-id": "f-f2hf-sociétédetransportdesherbrooke~rt",
+            "skip": true,
+            "skip-reason": "api-key is missing"
         },
         {
             "name": "RTC",


### PR DESCRIPTION
`f-f259-exo~citduhaut~saint~laurent` seems to have vanished, not sure about the catenarymaps rt feed. I think this is the new feed
@kylerchin Independent of that https://birch.catenarymaps.org, appears to be offline