### PR TITLE
fr-sncf: switch to netex, add rudimentary reservation info

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -7414,7 +7414,8 @@
             "managed-by-script": true,
             "skip": false,
             "x-data-gov-fr-res-title": "GTFS Trenitalia France",
-            "x-data-gov-fr-dataset-id": "64635525318cc75a9a8a771f"
+            "x-data-gov-fr-dataset-id": "64635525318cc75a9a8a771f",
+            "script": "fr-trenitalia.lua"
         },
         {
             "name": "horaires-des-trains-trenitalia-france",
@@ -12244,6 +12245,43 @@
         {
             "name": "horaires-sncf",
             "type": "http",
+            "url": "https://mirror.traines.eu/french-netex/sncf-netex.fixed.zip",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/horaires-sncf",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "spec": "netex",
+            "x-data-gov-fr-res-id": 83195,
+            "managed-by-script": false,
+            "script": "fr-sncf.lua"
+        },
+        {
+            "name": "horaires-sncf",
+            "type": "url",
+            "url": "https://proxy.transport.data.gouv.fr/resource/sncf-siri-lite-estimated-timetable",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/horaires-sncf",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "spec": "siri",
+            "x-data-gov-fr-res-id": 83198,
+            "managed-by-script": false
+        },
+        {
+            "name": "horaires-sncf",
+            "type": "url",
+            "url": "https://proxy.transport.data.gouv.fr/resource/sncf-siri-lite-situation-exchange",
+            "license": {
+                "url": "https://transport.data.gouv.fr/datasets/horaires-sncf",
+                "spdx-identifier": "ODbL-1.0"
+            },
+            "spec": "siri",
+            "x-data-gov-fr-res-id": 83199,
+            "managed-by-script": false
+        },
+        {
+            "name": "horaires-sncf",
+            "type": "http",
             "url": "https://www.data.gouv.fr/api/1/datasets/r/9ae758ec-cd7a-40cd-a890-bb3963224942",
             "fix": true,
             "license": {
@@ -12253,7 +12291,9 @@
             "x-data-gov-fr-res-id": 83582,
             "managed-by-script": true,
             "x-data-gov-fr-res-title": "https://eu.ftp.opendatasoft.com/sncf/plandata/Export_OpenData_SNCF_GTFS_NewTripId.zip",
-            "x-data-gov-fr-dataset-id": "6853c089b3ed5781f6adfdf7"
+            "x-data-gov-fr-dataset-id": "6853c089b3ed5781f6adfdf7",
+            "skip": true,
+            "skip-reason": "netex is better"
         },
         {
             "name": "horaires-sncf",
@@ -12267,7 +12307,9 @@
             "x-data-gov-fr-res-id": 83196,
             "managed-by-script": true,
             "x-data-gov-fr-res-title": "https://proxy.transport.data.gouv.fr/resource/sncf-gtfs-rt-service-alerts",
-            "x-data-gov-fr-dataset-id": "6853c089b3ed5781f6adfdf7"
+            "x-data-gov-fr-dataset-id": "6853c089b3ed5781f6adfdf7",
+            "skip": true,
+            "skip-reason": "siri is better"
         },
         {
             "name": "horaires-sncf",
@@ -12281,7 +12323,9 @@
             "x-data-gov-fr-res-id": 83583,
             "managed-by-script": true,
             "x-data-gov-fr-res-title": "https://proxy.transport.data.gouv.fr/resource/sncf-gtfs-rt-trip-updates",
-            "x-data-gov-fr-dataset-id": "6853c089b3ed5781f6adfdf7"
+            "x-data-gov-fr-dataset-id": "6853c089b3ed5781f6adfdf7",
+            "skip": true,
+            "skip-reason": "siri is better"
         },
         {
             "name": "hop-bus-le-reseau-100-gratuit-du-coeur-de-flandre",

--- a/scripts/ch-opentransportdataswiss.lua
+++ b/scripts/ch-opentransportdataswiss.lua
@@ -11,9 +11,11 @@ function process_trip(trip)
     if trip:get_route():get_agency():get_id() == "87_LEX" then
         if trip:get_route():get_route_type() == 101 then
             trip:set_display_name("TGV " .. trip:get_short_name())
+            trip:set_compulsory_reservation(true)
         end
         if trip:get_route():get_route_type() == 102 then
             trip:set_display_name("IC " .. trip:get_short_name())
+            trip:set_compulsory_reservation(true)
         end
     end
 end

--- a/scripts/de-DELFI.lua
+++ b/scripts/de-DELFI.lua
@@ -41,6 +41,12 @@ function process_trip(trip)
         trip:set_display_name(trip:get_short_name())
       end
     end
+    if trip:get_route():get_agency():get_name() == 'FlixTrain-de' or trip:get_route():get_agency():get_name() == 'SNCF' then
+        trip:set_compulsory_reservation(true)
+    elseif trip:get_route():get_agency():get_name() == "HEAG mobiBus GmbH + Co. KG" and trip:get_route():get_short_name() == "AIR" then
+        trip:set_compulsory_reservation(true)
+        trip:set_route_type(203)
+    end
   end
 
   if trip:get_route():get_route_type() == 106 and is_number(trip:get_short_name()) then

--- a/scripts/fr-sncf.lua
+++ b/scripts/fr-sncf.lua
@@ -1,0 +1,20 @@
+-- SPDX-FileCopyrightText: Felix Gündling <felixguendling@gmail.com>
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+function process_trip(trip)
+    local brand = trip:get_vehicle_type_short_name()
+    if brand == 'LYR' then
+            brand = 'TGV Lyria'
+    elseif brand == 'TGVOUIGO' or brand == 'INCONNU' then
+            brand = 'OUIGO'
+    elseif brand == 'OUI' then
+            brand = 'TGV INOUI'
+    elseif brand == 'DBS' then
+            brand = 'ICE'
+    end
+    trip:set_display_name(brand .. ' ' .. trip:get_short_name())
+    if trip:get_route():get_route_type() == 101 or trip:get_route():get_route_type() == 102 then
+        trip:set_compulsory_reservation(true)
+    end
+end
+

--- a/scripts/fr-trenitalia.lua
+++ b/scripts/fr-trenitalia.lua
@@ -1,0 +1,7 @@
+-- SPDX-FileCopyrightText: Traines <git@traines.eu>
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+function process_trip(trip)
+        trip:set_compulsory_reservation(true)
+        trip:set_route_type(102)
+end


### PR DESCRIPTION
closes #2062 

In MOTIS versions < 2.11 (i.e. current failover) this leads to a loss of RT coverage. Though IMO useful train names and route_type are more important than RT.

Also some rudimentary reservation info (also only works >= 2.11, but should suprisingly not break earlier versions). It's not correct everywhere, particularly at the borders (some feeds don't split trips or not at the location where reservation regulations change, overriding that is not yet supported). But I think it's a good start. Also maybe we shouldn't get too much into the reservation frenzy before building the Wikidata connector.