### PR TITLE
STA: Remove GTFS-RT

### DIFF
--- a/feeds/it.json
+++ b/feeds/it.json
@@ -26,7 +26,7 @@
         },
         {
             "name": "Bolzano-STA",
-            "url": "https://files.opendatahub.com/gtfs-rt/feeds/sta/trip-updates.pb",
+            "url": "https://files.opendatahub.com/gtfs-rt/feeds/sta/vehicle-positions.pb",
             "type": "url",
             "spec": "gtfs-rt",
             "license": {

--- a/feeds/it.json
+++ b/feeds/it.json
@@ -25,16 +25,6 @@
             }
         },
         {
-            "name": "Bolzano-STA",
-            "url": "https://files.opendatahub.com/gtfs-rt/feeds/sta/vehicle-positions.pb",
-            "type": "url",
-            "spec": "gtfs-rt",
-            "license": {
-                "spdx-identifier": "CC0-1.0",
-                "url": "https://github.com/noi-techpark/opendatahub-gtfs-api/blob/839d698938a224a7db4885f717ca05706fa6bae1/datasets.yml#L33"
-            }
-        },
-        {
             "name": "Bolzano-STA-flex",
             "url": "ftp://ftp.sta.bz.it/gtfs/google_transit_flex.zip",
             "type": "ftp",


### PR DESCRIPTION
I'm not 100% sure, but it seems that there is more data on the vehicle's position endpoint than on the trip updates endpoint.

I suggest testing this data beforehand. When I checked the data using [this website](https://app.transit-lens.com/), it showed more (accurate) data for the vehicle's position endpoint than for the trip updates endpoint. Currently, only a handful of services have real-time data, which is usually incorrect.

To verify this new data, you can use the [operator's website](https://www.suedtirolmobil.info/).