### PR TITLE
Add website license data for Bolzano-STA

### DIFF
--- a/feeds/it.json
+++ b/feeds/it.json
@@ -15,8 +15,8 @@
         },
         {
             "name": "Bolzano-STA",
-            "url": "ftp://ftp.sta.bz.it/gtfs/google_transit_shp.zip",
-            "type": "ftp",
+            "url": "https://gtfs.api.opendatahub.com/v1/dataset/sta-time-tables/raw",
+            "type": "http",
             "spec": "gtfs",
             "script": "it-sta.lua",
             "license": {

--- a/website/data/license.json
+++ b/website/data/license.json
@@ -14952,6 +14952,17 @@
         "human_name": "Veneto Venezia Ferries"
     },
     {
+        "country_code": "IT",
+        "country_name": "Italy",
+        "region_code": "IT",
+        "region_name": "Italy",
+        "spdx_license_identifier": "CC0-1.0",
+        "operators": [],
+        "source": "http://gtfs.api.opendatahub.com/v1/dataset/sta-time-tables/raw",
+        "filename": "it_Bolzano-STA.gtfs.zip",
+        "human_name": "Südtiroler Transportstrukturen AG"
+    },
+    {
         "country_code": "JP",
         "country_name": "Japan",
         "region_code": "JP",

--- a/website/data/license.json
+++ b/website/data/license.json
@@ -14952,17 +14952,6 @@
         "human_name": "Veneto Venezia Ferries"
     },
     {
-        "country_code": "IT",
-        "country_name": "Italy",
-        "region_code": "IT",
-        "region_name": "Italy",
-        "spdx_license_identifier": "CC0-1.0",
-        "operators": [],
-        "source": "http://gtfs.api.opendatahub.com/v1/dataset/sta-time-tables/raw",
-        "filename": "it_Bolzano-STA.gtfs.zip",
-        "human_name": "Südtiroler Transportstrukturen AG"
-    },
-    {
         "country_code": "JP",
         "country_name": "Japan",
         "region_code": "JP",


### PR DESCRIPTION
Commit changes the entry to http in order to add it to the license website/endpoint.