### PR TITLE
Add license identifiers for various turkish feeds

### DIFF
--- a/feeds/tr.json
+++ b/feeds/tr.json
@@ -105,12 +105,18 @@
         {
             "name": "nigde",
             "type": "http",
-            "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/nigde.zip"
+            "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/nigde.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            }
         },
         {
             "name": "adana",
             "type": "http",
             "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/adana.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            },
             "fix": true
         },
         {
@@ -124,30 +130,45 @@
             "name": "alapli",
             "type": "http",
             "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/alapli.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            },
             "skip": true,
             "skip-reason": "routes.txt doesn't exist"
         },
         {
             "name": "burdur",
             "type": "http",
-            "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/burdur.zip"
+            "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/burdur.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            }
         },
         {
             "name": "canakkale",
             "type": "http",
             "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/canakkale.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            },
             "fix": true
         },
         {
             "name": "duzce",
             "type": "http",
             "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/duzce.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            },
             "fix": true
         },
         {
             "name": "edirne",
             "type": "http",
             "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/edirne.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            },
             "skip": true,
             "skip-reason": "trips.txt doesn't exist"
         },
@@ -155,6 +176,9 @@
             "name": "eregli",
             "type": "http",
             "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/eregli.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            },
             "skip": true,
             "skip-reason": "trips.txt doesn't exist"
         },
@@ -162,57 +186,87 @@
             "name": "erzurum",
             "type": "http",
             "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/erzurum.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            },
             "fix": true
         },
         {
             "name": "kastamonu",
             "type": "http",
             "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/kastamonu.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            },
             "fix": true
         },
         {
             "name": "kirklareli",
             "type": "http",
             "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/kirklareli.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            },
             "fix": true
         },
         {
             "name": "luleburgaz",
             "type": "http",
             "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/luleburgaz.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            },
             "fix": true
         },
         {
             "name": "mardin",
             "type": "http",
             "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/mardin.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            },
             "fix": true
         },
         {
             "name": "mugla",
             "type": "http",
             "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/mugla.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            },
             "fix": true
         },
         {
             "name": "ordu",
             "type": "http",
-            "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/ordu.zip"
+            "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/ordu.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            }
         },
         {
             "name": "osmaniye",
             "type": "http",
-            "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/osmaniye.zip"
+            "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/osmaniye.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            }
         },
         {
             "name": "safranbolu",
             "type": "http",
-            "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/safranbolu.zip"
+            "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/safranbolu.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            }
         },
         {
             "name": "sivas",
             "type": "http",
             "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/sivas.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            },
             "skip": true,
             "skip-reason": "trips.txt doesn't exist"
         },
@@ -220,12 +274,18 @@
             "name": "tokat",
             "type": "http",
             "url": "https://github.com/Egezenn/kk-gtfs/raw/main/data/tokat.zip",
+            "license": {
+                "spdx-identifier": "CC0-1.0"
+            },
             "fix": true
         },
         {
             "name": "tcdd",
             "type": "http",
             "url": "https://github.com/yasinkaraaslan/tcdd-gtfs/raw/main/output/tcdd.zip",
+            "license": {
+                "spdx-identifier": "MIT"
+            },
             "fix": true
         }
     ]


### PR DESCRIPTION
This marks all KentKart feeds (those from Egezenn's repo) as CC0, just like how it's stated in that repo's data license, and the TCDD feed as MIT (taken from that repo's license; might not be the case with the actual data coming from TCDD, but i'm not sure).