### PR TITLE
hu: add Dunakeszi ferry GTFS

### DIFF
--- a/feeds/hu.json
+++ b/feeds/hu.json
@@ -85,6 +85,14 @@
             }
         },
         {
+            "name": "dunakeszi-ferry",
+            "type": "http",
+            "url": "https://gy-mate.hu/gtfs/gtfs_hu_dunakeszi-ferry.zip",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            }
+        },
+        {
             "name": "pasztor-ferry",
             "type": "http",
             "url": "https://gy-mate.hu/gtfs/gtfs_hu_pasztor-ferry.zip",


### PR DESCRIPTION
 Add a self-created GTFS of the Dunakeszi–Horány ferry.

The feed is automatically built and updated from [gy-mate/gtfs-feeds](https://github.com/gy-mate/gtfs-feeds/tree/25119c2b1ca0b01cb2e450ed0583aaff15297b48/hu_dunakeszi-ferry). It's currently valid until the end of the year.