### PR TITLE
add sk:`kompa-vojka` feed

### DIFF
--- a/feeds/sk.json
+++ b/feeds/sk.json
@@ -11,6 +11,14 @@
         {
             "name": "Jozef Steinhübl",
             "github": "xhyrom"
+        },
+        {
+            "name": "Charlie",
+            "github": "0charliecat"
+        },
+        {
+            "name": "gtfs.sk",
+            "github": "gtfs-sk"
         }
     ],
     "sources": [
@@ -148,6 +156,11 @@
             "name": "Slovak-Lines-Express",
             "type": "http",
             "url": "https://transiq.xhyrom.dev/gtfs/sk/slovak-lines-express-as.zip"
+        },
+        {
+            "name": "kompa-vojka",
+            "type": "http",
+            "url": "https://github.gtfs.sk/kompa-vojka/gtfs.zip"
         }
     ]
 }


### PR DESCRIPTION
this PR lists feed produced for the Vojka nad Dunajom–Kyselica ferry service operated by Vodohospodárska výstavba, š. p.

https://kompa-vojka.sk
https://github.com/gtfs-sk/kompa-vojka