### PR TITLE
added temporary fix to Rheinbahn routes

### DIFF
--- a/scripts/de-DELFI.lua
+++ b/scripts/de-DELFI.lua
@@ -63,6 +63,11 @@ end
 function process_route(route)
     local agency_name = route:get_agency():get_name()
     local route_name = route:get_short_name()
+  -- temp Rheinbahn fix (make buses to metro, GTFS issue is already open)
+    if route:get_short_name() == 'U80' or route:get_short_name() == 'U81' or route:get_short_name() == 'U79' or route:get_short_name() == 'U75' or route:get_short_name() == 'U77' then
+      route:set_route_type(1) -- metro
+    end
+  -- end of Rheinbahn fix
 	-- remove spaces from route name for matching
 	route_name = route_name:gsub("%s+", "")
 	local original_route_color = route:get_color()


### PR DESCRIPTION
Currently, Rheinbahn metro lines are displayed as buses, that's an error existing for a couple of weeks now.
I've already opened a GTFS issue https://github.com/mfdz/GTFS-Issues/issues/313 and would like to propose, for the time being, temporarily fixing it in the DELFI feed.

I'll keep an eye out, once the error is fixed, I'll revert the change.

The code is ugly, it works though:

_before:_
<img width="607" height="359" alt="image" src="https://github.com/user-attachments/assets/dbd9da65-43b7-46bd-8f20-66f67dd7d1ad" />

_after:_
<img width="846" height="542" alt="image" src="https://github.com/user-attachments/assets/3e175b60-899b-4008-a080-a60bc7166512" />
