### PR TITLE
Added Tegaltrans provider from Galați

### DIFF
--- a/feeds/ro.json
+++ b/feeds/ro.json
@@ -153,6 +153,17 @@
             }
         },
         {
+            "name": "Galati-Tegaltrans",
+            "type": "http",
+            "url": "https://codeberg.org/rapiteanu/public-transport/releases/download/gtfs-tegaltrans/gtfs-tegaltrans.zip",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0",
+                "url": "https://codeberg.org/rapiteanu/public-transport/raw/branch/main/LICENSE",
+                "publisher": "rapiteanu",
+                "publisher-url": "https://codeberg.org/rapiteanu/public-transport"
+            }
+        },
+        {
             "name": "Hunedoara-public-bike-system",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-hunedoara~gbfs"


### PR DESCRIPTION
Tegaltrans is a transportation firm that has a number of minibusses that link the villages nearby Galati to each-other and to the main city.

The initial archive contains only one of their route (the longest one), but I plan to map them all in the forseable future.