### PR TITLE
Add Taiwan (TDX national GTFS)

### DIFF
--- a/feeds/tw.json
+++ b/feeds/tw.json
@@ -1,0 +1,23 @@
+{
+    "maintainers": [
+        {
+            "name": "Javier Canizalez",
+            "github": "jcanizalez"
+        }
+    ],
+    "sources": [
+        {
+            "name": "taiwan-tdx",
+            "type": "http",
+            "url": "https://github.com/jcanizalez/tdx-gtfs-mirror/releases/download/latest/tw-gtfs.zip",
+            "license": {
+                "url": "https://tdx.transportdata.tw/term",
+                "publisher": "Ministry of Transportation and Communications, Taiwan (TDX)",
+                "publisher-url": "https://tdx.transportdata.tw",
+                "attribution-text": "Ministry of Transportation and Communications Transportation Data Circulation Service Platform"
+            },
+            "fix": true,
+            "fetch-interval-days": 1
+        }
+    ]
+}


### PR DESCRIPTION
Adds Taiwan via the Ministry of Transportation's TDX platform, their single national GTFS covers rail (TRA/THSR), metro (Taipei, Taoyuan, Kaohsiung), and bus operators island-wide (~400 agencies).

TDX gates downloads behind OAuth2 client-credentials, so this points at a daily authenticated mirror: https://github.com/jcanizalez/tdx-gtfs-mirror (fetches at 03:30 Taipei, strips the fare tables that make up two thirds of the raw feed, same approach as Transitland's TDX fetchers, and publishes a rolling release). The TDX terms permit redistribution with attribution, carried in the license block.

Happy to instead upstream OAuth token support into fetch.py if you'd prefer to pull from TDX directly,  the mirror exists only because of the auth gate.

Verified locally: 401 agencies, Asia/Taipei, rolling ~7-week service horizon, translations.txt with English stop names.