### PR TITLE
Add Transurb S.A. from Galati, Romania

### DIFF
--- a/feeds/ro.json
+++ b/feeds/ro.json
@@ -131,6 +131,17 @@
             "transitland-atlas-id": "f-dej~velo~city~gbfs"
         },
         {
+            "name": "Galati-Transurb",
+            "type": "http",
+            "url": "https://github.com/Steinhagen/gtfs-galati/releases/download/gtfs-latest/gtfs-transurb.zip",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0",
+                "url": "https://github.com/Steinhagen/gtfs-galati/blob/main/LICENSE",
+                "publisher": "Steinhagen",
+                "publisher-url": "https://github.com/Steinhagen/gtfs-galati"
+            }
+        },
+        {
             "name": "Hunedoara-public-bike-system",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-hunedoara~gbfs"


### PR DESCRIPTION
Transurb doesn't offer a GTFS archive, so I've started mapping each bus and trolley route in Galati in OSM based on their web programs. Since this process is quite time consumming, the GTFS (and OSM routes) are slowly been added.

At the moment, the existing GTFS archive contains some of the most used buses and the only trolley in Galati.
