### PR TITLE
Add Detská železnica Košice feed mirrored by gtfs.sk

### DIFF
--- a/feeds/sk.json
+++ b/feeds/sk.json
@@ -165,7 +165,11 @@
         {
             "name": "Detska-zeleznica-Kosice",
             "type": "http",
-            "url": "https://github.gtfs.sk/mirror-dzk/gtfs.zip"
+            "url": "https://github.gtfs.sk/mirror-dzk/gtfs.zip",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0",
+                "url": "https://www.detskazeleznica.sk/gtfs-license"
+            }
         }
     ]
 }

--- a/feeds/sk.json
+++ b/feeds/sk.json
@@ -161,6 +161,11 @@
             "name": "kompa-vojka",
             "type": "http",
             "url": "https://github.gtfs.sk/kompa-vojka/gtfs.zip"
+        },
+        {
+            "name": "Detska-zeleznica-Kosice",
+            "type": "http",
+            "url": "https://github.gtfs.sk/mirror-dzk/gtfs.zip"
         }
     ]
 }


### PR DESCRIPTION
This pull request adds a new feed entry to the `feeds/sk.json` file. The update introduces the "Detska-zeleznica-Kosice" GTFS feed to the list.

Feed additions:

* Added a new GTFS feed for "Detska-zeleznica-Kosice" with its corresponding URL to the `feeds/sk.json` configuration.

https://github.com/gtfs-sk/mirror-dzk
https://www.detskazeleznica.sk/gtfs-license

~FIX ME: add CC BY 4.0 licence for the feed~