### PR TITLE
gb: drop shapes in main feed

### DIFF
--- a/feeds/gb.json
+++ b/feeds/gb.json
@@ -22,7 +22,8 @@
                 "FlixBus"
             ],
             "script": "gb-great-britain.lua",
-            "keep-additional-fields": false
+            "keep-additional-fields": false,
+            "drop-shapes": true
         },
         {
             "name": "great-britain",


### PR DESCRIPTION
Drop shapes for great britain feed since train journeys are mostly only a beeline between stations.