### PR TITLE
hu: add Pásztor ferry GTFS

### DIFF
--- a/feeds/hu.json
+++ b/feeds/hu.json
@@ -85,6 +85,14 @@
             }
         },
         {
+            "name": "pasztor-ferry",
+            "type": "http",
+            "url": "https://gy-mate.hu/gtfs/gtfs_hu_pasztor-ferry.zip",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            }
+        },
+        {
             "name": "mvk",
             "type": "transitland-atlas",
             "transitland-atlas-id": "f-u2wc-mvkzrt",


### PR DESCRIPTION
Add a self-created GTFS of the Szentendre Pásztor ferry.

The feed is automatically built and updated from [gy-mate/gtfs-feeds](https://github.com/gy-mate/gtfs-feeds/tree/8fe4e3e8f648e03e5b2d87d7cf938374589d5c2a/hu_pasztor-ferry). It's currently valid for one year since the last timetable change.