### PR TITLE
at: Blank placeholder "0" trip headsigns in Upper Austria

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -296,6 +296,7 @@ Option Name            | Description
 `skip`                 | Don't download or use this feed.
 `skip-reason`          | Reason for why this feed can't be used right now.
 `fix-csv-quotes`       | Try to fix GTFS files in which fields are improperly quoted. A symptom of this is if stop names start containing CSV.
+`blank-headsigns-matching` | Regular expression for `trip_headsign` values that are placeholders rather than destinations, e.g. `0`. Matching headsigns are cleared before import, so MOTIS falls back to the last stop of the trip. Clearing them from an import script does not work, because the fallback is applied before the script stage runs.
 `license`              | Dictionary of license-related options
 `http-options`         | Dictionary of HTTP-related options
 `drop-shapes`          | Remove route shapes, use if the shapes are mostly wrong

--- a/feeds/at.json
+++ b/feeds/at.json
@@ -126,6 +126,7 @@
             "managed-by-script": true,
             "x-mvo-id": "77-2026",
             "use-gtfsclean": false,
+            "blank-headsigns-matching": "0",
             "script": "at.lua"
         },
         {

--- a/src/blank-headsigns-matching.py
+++ b/src/blank-headsigns-matching.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Johannes Grof <contact@johannesgrof.me>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Blank trip headsigns matching a regular expression.
+
+Some feeds export a placeholder instead of a destination, e.g. "0". MOTIS
+substitutes the last stop of a trip for headsigns that are empty when the
+GTFS is parsed, so clearing the field here restores a usable destination.
+Clearing it from an import script does not work: the substitution happens
+before the script stage runs.
+"""
+
+import csv
+import io
+import os
+import re
+import sys
+import zipfile
+
+HEADSIGN_COLUMN = "trip_headsign"
+
+
+def blank_headsigns(content: bytes, pattern: re.Pattern) -> tuple[bytes, int]:
+    reader = csv.reader(io.StringIO(content.decode("utf-8-sig")))
+    rows = list(reader)
+    if not rows:
+        return content, 0
+
+    header = rows[0]
+    if HEADSIGN_COLUMN not in header:
+        return content, 0
+
+    column = header.index(HEADSIGN_COLUMN)
+    blanked = 0
+    for row in rows[1:]:
+        if column < len(row) and pattern.fullmatch(row[column]):
+            row[column] = ""
+            blanked += 1
+
+    if blanked == 0:
+        return content, 0
+
+    with io.StringIO(newline="") as out:
+        csv.writer(out, lineterminator="\r\n").writerows(rows)
+        return out.getvalue().encode(), blanked
+
+
+def edit_zip(source: str, destination: str, pattern: re.Pattern) -> int:
+    blanked = 0
+    with zipfile.ZipFile(source) as inzip, \
+            zipfile.ZipFile(destination, "w",
+                            compression=zipfile.ZIP_DEFLATED) as outzip:
+        for info in inzip.infolist():
+            with inzip.open(info) as infile:
+                content = infile.read()
+                if os.path.basename(info.filename) == "trips.txt":
+                    content, blanked = blank_headsigns(content, pattern)
+                outzip.writestr(info, content)
+    return blanked
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} <gtfs.zip> <regex>", file=sys.stderr)
+        sys.exit(1)
+
+    archive = sys.argv[1]
+    pattern = re.compile(sys.argv[2])
+    destination = archive + ".tmp"
+
+    blanked = edit_zip(archive, destination, pattern)
+    os.rename(destination, archive)
+
+    print(f"Blanked {blanked} headsigns matching {pattern.pattern}")

--- a/src/fetch.py
+++ b/src/fetch.py
@@ -404,6 +404,11 @@ class Fetcher:
         if source.fix_csv_quotes and source.spec == "gtfs":
             subprocess.check_call(["./src/fix-csv-quotes.py", temp_file])
 
+        if source.blank_headsigns_matching and source.spec == "gtfs":
+            subprocess.check_call(["./src/blank-headsigns-matching.py",
+                                   temp_file,
+                                   source.blank_headsigns_matching])
+
         if source.use_gtfsclean and source.spec == "gtfs":
             command = ["gtfsclean", str(temp_file),
                     "--fix-zip",

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -49,6 +49,7 @@ class Source:
     license: License
     spec: str = "gtfs"
     fix_csv_quotes: bool = False
+    blank_headsigns_matching: Optional[str] = None
     skip: bool = False
     skip_reason: str = ""
     function: Optional[str] = None
@@ -86,6 +87,9 @@ class Source:
                 self.use_gtfsclean = bool(parsed["use-gtfsclean"])
             if "fix-csv-quotes" in parsed:
                 self.fix_csv_quotes = bool(parsed["fix-csv-quotes"])
+            if "blank-headsigns-matching" in parsed:
+                self.blank_headsigns_matching = \
+                    parsed["blank-headsigns-matching"]
             if "spec" in parsed:
                 self.spec = parsed["spec"]
             if "skip" in parsed:


### PR DESCRIPTION
Fixes the Upper Austria part of #1627.

### The problem

Several operators in `PTA-Upper-Austria-Flex-2026` export `0` as `trip_headsign` instead of a destination. Sampling ~150 consecutive departures per stop from api.transitous.org:

| Stop | departures with `headsign="0"` |
|---|---|
| Gmunden Bahnhof | 74 / 150 (49%) |
| Wels Hauptbahnhof | 67 / 150 (45%) |
| Linz Hauptbahnhof | 12 / 151 (8%) |
| Salzburg Hbf, Graz Hbf, Steyr Bahnhof | 0 |

All of them come from that single feed. Affected agencies: Stern & Hafferl, Österreichische Postbus, Wilhelm Welser Verkehrsbetriebe, Wels Linien.

### Why not an import script

The obvious fix — clearing the headsign from `at.lua` and relying on the fallback to the last stop — does not work. I tested this against MOTIS v2.11.2 with a synthetic three-trip feed (details in https://github.com/public-transport/transitous/issues/1627#issuecomment-5471648825):

```
no script:    T_ZERO -> "0"     T_EMPTY -> "Endstation Nordwest"   T_OK -> "Echtes Ziel"
with script:  T_ZERO -> ""      T_EMPTY -> "Endstation Nordwest"   T_OK -> "Echtes Ziel"
control:      T_ZERO -> ""      T_EMPTY -> "Endstation Nordwest"   T_OK -> ""
```

The fallback is applied when the GTFS is parsed, before the script stage runs, so anything blanked from Lua stays blank. The control run blanks a trip that had a perfectly valid headsign and it comes out empty too, so this is not specific to the `0` value.

### What this does

Adds a `blank-headsigns-matching` source option that clears `trip_headsign` values matching a regular expression during postprocessing, before MOTIS sees the feed — so the existing last-stop fallback applies. `PTA-Upper-Austria-Flex-2026` has `use-gtfsclean: false`, so it runs as its own step alongside `fix-csv-quotes` rather than as a gtfsclean flag.

End-to-end with the same synthetic feed:

```
after blank-headsigns-matching:  T_ZERO -> "Endstation Nordwest"   T_OK -> "Echtes Ziel"
```

Handles BOM, quoted fields containing commas, and CRLF line endings; the pattern is matched with `fullmatch`, so `10` and `00` are left alone. REUSE lint passes.

### Note

This is option 1 from my comment on the issue. If you would rather see the fallback applied after the script stage in MOTIS instead — the more general fix, since it would cover every feed with this class of broken data — I am happy to close this and write that instead.
