### PR TITLE
Add Tampere bus & tram routes

### DIFF
--- a/feeds/fi.json
+++ b/feeds/fi.json
@@ -80,6 +80,11 @@
             "spec": "gtfs-rt",
             "type": "url",
             "url": "https://realtime.hsl.fi/realtime/vehicle-positions/v2/hsl"
+        },
+        {
+            "name": "nysse",
+            "spec": "transitland-atlas",
+            "transitland-atlas-id": "f-udb-tampereenjoukkoliikenne"
         }
     ]
 }

--- a/feeds/fi.json
+++ b/feeds/fi.json
@@ -83,7 +83,7 @@
         },
         {
             "name": "nysse",
-            "spec": "transitland-atlas",
+            "type": "transitland-atlas",
             "transitland-atlas-id": "f-udb-tampereenjoukkoliikenne"
         }
     ]


### PR DESCRIPTION
They seem to be on Transitland and look up to date. I hope you're ok with well-intentioned PRs out of the blue, I trawled through the git logs and the docs and hope that I'm doing this right!