### PR TITLE
Use Korail feed with Realtime

### DIFF
--- a/feeds/kr.json
+++ b/feeds/kr.json
@@ -25,12 +25,21 @@
       {
         "name": "korail",
         "type": "http",
-        "url": "https://shells.ccc.ac/~aelin/gtfs/korail.gtfs.zip",
+        "url": "https://mkuran.pl/gtfs/korail.zip",
         "license": {
-          "spdx-identifier": "ODbL-1.0",
-          "url": "https://shells.ccc.ac/~aelin/gtfs/LICENSE.txt"
+          "spdx-identifier": "CC-BY-4.0",
+          "url": "https://mkuran.pl/gtfs/"
+        }
+      },
+      {
+        "name": "korail",
+        "spec": "gtfs-rt",
+        "type": "url",
+        "url": "https://mkuran.pl/gtfs/korail.pb",
+        "license": {
+            "spdx-identifier": "CC-BY-4.0",
+            "url": "https://mkuran.pl/gtfs/"
         }
       }
     ]
   }
-  

--- a/feeds/kr.json
+++ b/feeds/kr.json
@@ -29,7 +29,8 @@
         "license": {
           "spdx-identifier": "CC-BY-4.0",
           "url": "https://mkuran.pl/gtfs/"
-        }
+        },
+        "script": "kr-korail.lua"
       },
       {
         "name": "korail",

--- a/scripts/kr-korail.lua
+++ b/scripts/kr-korail.lua
@@ -1,0 +1,17 @@
+-- SPDX-FileCopyrightText: Mikołaj Kuranowski <mkuranowski@gmail.com>
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+function process_route(route)
+    local short_name = route:get_short_name()
+    if string.find(short_name, "KTX") then
+        route:set_route_type(HIGH_SPEED_RAIL_SERVICE)
+    elseif string.find(short_name, "ITX") then
+        route:set_route_type(LONG_DISTANCE_TRAINS_SERVICE)
+    else
+        route:set_route_type(INTER_REGIONAL_RAIL_SERVICE)
+    end
+end
+
+function process_trip(trip)
+    trip:set_display_name(trip:get_route():get_short_name() .. " " .. trip:get_short_name())
+end


### PR DESCRIPTION
This PR changes the Korail feed from @dancojocaru2000's one to mine. The original feed has wrong schedules, as if it was assuming that Saturday schedules apply over the entire week. For example, train 1013 runs only on Saturday, but in the current feed it's marked as all-weekdays, and several trains like 1173 or 1651 are missing.

My feed also comes with shapes and realtime; however it is missing SRT schedules, as there is no reliable source for those (that's a question for @dancojocaru2000 - where do you get the source data from?). On the other hand, [SR is being taken over by Korail](https://www.koreatimes.co.kr/business/companies/20260802/korea-approves-korail-sr-merger), but on the other other hand, SRT schedules are still not available on https://www.korail.com/ticket/reserve/train-timeTable.

The made up train schedules from the disaster of a KTDB feed should probably be purged, but I don't really have the time to do that.