### PR TITLE
Update pl.json - add Mobility Database feed mdb-3477 for Łódź Suburban & Regional transport

### DIFF
--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -1678,7 +1678,6 @@
             "name": "Łódź-Suburban",
             "type": "mobility-database",
             "mdb-id": "mdb-3477"
-            }
         }
     ]
 }

--- a/feeds/pl.json
+++ b/feeds/pl.json
@@ -1673,6 +1673,12 @@
             "license": {
                 "spdx-identifier": "MIT"
             }
+        },
+        {
+            "name": "Łódź-Suburban",
+            "type": "mobility-database",
+            "mdb-id": "mdb-3477"
+            }
         }
     ]
 }


### PR DESCRIPTION
## Description

Add the GTFS feed for suburban & regional bus services around Łódź, Poland.

The feed is available in Mobility Database as:

- Mobility Database ID: `mdb-3477`
- Feed name: GTFS Łódź Suburban
- License: CC BY 4.0

Source repository:

https://github.com/qbx-tt/gtfs-lodz-suburban

The feed covers suburban bus routes around Łódź and is maintained as an
independent community GTFS feed based on publicly available timetable data.

## Changes

- Add `Łódź-Suburban` as a Mobility Database source to `feeds/pl.json`.

## Testing

The feed is available through Mobility Database and can be fetched using
the configured `mobility-database` source.