### PR TITLE
proxy nl openov GTFS-RT

### DIFF
--- a/feeds/nl.json
+++ b/feeds/nl.json
@@ -29,25 +29,22 @@
             "name": "OpenOV",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfs.openov.nl/gtfs-rt/trainUpdates.pb"
+            "url": "https://gtfs.openov.nl/gtfs-rt/trainUpdates.pb",
+            "use-feed-proxy": true
         },
         {
             "name": "OpenOV",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfs.openov.nl/gtfs-rt/tripUpdates.pb"
+            "url": "https://gtfs.openov.nl/gtfs-rt/tripUpdates.pb",
+            "use-feed-proxy": true
         },
         {
             "name": "OpenOV",
             "type": "url",
             "spec": "gtfs-rt",
-            "url": "https://gtfs.openov.nl/gtfs-rt/alerts.pb"
-        },
-        {
-            "name": "OpenOV",
-            "type": "url",
-            "spec": "gtfs-rt",
-            "url": "https://gtfs.openov.nl/gtfs-rt/vehiclePositions.pb"
+            "url": "https://gtfs.openov.nl/gtfs-rt/alerts.pb",
+            "use-feed-proxy": true
         }
     ]
 }


### PR DESCRIPTION
@skinkie informed me that only one user-agent / IP combination is allowed

We should stop sharing the final config.yml with all our settings that apply only to the "original" Transitous servers.

@skinkie: I would propose we switch the user agent for our "original" Transitous server and you ban the previously used user agent after some grace period. I think that's the only way to get writ of copy cat servers that don't update the user agent and disguise as Transitous servers, without serving the community.