### PR TITLE
dropped VIAS Rail from NL feed

### DIFF
--- a/feeds/nl.json
+++ b/feeds/nl.json
@@ -16,7 +16,8 @@
             "url" : "https://gtfs.openov.nl/gtfs-rt/gtfs-openov-nl.zip",
             "fix": true,
             "drop-agency-names": [
-                "Eurobahn"
+                "Eurobahn",
+                "VIAS"
             ],
             "license": {
                 "spdx-identifier": "CC0-1.0",


### PR DESCRIPTION
I propose to drop VIAS from the Dutch feed, due to their cross-border traffic without real time data on OVapi, it's provided through DELFI.