### PR TITLE
Add license to Istanbul IBB

### DIFF
--- a/feeds/tr.json
+++ b/feeds/tr.json
@@ -48,7 +48,10 @@
             "type": "http",
             "url": "https://jbb.ghsq.de/gtfs/tr-istanbul.gtfs.zip",
             "fix": false,
-            "skip": false
+            "skip": false,
+            "license": {
+                "spdx-identifier": "CC-BY-4.0"
+            }
         },
         {
             "name": "istanbul-iett",


### PR DESCRIPTION
See here: https://data.ibb.gov.tr/en/license
They invent their own license, but state that CC BY 4.0 can be used as license information.

> If the Information Provider does not provide a specific attribution statement, you must use the following:
> 
> Contains public sector information licensed under the Attribution 4.0 International (CC BY 4.0).