### PR TITLE
Add Japanese trains

### DIFF
--- a/feeds/jp.json
+++ b/feeds/jp.json
@@ -7,6 +7,11 @@
     ],
     "sources": [
         {
+            "name": "japan-rail",
+            "type": "http",
+            "url": "https://jbb.ghsq.de/gtfs/jp-jr.gtfs.zip"
+        },
+        {
             "name": "hiroden",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-hiroden~jp",


### PR DESCRIPTION
Add a (to my knowledge) complete feed of Japanese trains. Some of these might overlap with e.g. the Tokyo feed, which should be preferred as it has real-time information.