### PR TITLE
removed three TOCs from VBN feed

### DIFF
--- a/feeds/de.json
+++ b/feeds/de.json
@@ -125,8 +125,9 @@
             "type": "http",
             "url": "https://www.connect-info.net/opendata/gtfs/connect-nds-lowlevel/eyqasqtsse",
             "drop-agency-names": [
-                "DB Fernverkehr (Codesharing)",,
-                "eurobahn"
+                "DB Fernverkehr (Codesharing)",
+                "DB Regio AG Nord",
+                "eurobahn",
                 "metronom Eisenbahngesellschaft mbH",
                 "NordWestBahn"
             ],

--- a/feeds/de.json
+++ b/feeds/de.json
@@ -125,8 +125,10 @@
             "type": "http",
             "url": "https://www.connect-info.net/opendata/gtfs/connect-nds-lowlevel/eyqasqtsse",
             "drop-agency-names": [
-                "DB Fernverkehr (Codesharing)",
-                "metronom Eisenbahngesellschaft mbH"
+                "DB Fernverkehr (Codesharing)",,
+                "eurobahn"
+                "metronom Eisenbahngesellschaft mbH",
+                "NordWestBahn"
             ],
             "script": "de-VBN.lua",
             "http-options": {


### PR DESCRIPTION
Due to (currently) missing real-time data from the VBN feed, I've taken the liberty of removing _DB Regio AG Nord_, _NordWestBahn_ and _eurobahn_ from the VBN feed.

Every train has been shown twice in Transitous (one VBN and one DELFI) entry