### PR TITLE
Add BC, Canada bike/scooter share providers

### DIFF
--- a/feeds/ca-bc.json
+++ b/feeds/ca-bc.json
@@ -250,7 +250,7 @@
             "transitland-atlas-id": "f-lime~vancouver~gbfs"
         },
         {
-            "name": "Lime - Kelowna",
+            "name": "Lime-Kelowna",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-lime~kelowna~gbfs"
         }

--- a/feeds/ca-bc.json
+++ b/feeds/ca-bc.json
@@ -238,6 +238,21 @@
             "name": "Whistler-Transit",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-c2bt-bctransit~whistlertransitsystem~rt"
+        },
+        {
+            "name": "Mobi",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-mobi~bike~share~vancouver~gbfs"
+        },
+        {
+            "name": "Lime - Vancouver",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-lime~vancouver~gbfs"
+        },
+        {
+            "name": "Lime - Kelowna",
+            "type": "transitland-atlas",
+            "transitland-atlas-id": "f-lime~kelowna~gbfs"
         }
     ]
 }

--- a/feeds/ca-bc.json
+++ b/feeds/ca-bc.json
@@ -245,7 +245,7 @@
             "transitland-atlas-id": "f-mobi~bike~share~vancouver~gbfs"
         },
         {
-            "name": "Lime - Vancouver",
+            "name": "Lime-Vancouver",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-lime~vancouver~gbfs"
         },


### PR DESCRIPTION
The City of Vancouver operates their own bike share program with public GBFS, and Lime operates in five or six cities through the province (but only offers a GBFS feed in two). I've added all of the feeds I know of. I tried to follow what was done in other regions, hopefully this looks good enough. 