### PR TITLE
hu: add BAHART ferry GTFS

### DIFF
--- a/feeds/hu.json
+++ b/feeds/hu.json
@@ -128,6 +128,14 @@
             "fix": true
         },
         {
+            "name": "BAHART-ferry",
+            "type": "http",
+            "url": "https://gy-mate.hu/gtfs/gtfs_hu_bahart-ferry.zip",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            }
+        },
+        {
             "name": "kaposvár",
             "type": "http",
             "url": "https://www.kaposbusz.hu/letoltheto-menetrend",


### PR DESCRIPTION
Add a self-created GTFS extension of the BAHART feed covering the only line missing from it: the Lake Balaton ferry. It transports cars so I've marked all trips as `cars_allowed=1`.

The feed is automatically built and updated from [gy-mate/gtfs-feeds](https://github.com/gy-mate/gtfs-feeds/tree/ec431b4a68a248ef3421b5303a5dcb922f3797d7/hu_bahart-ferry). It's currently valid for the rest of 2026.