### PR TITLE
it: add ATM Messina GTFS-RT trip updates

### DIFF
--- a/feeds/it.json
+++ b/feeds/it.json
@@ -311,6 +311,19 @@
             }
         },
         {
+            "name": "Sicilia-Messina-ATM",
+            "type": "url",
+            "spec": "gtfs-rt",
+            "url": "https://rt.annacati.com/atm-messina/messina.pb",
+            "license": {
+                "spdx-identifier": "CC-BY-4.0",
+                "url": "https://opendata.comune.messina.it/dataset/dati-trasporto-pubblico-urbano-atm-gtfs",
+                "publisher": "Azienda Trasporti Messina S.p.A.",
+                "publisher-url": "https://www.atmmessinaspa.it/",
+                "attribution-text": "This feed contains derivative realtime data based on public transport data provided by Azienda Trasporti Messina S.p.A. (ATM Messina), licensed under CC-BY. Realtime feed produced by Annacati."
+            }
+        },
+        {
             "name": "Sicilia-Palermo-AMAT",
             "type": "http",
             "url": "https://opendata.comune.palermo.it/js/server/uploads/dataset/gtfs/amat_gtfs.zip",


### PR DESCRIPTION
Adds a GTFS-RT TripUpdates feed for ATM Messina, attached to the existing `Sicilia-Messina-ATM` static source (same `name`).

The feed is self-produced from ATM Messina's public "smart poles" departure boards and re-published as GTFS-RT at `https://rt.annacati.com/atm-messina/messina.pb`. Its `trip_id`s are matched against the same `GTFS_ATM_SPA.zip` this source already imports, so the updates attach to the existing trips. It is already live in "Annacati", another MOTIS-based routing service.

Data is CC-BY (Comune di Messina open data portal); attribution is set in the license block.