### PR TITLE
added new Istanbul feed

### DIFF
--- a/feeds/tr.json
+++ b/feeds/tr.json
@@ -7,6 +7,10 @@
         {
             "name": "Luna",
             "github": "luna-cant-code"
+        },
+        {
+            "name": "Jonah Brüchert",
+            "github": "jbruechert"
         }
     ],
     "sources": [
@@ -42,7 +46,7 @@
         {
             "name": "istanbul-ibb",
             "type": "http",
-            "url": "https://github.com/luna-cant-code/istanbul-gtfs/blob/main/istanbul-gtfs.zip",
+            "url": "https://jbb.ghsq.de/gtfs/tr-istanbul.gtfs.zip",
             "fix": false,
             "skip": false
         },

--- a/feeds/tr.json
+++ b/feeds/tr.json
@@ -3,6 +3,10 @@
         {
             "name": "Yasin Karaaslan",
             "github": "yasinkaraaslan"
+        },
+        {
+            "name": "Luna",
+            "github": "luna-cant-code"
         }
     ],
     "sources": [
@@ -38,9 +42,9 @@
         {
             "name": "istanbul-ibb",
             "type": "http",
-            "url": "https://dl.dropboxusercontent.com/scl/fi/v937qi0xnytzl21a3bbd0/istanbul-ibb.zip?rlkey=dgi6l0cxb2203fresf1s16r7i",
-            "fix": true,
-            "skip": true
+            "url": "https://github.com/luna-cant-code/istanbul-gtfs/blob/main/istanbul-gtfs.zip",
+            "fix": false,
+            "skip": false
         },
         {
             "name": "istanbul-iett",


### PR DESCRIPTION
Rather by accident I found out that Transitous doesn't have a working feed for Istanbul, there was also an open issue here regarding exactly that (issue #2252)

I've uploaded Istanbul's data to [my GitHub repo](https://github.com/luna-cant-code/istanbul-gtfs) (as they don't provide a single zip file) for this PR.

The data isn't updated daily but it should be better than nothing. Let's just see how it'll work out