### PR TITLE
fr: replace GTFS and GTFS-RT resources for Rouen (Réseau Astuce)

### DIFF
--- a/feeds/fr.json
+++ b/feeds/fr.json
@@ -2047,9 +2047,18 @@
             },
             "x-data-gov-fr-res-id": 64973,
             "managed-by-script": true,
-            "skip": false,
+            "skip": true,
+            "skip-reason": "Replaced by GTFS @ gtfs.bus-tracker.fr",
             "x-data-gov-fr-res-title": "Liste des arrêts, horaires et parcours du réseau Astuce",
             "x-data-gov-fr-dataset-id": "5cd4321f8b4c4137d1244318"
+        },
+        {
+            "name": "donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
+            "type": "http",
+            "url": "https://gtfs.bus-tracker.fr/astuce-global.zip",
+            "license": {
+                "spdx-identifier": "ODbL-1.0"
+            }
         },
         {
             "name": "donnees-statiques-et-temps-reel-du-reseau-astuce-metropole-rouen-normandie",
@@ -2076,6 +2085,8 @@
             "spec": "gtfs-rt",
             "x-data-gov-fr-res-id": 80752,
             "managed-by-script": true,
+            "skip": true,
+            "skip-reason": "Replaced by res-id 82678",
             "x-data-gov-fr-res-title": "Prochains passages des lignes du réseau Astuce exploitées par Transdev Rouen",
             "x-data-gov-fr-dataset-id": "5cd4321f8b4c4137d1244318"
         },


### PR DESCRIPTION
This PR aims to replace the GTFS feed with a enhanced one, and disables the Transdev Rouen GTFS-RT feed that contains false data to only have `gtfs.bus-tracker.fr` GTFS-RT as a source of truth for this operator lines.

**GTFS**
- Synchronized with the source GTFS feed (updates are performed at most 5 minutes after upstream updates).
- Includes actual shapes matching vehicle paths (instead of straight lines).
- Removes technical duplicates `TCAR:26` and `TCAR:530` (the same as `TNI:26` and `TNI:530` but with no real-time information) that may appear when import goes wrong ont their side.
- Removes the commercial duplicate `TCAR:529` which is the same as the line 529 from the NOMAD Car regional network (from Gare Routière ROUEN to Route de Montville MALAUNAY).

**GTFS-RT**
- Sourced by the official feed (now skipped here) every 20 seconds.
- Filters out trip updates from lines that are not covered by the operator's CAD/AVL system (F6, 13, 14, 27, 28, 33, 35, 36, 37, 38, 42, 44, and scholar lines) and therefore publishes incorrect real-time information.
- Publishes skipped stops, based on a extract of the alerts feed, for trip updates running both in real-time or not. _When a trip update has no real-time information but at least one skipped stop, the first stop is set to `NO_DATA` and the skipped stops as `SKIPPED`._