### PR TITLE
removed MOIN and metronom from DELFI/VBN data

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -124,7 +124,9 @@
             "type": "http",
             "url": "https://www.connect-info.net/opendata/gtfs/connect-nds-lowlevel/eyqasqtsse",
             "drop-agency-names": [
-                "DB Fernverkehr (Codesharing)"
+                "DB Fernverkehr (Codesharing)",
+                "MOIN Mobilitäts und -betriebs GmbH",
+                "metronom Eisenbahngesellschaft mbH"
             ],
             "script": "de-VBN.lua",
             "http-options": {

--- a/feeds/de.json
+++ b/feeds/de.json
@@ -35,6 +35,7 @@
                 "FlixBus-de",
                 "EUROSTAR",
                 "Bremer Straßenbahn AG",
+                "MOIN Mobilitäts und -betriebs GmbH",
                 "Verkehrsgemeinschaft Osnabrück",
                 "Weser-Ems-Bus Betrieb Osnabrück",
                 "SNCB",
@@ -125,7 +126,6 @@
             "url": "https://www.connect-info.net/opendata/gtfs/connect-nds-lowlevel/eyqasqtsse",
             "drop-agency-names": [
                 "DB Fernverkehr (Codesharing)",
-                "MOIN Mobilitäts und -betriebs GmbH",
                 "metronom Eisenbahngesellschaft mbH"
             ],
             "script": "de-VBN.lua",


### PR DESCRIPTION
I've removed "MOIN" (new bus operator in Lüneburg, Germany) from DELFI and "metronom" from VBN.

Reason:
While MOIN's data is -somewhat- reliable on VBN, metronom's is not.
For latter, I might open an issue, not today though. RT via DELFI works.
It's the exact opposite for MOIN, for whatever reason.